### PR TITLE
[IDLE-125] 인증 번호 검증 API

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/controller/AuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/controller/AuthController.kt
@@ -5,6 +5,7 @@ import com.swm.idle.api.auth.core.dto.SendSmsVerificationRequest
 import com.swm.idle.api.auth.core.facade.AuthFacadeService
 import com.swm.idle.api.auth.core.spec.AuthApi
 import com.swm.idle.domain.user.vo.PhoneNumber
+import com.swm.idle.domain.user.vo.UserSmsVerificationNumber
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -12,14 +13,17 @@ class AuthController(
     val authFacadeService: AuthFacadeService,
 ) : AuthApi {
 
-    override fun sendAuthenticationMessage(request: SendSmsVerificationRequest) {
+    override fun sendVerificationMessage(request: SendSmsVerificationRequest) {
         authFacadeService.sendVerificationMessage(
-            PhoneNumber(request.phoneNumber)
+            phoneNumber = PhoneNumber(request.phoneNumber)
         )
     }
 
-    override fun verifyAuthenticationMessage(request: ConfirmSmsVerificationRequest) {
-        TODO("Not yet implemented")
+    override fun confirmVerificationMessage(request: ConfirmSmsVerificationRequest) {
+        authFacadeService.confirmVerificationMessage(
+            phoneNumber = PhoneNumber(request.phoneNumber),
+            verificationNumber = UserSmsVerificationNumber(request.verificationNumber)
+        )
     }
 
 }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/dto/ConfirmSmsVerificationRequest.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/dto/ConfirmSmsVerificationRequest.kt
@@ -7,6 +7,9 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "인증 번호 검증 요청"
 )
 data class ConfirmSmsVerificationRequest(
+    @Schema(description = "Phone Number", example = "010-0000-0000")
+    val phoneNumber: String,
+
     @Schema(description = "Verification Number", example = "123456")
     val verificationNumber: String,
 )

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/facade/AuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/facade/AuthFacadeService.kt
@@ -2,6 +2,7 @@ package com.swm.idle.api.auth.core.facade
 
 import com.swm.idle.domain.user.service.UserSmsVerificationService
 import com.swm.idle.domain.user.vo.PhoneNumber
+import com.swm.idle.domain.user.vo.UserSmsVerificationNumber
 import com.swm.idle.infrastructure.sms.auth.service.SmsService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,6 +29,17 @@ class AuthFacadeService(
                 )
             }
         }
+    }
+
+    fun confirmVerificationMessage(
+        phoneNumber: PhoneNumber,
+        verificationNumber: UserSmsVerificationNumber,
+    ) {
+        userSmsVerificationService.findByPhoneNumber(phoneNumber)?.let {
+            if (it.first != phoneNumber || it.second != verificationNumber) {
+                throw IllegalArgumentException()
+            }
+        } ?: throw IllegalArgumentException()
     }
 
 }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/spec/AuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/spec/AuthApi.kt
@@ -4,9 +4,11 @@ import com.swm.idle.api.auth.core.dto.ConfirmSmsVerificationRequest
 import com.swm.idle.api.auth.core.dto.SendSmsVerificationRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 
 @Tag(name = "Auth-Common", description = "공통 Auth API")
 @RequestMapping("/api/v1/auth/core", produces = ["application/json"])
@@ -14,13 +16,15 @@ interface AuthApi {
 
     @Operation(summary = "인증번호 메세지 발송 API")
     @PostMapping("/send")
-    fun sendAuthenticationMessage(
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun sendVerificationMessage(
         @RequestBody request: SendSmsVerificationRequest,
     )
 
     @Operation(summary = "인증번호 메세지 검증 API")
     @PostMapping("/confirm")
-    fun verifyAuthenticationMessage(
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun confirmVerificationMessage(
         @RequestBody request: ConfirmSmsVerificationRequest,
     )
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/repository/UserSmsVerificationNumberRedisRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/repository/UserSmsVerificationNumberRedisRepository.kt
@@ -6,4 +6,4 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface UserSmsVerificationNumberRedisRepository :
-    CrudRepository<UserSmsVerificationNumberRedisHash, Long>
+    CrudRepository<UserSmsVerificationNumberRedisHash, String>

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/UserSmsVerificationService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/UserSmsVerificationService.kt
@@ -25,4 +25,13 @@ class UserSmsVerificationService(
         userSmsVerificationNumberRedisRepository.save(userSmsVerificationNumberRedisHash)
     }
 
+    fun findByPhoneNumber(phoneNumber: PhoneNumber): Pair<PhoneNumber, UserSmsVerificationNumber>? {
+        return userSmsVerificationNumberRedisRepository
+            .findById(phoneNumber.value)
+            .map {
+                PhoneNumber(it.phoneNumber) to UserSmsVerificationNumber(it.verificationNumber)
+            }
+            .orElse(null)
+    }
+
 }


### PR DESCRIPTION
## 1. 📄 Summary
* SMS 인증번호 검증 API를 구현하였습니다. 
* 아직 전역 에러 처리 로직이 작성되지 않아 예외 로직에서는 `IllegalArgumentException()` 이 발생하도록 조치하였습니다.

## 2. ✏️ Documentation
### API

- API
    - [인증 번호 메세지 검증 API] POST /api/v1/auth/core/confirm
        - request
            - method & path: `POST /api/v1/auth/core/confirm`
            - body
                
                ```json
                {
                  "verificationNumber": "string" (required & not blank)
                }
                ```
                
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
            - 인증번호가 맞지 않는 경우
                - status code: `400 Bad Request`
            - 인증번호가 만료된 경우(인증번호를 찾을 수 없는 경우)
                - status code: `400 Bad Request`