### PR TITLE
[IDLE-121] CD 트리거링 시, Github Actions IP 허용하도록 변경

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -8,6 +8,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Get Public IP
+        id: ip
+        uses: haythem/public-ip@v1.3
+
+      - name: Add GitHub Actions IP
+        run: |
+          aws ec2 authorize-security-group-ingress \
+              --group-id ${{ secrets.SECURITY_GROUP_ID }} \
+              --protocol tcp \
+              --port 22 \
+              --cidr ${{ steps.ip.outputs.ipv4 }}/32
+
       - name: Copy Docker Compose file to server
         uses: appleboy/scp-action@master
         with:
@@ -52,3 +64,11 @@ jobs:
             sudo docker-compose -f ~/app/docker/compose-dev.yaml down --rmi all
             sudo docker-compose -f ~/app/docker/compose-dev.yaml pull
             sudo docker-compose -f ~/app/docker/compose-dev.yaml up -d --force-recreate
+
+      - name: Remove GitHub Actions IP
+        run: |
+          aws ec2 revoke-security-group-ingress \
+              --group-id ${{ secrets.SECURITY_GROUP_ID }} \
+              --protocol tcp \
+              --port 22 \
+              --cidr ${{ steps.ip.outputs.ipv4 }}/32


### PR DESCRIPTION
## 1. 📄 Summary
* CD 트리거링 시, Github Actions IP를 동적으로 보안 그룹에 추가하여 접근 가능하도록 합니다.

## 2. 🤔 고민했던 점
![image](https://github.com/3IDLES/idle-server/assets/59856002/8d40e353-1a08-4e58-916e-0bc89dd88ac1)

개발 서버 배포 이후, 새벽 시간대에 네트워크 패킷이 3K 이상을 기록하며 인스턴스가 다운되는 현상을 경험하였습니다.
API가 나오지 않은 현 시점에 발생한 것을 고려했을 때, 외부에서 EC2 KEY를 알아내기 위한 해킹 시도로 의심됩니다. 

저희 서비스는 EC2의 free-tier 요금제를 적용하고 있기 때문에, 
기본 메모리 허용치인 1GB 이상을 넘어가게 되면 서비스 전체가 다운됩니다.

Github Actions CI/CD의 경우 매번 접속 ip가 동적으로 할당된다는 특징이 있습니다.
이를 감안하여 기존에는 SSH 접속 포트를 전면 개방하였고 위와 같은 문제가 발생한 것으로 사료됩니다.

## 3. ☘️ Solution

![image](https://github.com/3IDLES/idle-server/assets/59856002/36e322c7-0e95-4cad-8a3a-072ca5106074)

따라서, 현재 사용중인 IP와 함께 매번 변동되는 Github Actions의 IP를 동적으로 허용하도록 변경하였습니다.

CD workflow에서 현재 실행중인 Github Actions의 IP값을 동적 할당하여, 임시로 EC2의 보안 그룹을 생성하도록 변경했습니다.  배포 이후에는 보안 그룹에서 삭제하는 스크립트가 동작하게 됩니다.