### PR TITLE
[IDLE-127] 에러 응답 및 전역 컨트롤러 정의

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ApiException.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ApiException.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.api.common.exception
+
+import com.swm.idle.support.common.exception.CustomException
+
+sealed class ApiException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class InvalidParameter(message: String = "") :
+        ApiException(codeNumber = 1, message = message)
+
+    companion object {
+        const val CODE_PREFIX = "API"
+    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/CustomExceptionHandler.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/CustomExceptionHandler.kt
@@ -1,0 +1,56 @@
+package com.swm.idle.api.common.exception
+
+import com.swm.idle.support.common.exception.CustomException
+import io.swagger.v3.oas.annotations.Hidden
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@Hidden
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class CustomExceptionHandler {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(CustomException::class)
+    fun handleCustomException(exception: CustomException): ErrorResponse {
+        return ErrorResponse(
+            code = exception.code,
+            message = exception.message,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(exception: IllegalArgumentException): ErrorResponse {
+        return ErrorResponse(
+            code = ApiException.InvalidParameter().code,
+            message = exception.message!!,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(exception: MethodArgumentNotValidException): ErrorResponse {
+        val builder = StringBuilder()
+        exception
+            .bindingResult
+            .fieldErrors
+            .forEach { fieldError ->
+                builder
+                    .append("[${fieldError.field}](은)는 ${fieldError.defaultMessage}")
+                    .append("입력된 값: ${fieldError.rejectedValue}")
+                    .append("|")
+            }
+        val message = builder.toString()
+        return ErrorResponse(
+            code = ApiException.InvalidParameter().code,
+            message = message
+        )
+    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ErrorResponse.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ErrorResponse.kt
@@ -1,0 +1,9 @@
+package com.swm.idle.api.common.exception
+
+import java.time.LocalDateTime
+
+data class ErrorResponse(
+    val code: String,
+    val message: String,
+    val timestamp: LocalDateTime = LocalDateTime.now(),
+)

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/SystemExceptionHandler.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/SystemExceptionHandler.kt
@@ -1,0 +1,30 @@
+package com.swm.idle.api.common.exception
+
+import com.swm.idle.support.common.exception.SystemException
+import io.swagger.v3.oas.annotations.Hidden
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@Hidden
+@RestControllerAdvice
+@Order(value = Ordered.HIGHEST_PRECEDENCE + 1)
+class SystemExceptionHandler {
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(SystemException::class)
+    fun handleSystemException(
+        e: Throwable,
+        request: HttpServletRequest,
+    ): ErrorResponse {
+        return ErrorResponse(
+            code = SystemException.InternalServerError().code,
+            message = "Internal Server Error"
+        )
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/sms/exception/SmsException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/sms/exception/SmsException.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.domain.sms.exception
+
+import com.swm.idle.support.common.exception.CustomException
+
+sealed class SmsException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class InvalidSmsVerificationNumber(message: String = "잘못된 인증번호입니다.") :
+        SmsException(codeNumber = 1, message = message)
+
+    class SmsVerificationNumberNotFound(message: String = "인증번호가 만료되었거나 존재하지 않습니다.") :
+        SmsException(codeNumber = 2, message = message)
+
+    companion object {
+        const val CODE_PREFIX = "SMS"
+    }
+}

--- a/idle-support/common/src/main/kotlin/com/swm/idle/support/common/exception/CustomException.kt
+++ b/idle-support/common/src/main/kotlin/com/swm/idle/support/common/exception/CustomException.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.support.common.exception
+
+abstract class CustomException(
+    codePrefix: String = DEFAULT_CODE_PREFIX,
+    codeNumber: Int,
+    override val message: String = DEFAULT_ERROR_MESSAGE,
+) : RuntimeException(message) {
+
+    val code: String = "$codePrefix-${
+        codeNumber.toString().padStart(DEFAULT_CODE_LENGTH, DEFAULT_CODE_PAD_CHAR)
+    }"
+
+    companion object {
+        const val DEFAULT_CODE_LENGTH = 3
+        const val DEFAULT_CODE_PAD_CHAR = '0'
+        const val DEFAULT_CODE_PREFIX = "UNKNOWN"
+        const val DEFAULT_ERROR_MESSAGE = "알 수 없는 오류가 발생하였습니다."
+    }
+}

--- a/idle-support/common/src/main/kotlin/com/swm/idle/support/common/exception/SystemException.kt
+++ b/idle-support/common/src/main/kotlin/com/swm/idle/support/common/exception/SystemException.kt
@@ -1,0 +1,15 @@
+package com.swm.idle.support.common.exception
+
+sealed class SystemException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class InternalServerError(message: String = "") :
+        SystemException(codeNumber = 1, message = message)
+
+    companion object {
+        const val CODE_PREFIX = "SYSTEM"
+    }
+
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 에러 응답 및 전역 에러 컨트롤러를 정의하였습니다.
* CustomException을 정의하여, 매번 예외 클래스를 추가하고 이에 대한 별도 handler function을 추가할 필요가 없습니다.

## 2. ✏️ Documentation
* 에러 메세지를 그대로 사용자에게 노출할 경우, 악의적인 사용자에게 시스템 내부 정보를 전달할 수 있는 가능성이 존재합니다.
* 따라서 에러 코드 응답에는 Error Code만 전달하며, 세부적인 에러 메세지의 경우 별도 문서를 통해 내부적으로 관리하도록 하였습니다. 
* 해당 정책은 런칭 이후에 적용되며, 런칭 이전까지는 개발 편의를 위해 적용하지 않았습니다.

* 예시 사진입니다.
![image](https://github.com/3IDLES/idle-server/assets/59856002/2c5de877-231a-4a99-b396-777386a9f493)

* 에러 코드 문서는 아래 링크를 확인해주세요! 
https://www.notion.so/8ce764ea990a43e6a0b11c931983e17f
