### PR TITLE
[IDLE-0000] CD timeout 시간 연장

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -16,6 +16,7 @@ jobs:
           key: ${{ secrets.DEV_INSTANCE_KEY }}
           source: "./idle-api/compose-dev.yaml"
           target: "~/app/docker"
+          timeout: 120s
           overwrite: true
 
       - name: Install Docker if not present


### PR DESCRIPTION
## 1. 📄 Summary
![image](https://github.com/3IDLES/idle-server/assets/59856002/e3dbcfbd-6891-4a23-aa04-b9b94986ea28)

CD 스크립트 내 timeout 에러를 핸들링하기 위해 timeout 기준을 30s에서 120s로 연장합니다.
