### PR TITLE
[IDLE-000] haythem/public-ip@v1.3 의존성 대체

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Github Actions IP Addresses
         id: publicip

--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -8,9 +8,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Get Public IP
-        id: ip
-        uses: haythem/public-ip@v1.3
+      - name: Get Github Actions IP Addresses
+        id: publicip
+        run: |
+          response=$(curl -s canhazip.com)
+          echo "ip=$response" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -25,7 +27,7 @@ jobs:
               --group-id ${{ secrets.SECURITY_GROUP_ID }} \
               --protocol tcp \
               --port 22 \
-              --cidr ${{ steps.ip.outputs.ipv4 }}/32
+              --cidr ${{ steps.publicip.outputs.ip }}/32
 
       - name: Copy Docker Compose file to server
         uses: appleboy/scp-action@master
@@ -78,4 +80,4 @@ jobs:
               --group-id ${{ secrets.SECURITY_GROUP_ID }} \
               --protocol tcp \
               --port 22 \
-              --cidr ${{ steps.ip.outputs.ipv4 }}/32
+              --cidr ${{ steps.publicip.outputs.ip }}/32


### PR DESCRIPTION
## 1. 📄 Summary
* 기존 github actions의 ip를 가져오기 위해 [haythem/public-ip@v1.3](https://github.com/haythem/public-ip) 의존성을 사용하고 있었으나, 간헐적으로 ETIMEOUT 에러가 발생하였습니다. 
* github issue를 확인해 보니 위와 같은 [에러에 대한 이슈](https://github.com/haythem/public-ip/issues/23)가 상당수 발생하고 있음을 파악하였습니다. 이에 따라 해당 의존성을 제거하고 다른 방식으로 대체하였습니다.
