### PR TITLE
[IDLE-63] 인증 번호 메세지 발송 API

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,14 +6,15 @@ spring-boot-dependency-management = "1.1.4"
 kotlin = "1.9.21"
 sonar-cloud = "4.4.1.3373"
 
-springdoc-openapi = "2.3.0"
-
 mockk = "1.13.7"
 spring-mockk = "4.0.2"
 kotest = "5.6.0"
 kotest-extensions-spring = "1.1.3"
 kotest-extensions-testcontainers = "2.0.2"
 testcontainers = "1.19.6"
+springdoc-openapi = "2.3.0"
+
+cool-sms = "4.3.0"
 
 mysql = "8.0.33"
 
@@ -42,6 +43,8 @@ kotest-extensions-testcontainers = { group = "io.kotest.extensions", name = "kot
 testcontainers-junit-jupiter = { group = "org.testcontainers", name = "junit-jupiter", version.ref = "testcontainers" }
 
 springdoc-openapi-starter-webmvc-ui = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
+net-nurigo-sdk = { group = "net.nurigo", name = "sdk", version.ref = "cool-sms"}
+
 [plugins]
 
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-cloud" }

--- a/idle-api/build.gradle.kts
+++ b/idle-api/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     implementation(project(":idle-domain"))
     implementation(project(":idle-support:logging"))
     implementation(project(":idle-support:common"))
+    implementation(project(":idle-infrastructure:sms"))
 
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)

--- a/idle-api/src/main/kotlin/com/swm/idle/api/IdleServerApplication.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/IdleServerApplication.kt
@@ -1,9 +1,16 @@
-package com.swm.idle
+package com.swm.idle.api
 
+import com.swm.idle.infrastructure.sms.common.config.SmsConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Import
 
 @SpringBootApplication
+@Import(
+    value = [
+        SmsConfig::class,
+    ]
+)
 class IdleServerApplication
 
 fun main(args: Array<String>) {

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
@@ -1,11 +1,9 @@
 package com.swm.idle.api.auth.center.spec
 
-import com.swm.idle.api.auth.center.dto.ConfirmVerificationMessageRequest
 import com.swm.idle.api.auth.center.dto.LoginRequest
 import com.swm.idle.api.auth.center.dto.LoginResponse
 import com.swm.idle.api.auth.center.dto.RefreshLoginTokenResponse
 import com.swm.idle.api.auth.center.dto.RefreshTokenRequest
-import com.swm.idle.api.auth.center.dto.SendVerificationMessageRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -18,18 +16,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 @RequestMapping("/api/v1/auth/center", produces = ["application/json"])
 interface CenterAuthApi {
 
-    @Operation(summary = "인증번호 메세지 전송 API")
-    @PostMapping("/send")
-    fun sendAuthenticationMessage(
-        @RequestBody request: SendVerificationMessageRequest,
-    )
-
-    @Operation(summary = "인증번호 메세지 검증 API")
-    @PostMapping("/confirm")
-    fun verifyAuthenticationMessage(
-        @RequestBody request: ConfirmVerificationMessageRequest,
-    )
-
     @Operation(summary = "센터 로그인 API")
     @PostMapping("/login")
     fun login(
@@ -41,14 +27,14 @@ interface CenterAuthApi {
     @ResponseStatus(HttpStatus.OK)
     fun logout()
 
-    @Operation(summary = "Refresh Login Token")
+    @Operation(summary = "Refresh Login Token API")
     @PostMapping("/refresh")
     @ResponseStatus(HttpStatus.OK)
     fun refreshLoginToken(
         @RequestBody request: RefreshTokenRequest,
     ): RefreshLoginTokenResponse
 
-    @Operation(summary = "Withdraw Account")
+    @Operation(summary = "센터 회원 탈퇴 API")
     @PostMapping("/withdraw")
     @ResponseStatus(HttpStatus.OK)
     fun withDraw()

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/controller/AuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/controller/AuthController.kt
@@ -1,0 +1,25 @@
+package com.swm.idle.api.auth.common.controller
+
+import com.swm.idle.api.auth.common.dto.ConfirmVerificationMessageRequest
+import com.swm.idle.api.auth.common.dto.SendVerificationMessageRequest
+import com.swm.idle.api.auth.common.facade.AuthFacadeService
+import com.swm.idle.api.auth.common.spec.AuthApi
+import com.swm.idle.domain.user.vo.PhoneNumber
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthController(
+    val authFacadeService: AuthFacadeService,
+) : AuthApi {
+
+    override fun sendAuthenticationMessage(request: SendVerificationMessageRequest) {
+        authFacadeService.sendVerificationMessage(
+            PhoneNumber(request.phoneNumber)
+        )
+    }
+
+    override fun verifyAuthenticationMessage(request: ConfirmVerificationMessageRequest) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/dto/ConfirmVerificationMessageRequest.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/dto/ConfirmVerificationMessageRequest.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.api.auth.center.dto
+package com.swm.idle.api.auth.common.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "인증 번호 검증 요청"
 )
 data class ConfirmVerificationMessageRequest(
-    @Schema(description = "Verification Number")
+    @Schema(description = "Verification Number", example = "123456")
     val verificationNumber: String,
 )
 

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/dto/SendVerificationMessageRequest.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/dto/SendVerificationMessageRequest.kt
@@ -1,5 +1,6 @@
-package com.swm.idle.api.auth.center.dto
+package com.swm.idle.api.auth.common.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(
@@ -7,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "전화번호 인증 메세지 요청"
 )
 data class SendVerificationMessageRequest(
-    @Schema(description = "Phone Number")
+    @JsonProperty("phoneNumber")
+    @Schema(description = "Phone Number", example = "010-0000-0000")
     val phoneNumber: String,
 )

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/facade/AuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/facade/AuthFacadeService.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.api.auth.common.facade
+
+import com.swm.idle.domain.user.vo.PhoneNumber
+import com.swm.idle.infrastructure.sms.auth.common.SmsService
+import org.springframework.stereotype.Service
+
+@Service
+class AuthFacadeService(
+    private val smsService: SmsService,
+) {
+
+    fun sendVerificationMessage(phoneNumber: PhoneNumber) {
+        smsService.sendVerificationMessage(
+            phoneNumber = phoneNumber
+        )
+    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/spec/AuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/common/spec/AuthApi.kt
@@ -1,0 +1,27 @@
+package com.swm.idle.api.auth.common.spec
+
+import com.swm.idle.api.auth.common.dto.ConfirmVerificationMessageRequest
+import com.swm.idle.api.auth.common.dto.SendVerificationMessageRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Auth-Common", description = "공통 Auth API")
+@RequestMapping("/api/v1/auth/common", produces = ["application/json"])
+interface AuthApi {
+
+    @Operation(summary = "인증번호 메세지 발송 API")
+    @PostMapping("/send")
+    fun sendAuthenticationMessage(
+        @RequestBody request: SendVerificationMessageRequest,
+    )
+
+    @Operation(summary = "인증번호 메세지 검증 API")
+    @PostMapping("/confirm")
+    fun verifyAuthenticationMessage(
+        @RequestBody request: ConfirmVerificationMessageRequest,
+    )
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/config/SwaggerConfig.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/config/SwaggerConfig.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.common
+package com.swm.idle.api.common.config
 
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class SwaggerConfig(
-    @Value("{SERVER_URL:http://localhost:8080}")
+    @Value("\${swagger.server.url:http://localhost:8080}")
     private val serverUrl: String,
 ) {
 

--- a/idle-api/src/main/resources/application.yml
+++ b/idle-api/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
     active: local
     include:
       - persistence
+      - sms
 
 swagger:
   server:

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/PhoneNumber.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/PhoneNumber.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.domain.user.vo
+
+@JvmInline
+value class PhoneNumber(val value: String) {
+
+    init {
+        require(value.matches(Regex(VALIDATION_REGEX))) {
+            "전화번호 형식이 올바르지 않습니다."
+        }
+    }
+
+    companion object {
+        const val VALIDATION_REGEX = "^010-\\d{4}-\\d{4}$"
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/SmsVerificationNumber.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/SmsVerificationNumber.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.domain.user.vo
+
+@JvmInline
+value class SmsVerificationNumber(val value: Int) {
+
+    init {
+        require(value.toString().length == 6)
+    }
+
+}

--- a/idle-infrastructure/sms/build.gradle.kts
+++ b/idle-infrastructure/sms/build.gradle.kts
@@ -7,4 +7,8 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation(project(":idle-domain"))
+
+    implementation(libs.net.nurigo.sdk)
+    implementation(libs.spring.boot.starter.web)
 }

--- a/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/auth/common/SmsService.kt
+++ b/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/auth/common/SmsService.kt
@@ -1,0 +1,39 @@
+package com.swm.idle.infrastructure.sms.auth.common
+
+import com.swm.idle.domain.user.vo.PhoneNumber
+import com.swm.idle.domain.user.vo.SmsVerificationNumber
+import com.swm.idle.infrastructure.sms.util.SmsClient
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class SmsService(
+    private val smsClient: SmsClient
+) {
+
+    fun sendVerificationMessage(phoneNumber: PhoneNumber) {
+        val smsVerificationNumber = generateVerificationNumber()
+
+        smsClient.sendMessage(
+            to = phoneNumber.value.replace("-", ""),
+            content = CENTER_VERIFICATION_MESSAGE_FORMAT.format(smsVerificationNumber.value),
+        )
+    }
+
+    fun generateVerificationNumber(): SmsVerificationNumber {
+        val random = Random(System.currentTimeMillis())
+
+        return SmsVerificationNumber(
+            MINIMUM_VERIFICATION_NUMBER + random.nextInt(
+                VERIFICATION_NUMBER_SCALE
+            ))
+    }
+
+    companion object {
+        const val MINIMUM_VERIFICATION_NUMBER = 100_000
+        const val VERIFICATION_NUMBER_SCALE = 900_000
+        const val CENTER_VERIFICATION_MESSAGE_FORMAT = "[케어밋] 센터 회원가입 인증번호는 %s 입니다."
+    }
+
+}
+

--- a/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/common/config/SmsConfig.kt
+++ b/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/common/config/SmsConfig.kt
@@ -1,0 +1,13 @@
+package com.swm.idle.infrastructure.sms.common.config
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ComponentScan(basePackages = ["com.swm.idle.infrastructure.sms"])
+@EnableConfigurationProperties
+@ConfigurationPropertiesScan(basePackages = ["com.swm.idle.infrastructure.sms"])
+class SmsConfig{
+}

--- a/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/common/properties/SmsProperties.kt
+++ b/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/common/properties/SmsProperties.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.infrastructure.sms.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("sms")
+data class SmsProperties(
+    val accessKey: String,
+    val secretKey: String,
+    val sendingNumber: String,
+)

--- a/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/util/SmsClient.kt
+++ b/idle-infrastructure/sms/src/main/kotlin/com/swm/idle/infrastructure/sms/util/SmsClient.kt
@@ -1,0 +1,31 @@
+package com.swm.idle.infrastructure.sms.util
+
+import com.swm.idle.infrastructure.sms.common.properties.SmsProperties
+import net.nurigo.sdk.NurigoApp
+import net.nurigo.sdk.message.model.Message
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest
+import net.nurigo.sdk.message.service.DefaultMessageService
+import org.springframework.stereotype.Component
+
+@Component
+class SmsClient(
+    val smsProperties: SmsProperties,
+) {
+    val messageService: DefaultMessageService by lazy {
+        NurigoApp.initialize(
+            apiKey = smsProperties.accessKey,
+            apiSecretKey = smsProperties.secretKey,
+            domain = "https://api.coolsms.co.kr"
+        )
+    }
+
+    fun sendMessage(to: String, content: String) {
+        val message = Message(
+            from = smsProperties.sendingNumber,
+            to = to,
+            text = content,
+        )
+
+        messageService.sendOne(SingleMessageSendingRequest(message))
+    }
+}

--- a/idle-infrastructure/sms/src/main/resources/application-sms.yaml
+++ b/idle-infrastructure/sms/src/main/resources/application-sms.yaml
@@ -1,0 +1,4 @@
+sms:
+  access-key: ${SMS_API_ACCESS_KEY}
+  secret-key: ${SMS_API_SECRET_KEY}
+  sending-number: ${SMS_SENDING_NUMBER}

--- a/idle-support/build.gradle.kts
+++ b/idle-support/build.gradle.kts
@@ -7,5 +7,4 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
-
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,9 +6,6 @@ project(":idle-api").projectDir = file("idle-api")
 include(":idle-domain")
 project(":idle-domain").projectDir = file("idle-domain")
 
-include(":idle-infrastructure")
-project(":idle-infrastructure").projectDir = file("idle-infrastructure")
-
 include(":idle-support:logging")
 project(":idle-support:logging").projectDir = file("idle-support/logging")
 
@@ -17,3 +14,6 @@ project(":idle-support:jacoco").projectDir = file("idle-support/jacoco")
 
 include(":idle-support:common")
 project(":idle-support:common").projectDir = file("idle-support/common")
+
+include(":idle-infrastructure:sms")
+project(":idle-infrastructure:sms").projectDir = file("idle-infrastructure/sms")


### PR DESCRIPTION
## Background

요양 보호사와 센터의 회원가입을 위해 SMS 인증 기반 전화번호 인증 API를 구현해야 합니다.

이를 통해 센터와 요양 보호사의 전화번호를 확보하여 추후 구직 및 매칭에 사용할 계획입니다.

### 사용하는 sms 솔루션

cool sms : https://coolsms.co.kr/

기본적으로 레퍼런스가 많고, 사업자 없이 사용할 수 있는 솔루션이라 선택하게 되었습니다.

### 가격 정책

건당 20원 정도로 책정되며, 10만원 충전 기준 실제 단가는 18.3원 정도입니다.

![image](https://github.com/3IDLES/idle-server/assets/59856002/d7c0f03b-dcac-40fb-a1a7-d27a901d3f29)

### 인증번호 정책

- 인증번호는 100,000 ~ 999,999 사이의 랜덤한 6자리 정수로 생성됩니다.
- 인증번호 발송 이후, 해당 인증번호는 최대 5분간 유효합니다.

## Goals & Non-Goals

### Goals

- 요양 보호사와 센터의 전화번호 인증 API를 구현합니다.
    - 입력한 전화번호에 대해 SMS 형태로 인증번호를 발송합니다.
    - 이후 사용자는 SMS로 전달받은 인증번호를 시스템에 입력하여 내부 검증 과정을 거칩니다.(미구현)

---

## **Methodology & Design(Proposal)**

### API

- API
    - [인증 번호 메세지 발송 API] POST /api/v1/auth/common/send
        - request
            - method & path: `POST /api/v1/auth/common/send`
            - body
                
                ```json
                {
                  "phoneNumber": "string" (required & not blank), (010-0000-0000의 형태를 가져야 합니다.)
                }
                
                ```
                
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
            - 전화번호 형식에 맞지 않는 경우
                - status code: `400 Bad Request`