### PR TITLE
[IDLE-000] CD 워크플로우 수정

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get Public IP
         id: ip


### PR DESCRIPTION
## 1. 📄 Summary
![image](https://github.com/3IDLES/idle-server/assets/59856002/869bfb71-cb28-4ce0-b257-a0192bd6166a)

* github checkout node 버전 호환성 문제가 있어 v3 버전으로 업데이트 하였습니다.
* 기존 github actions의 ip를 가져오기 위해 [haythem/public-ip@v1.3](https://github.com/haythem/public-ip) 의존성을 사용하고 있었으나, 간헐적으로 ETIMEOUT 에러가 발생하였습니다. 
* github issue를 확인해 보니 위와 같은 [에러에 대한 이슈](https://github.com/haythem/public-ip/issues/23)가 상당수 발생하고 있음을 파악하였습니다. 이에 따라 해당 의존성을 제거하고 다른 방식으로 대체하였습니다.
 