### PR TITLE
[IDLE-129] UUID Creator 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ subprojects {
 
         implementation(rootProject.libs.kotlin.reflect)
         implementation(rootProject.libs.kotlin.coroutines.core)
+        implementation(rootProject.libs.uuid.creator)
 
         annotationProcessor(rootProject.libs.spring.boot.configuration.processor)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ testcontainers = "1.19.6"
 springdoc-openapi = "2.3.0"
 
 cool-sms = "4.3.0"
+uuid-creator = "5.3.3"
 
 mysql = "8.0.33"
 
@@ -35,6 +36,7 @@ spring-boot-starter-data-redis = { group = "org.springframework.boot", name = "s
 mysql-connector-java = { group = "mysql", name = "mysql-connector-java", version.ref = "mysql" }
 
 spring-boot-configuration-processor = { group = "org.springframework.boot", name = "spring-boot-configuration-processor", version.ref = "spring-boot" }
+uuid-creator = { group = "com.github.f4b6a3", name = "uuid-creator", version.ref = "uuid-creator" }
 
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 spring-mockk = { group = "com.ninja-squad", name = "springmockk", version.ref = "spring-mockk" }

--- a/idle-support/common/src/main/kotlin/com/swm/idle/support/common/uuid/UuidCreator.kt
+++ b/idle-support/common/src/main/kotlin/com/swm/idle/support/common/uuid/UuidCreator.kt
@@ -1,0 +1,12 @@
+package com.swm.idle.support.common.uuid
+
+import com.github.f4b6a3.uuid.UuidCreator
+import java.util.*
+
+object UuidCreator {
+
+    fun create(): UUID {
+        return UuidCreator.getTimeOrderedEpochPlus1();
+    }
+
+}


### PR DESCRIPTION
## 1. 📄 Summary
* PK로 DB에서 제공하는 Auto-Increment를 사용하지 않고, Time-Based UUID를 적용합니다.

## 2. 💡 도입 배경

### WAS vs DB
테이블의 PK인 ID를 생성할 때, WAS와 DB중 어느 쪽에서 설정해야 할지 고민해 보았습니다.

먼저, MySQL에서는 Auto-Increment를 지원하며, Spring Data Jpa 역시 
`@GeneratedValue(strategy = GenerationType.IDENTITY)` 를 통해 편리하게 ID를 생성할 수 있습니다.

하지만, 위와 같은 방식을 이용하면 Auto-Increment의 주체는 DB가 된다는 점입니다. 
DB에서 Auto-Increment가 이루어지게 된다면 분산 환경에서의 Auto-Increment를 위한 값 동기화 문제에서는 자유로울 수 있지만, Auto-Increment가 이루어지는 동안 DB 내에서 Lock을 사용하므로 시스템 전체 성능의 저하로 이어질 수 있습니다.

이러한 맥락에서 분산 환경에서 동시에 벌크성 쿼리가 수행된다면 DB에 부하가 더욱 가중되며 시스템 성능 저하 및 SPOF가 될 수 있습니다.

### Scale-Out을 하면 해결할 수 있지 않을까?
DB의 Scale-Out은 시스템의 복잡도를 크게 증가시킵니다. RDB에서는 데이터 정합성을 보장하기 위해 트랜잭션을 지원하는데, Scale-Out이 된다면 분산 트랜잭션을 고려해야 하기 때문입니다.

### 그래서 왜 Time-Based UUID인가?
WAS에서 auto-increment를 담당한다면 분산 환경에서 값 동기화 문제가 발생할 수 있습니다.
즉, 매번 unique한 ID를 만들기가 어렵습니다. 
이러한 문제를 극복하기 위해, 생성 시각을 기준으로 생성되는 Time-Based UUID를 이용하고자 했습니다. 해당 라이브러리는 Unix Time을 기준으로 MS 단위까지 반영됩니다. 
또한 같은 UUID가 생성되었을 때, Linear Probing 방식의 연산이 발생하여 ID 값의 유일성을 보장합니다.