### PR TITLE
[IDLE-000] mysql dialect 설정 제거

### DIFF
--- a/idle-domain/src/main/resources/application-persistence.yml
+++ b/idle-domain/src/main/resources/application-persistence.yml
@@ -8,7 +8,7 @@ spring:
     open-in-view: false
     properties:
       hibernate.format_sql: true
-      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+      dialect: org.hibernate.dialect.MySQL8Dialect
 ---
 spring:
   config:

--- a/idle-domain/src/main/resources/application-persistence.yml
+++ b/idle-domain/src/main/resources/application-persistence.yml
@@ -8,7 +8,6 @@ spring:
     open-in-view: false
     properties:
       hibernate.format_sql: true
-      dialect: org.hibernate.dialect.MySQL8Dialect
 ---
 spring:
   config:


### PR DESCRIPTION
## 1. 📄 Summary
* spring 3.2.1 이후, JPA에서는 직접 Dialect 설정을 지정하지 않을 것을 권장하고 있습니다. 이에 따라 해당 설정을 제거합니다.
