### PR TITLE
[IDLE-62] 센터 관리자 회원가입 API

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/carer/spec/CarerAuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/carer/spec/CarerAuthApi.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.api.auth.carer.spec
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Tag(name = "Auth-Carer", description = "Carer Auth API")
+@RequestMapping("/api/v1/auth/carer", produces = ["application/json"])
+interface CarerAuthApi {
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
@@ -1,0 +1,41 @@
+package com.swm.idle.api.auth.center.controller
+
+import com.swm.idle.api.auth.center.dto.JoinRequest
+import com.swm.idle.api.auth.center.facade.CenterAuthFacadeService
+import com.swm.idle.api.auth.center.spec.CenterAuthApi
+import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
+import com.swm.idle.domain.sms.vo.PhoneNumber
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CenterAuthController(
+    private val centerAuthFacadeService: CenterAuthFacadeService,
+) : CenterAuthApi {
+
+    override fun join(request: JoinRequest) {
+        centerAuthFacadeService.join(
+            identifier = request.identifier,
+            password = request.password,
+            phoneNumber = PhoneNumber(request.phoneNumber),
+            managerName = request.managerName,
+            centerBusinessRegistrationNumber = BusinessRegistrationNumber(request.centerBusinessRegistrationNumber),
+        )
+    }
+
+//    override fun login(request: LoginRequest): LoginResponse {
+//        TODO("Not yet implemented")
+//    }
+//
+//    override fun logout() {
+//        TODO("Not yet implemented")
+//    }
+//
+//    override fun refreshLoginToken(request: RefreshTokenRequest): RefreshLoginTokenResponse {
+//        TODO("Not yet implemented")
+//    }
+//
+//    override fun withDraw() {
+//        TODO("Not yet implemented")
+//    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/dto/JoinRequest.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/dto/JoinRequest.kt
@@ -1,0 +1,20 @@
+package com.swm.idle.api.auth.center.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "Center Manager Join Request",
+    description = "센터 관리자 회원 가입 요청"
+)
+data class JoinRequest(
+    @Schema(description = "아이디(ID)")
+    val identifier: String,
+    @Schema(description = "비밀번호")
+    val password: String,
+    @Schema(description = "관리자 휴대폰 번호", example = "010-0000-0000")
+    val phoneNumber: String,
+    @Schema(description = "관리자 성명")
+    val managerName: String,
+    @Schema(description = "센터 사업자 등록 번호", example = "000-00-00000")
+    val centerBusinessRegistrationNumber: String,
+)

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
@@ -1,0 +1,28 @@
+package com.swm.idle.api.auth.center.facade
+
+import com.swm.idle.domain.center.service.CenterManagerService
+import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
+import com.swm.idle.domain.sms.vo.PhoneNumber
+import org.springframework.stereotype.Service
+
+@Service
+class CenterAuthFacadeService(
+    private val centerManagerService: CenterManagerService,
+) {
+    fun join(
+        identifier: String,
+        password: String,
+        phoneNumber: PhoneNumber,
+        managerName: String,
+        centerBusinessRegistrationNumber: BusinessRegistrationNumber,
+    ) {
+        centerManagerService.save(
+            identifier = identifier,
+            password = password,
+            phoneNumber = phoneNumber,
+            managerName = managerName,
+            centerBusinessRegistrationNumber = centerBusinessRegistrationNumber,
+        )
+    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
@@ -1,9 +1,6 @@
 package com.swm.idle.api.auth.center.spec
 
-import com.swm.idle.api.auth.center.dto.LoginRequest
-import com.swm.idle.api.auth.center.dto.LoginResponse
-import com.swm.idle.api.auth.center.dto.RefreshLoginTokenResponse
-import com.swm.idle.api.auth.center.dto.RefreshTokenRequest
+import com.swm.idle.api.auth.center.dto.JoinRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -16,27 +13,34 @@ import org.springframework.web.bind.annotation.ResponseStatus
 @RequestMapping("/api/v1/auth/center", produces = ["application/json"])
 interface CenterAuthApi {
 
-    @Operation(summary = "센터 로그인 API")
-    @PostMapping("/login")
-    fun login(
-        @RequestBody request: LoginRequest,
-    ): LoginResponse
+    @Operation(summary = "센터 관리자 회원가입 API")
+    @PostMapping("/join")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun join(
+        @RequestBody request: JoinRequest,
+    )
 
-    @Operation(summary = "센터 로그아웃 API")
-    @PostMapping("/logout")
-    @ResponseStatus(HttpStatus.OK)
-    fun logout()
-
-    @Operation(summary = "Refresh Login Token API")
-    @PostMapping("/refresh")
-    @ResponseStatus(HttpStatus.OK)
-    fun refreshLoginToken(
-        @RequestBody request: RefreshTokenRequest,
-    ): RefreshLoginTokenResponse
-
-    @Operation(summary = "센터 회원 탈퇴 API")
-    @PostMapping("/withdraw")
-    @ResponseStatus(HttpStatus.OK)
-    fun withDraw()
+//    @Operation(summary = "센터 로그인 API")
+//    @PostMapping("/login")
+//    fun login(
+//        @RequestBody request: LoginRequest,
+//    ): LoginResponse
+//
+//    @Operation(summary = "센터 로그아웃 API")
+//    @PostMapping("/logout")
+//    @ResponseStatus(HttpStatus.OK)
+//    fun logout()
+//
+//    @Operation(summary = "Refresh Login Token API")
+//    @PostMapping("/refresh")
+//    @ResponseStatus(HttpStatus.OK)
+//    fun refreshLoginToken(
+//        @RequestBody request: RefreshTokenRequest,
+//    ): RefreshLoginTokenResponse
+//
+//    @Operation(summary = "센터 회원 탈퇴 API")
+//    @PostMapping("/withdraw")
+//    @ResponseStatus(HttpStatus.OK)
+//    fun withDraw()
 
 }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/controller/AuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/controller/AuthController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class AuthController(
-    val authFacadeService: AuthFacadeService,
+    private val authFacadeService: AuthFacadeService,
 ) : AuthApi {
 
     override fun sendVerificationMessage(request: SendSmsVerificationRequest) {

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/entity/CenterManager.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/entity/CenterManager.kt
@@ -1,0 +1,54 @@
+package com.swm.idle.domain.center.entity
+
+import com.swm.idle.domain.center.enums.CenterAccountStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "center_manager")
+class CenterManager(
+    id: UUID,
+    identifier: String,
+    password: String,
+    managerName: String,
+    phoneNumber: String,
+    status: CenterAccountStatus,
+    centerBusinessRegistrationNumber: String,
+) {
+
+    @Id
+    @Column(nullable = false)
+    var id: UUID = id
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var identifier: String = identifier
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var password: String = password
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var managerName: String = managerName
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var phoneNumber: String = phoneNumber
+        private set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var status: CenterAccountStatus = status
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var centerBusinessRegistrationNumber: String = centerBusinessRegistrationNumber
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/enums/CenterAccountStatus.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/enums/CenterAccountStatus.kt
@@ -1,0 +1,7 @@
+package com.swm.idle.domain.center.enums
+
+enum class CenterAccountStatus {
+    ACTIVE,
+    PENDING,
+    INACTIVE,
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/repository/CenterManagerJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/repository/CenterManagerJpaRepository.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.domain.center.repository
+
+import com.swm.idle.domain.center.entity.CenterManager
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface CenterManagerJpaRepository : JpaRepository<CenterManager, UUID> {
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
@@ -1,0 +1,38 @@
+package com.swm.idle.domain.center.service
+
+import com.swm.idle.domain.center.entity.CenterManager
+import com.swm.idle.domain.center.enums.CenterAccountStatus
+import com.swm.idle.domain.center.repository.CenterManagerJpaRepository
+import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
+import com.swm.idle.domain.sms.vo.PhoneNumber
+import com.swm.idle.support.common.uuid.UuidCreator
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CenterManagerService(
+    private val centerManagerJpaRepository: CenterManagerJpaRepository,
+) {
+
+    @Transactional
+    fun save(
+        identifier: String,
+        password: String,
+        phoneNumber: PhoneNumber,
+        managerName: String,
+        centerBusinessRegistrationNumber: BusinessRegistrationNumber,
+    ) {
+        CenterManager(
+            id = UuidCreator.create(),
+            identifier = identifier,
+            password = password,
+            phoneNumber = phoneNumber.value,
+            managerName = managerName,
+            status = CenterAccountStatus.PENDING,
+            centerBusinessRegistrationNumber = centerBusinessRegistrationNumber.value,
+        ).also {
+            centerManagerJpaRepository.save(it)
+        }
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/vo/BusinessRegistrationNumber.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/vo/BusinessRegistrationNumber.kt
@@ -1,0 +1,13 @@
+package com.swm.idle.domain.center.vo
+
+@JvmInline
+value class BusinessRegistrationNumber(val value: String) {
+
+    init {
+        require(value.matches(Regex(VALIDATION_REGEX)))
+    }
+
+    companion object {
+        const val VALIDATION_REGEX = "^\\d{3}-\\d{2}-\\d{5}$"
+    }
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 관리자 회원가입 API 구현

## 2. ✏️ Documentation
## Background

센터 관리자의 서비스 이용을 위해, 센터 관리자 회원가입 API가 필요합니다.

## Goals & Non-Goals

### Goals

- 센터 관리자는 ID, PW로 회원가입을 진행합니다.
- 한 센터에 대해 여러 관리자가 회원가입 할 수 있어야 합니다.

### Non goals

- 센터에서 처음으로 회원가입 하는 센터 관리자는 자신의 센터 정보를 입력해야 할 의무가 있습니다.
    - 해당 FLOW는 이후 센터 프로필 등록 API를 통해 개발할 예정이므로, 해당 API에서는 제외합니다.

---

## **Methodology & Design(Proposal)**

### API

- API
    - [🆕 Sample] POST /api/v1/auth/center/join
        - request
            - method & path: `POST /api/v1/auth/center/join`
            - body
                
                ```json
                {
                  "identifier": "string", (required & not null)
                  "password": "string", (required & not null)
                  "phoneNumber": "string", (required & not null) (010-0000-0000의 형식을 따릅니다.)
                  "managerName": "string", (required & not null)
                  "centerBusinessRegistrationNumber": "string" (required & not null) (000-00-00000의 형식을 따릅니다.)
                }
                ```
                
        - response
            - 정상 처리된 경우
                - status code: `201 Created`
             
## 3. 🤔 고민했던 점 & 알게된 점
기존 회원가입 flow를 따르면, 센터 관리자가 먼저 등록되고 이후 센터 정보가 등록됩니다.
센터 : 센터 관리자는 1 : N 관계이며 센터 관리자 측에서 FK를 관리하게 되어 FK Constraint를 위배하게 됩니다.
![image](https://github.com/3IDLES/idle-server/assets/59856002/7b3ddaf3-1f8f-4bdb-912d-6eb738ccf4f5)


이에 대한 해결책으로 크게 3가지 방법을 고민해 보았습니다.

1. 임시 회원 테이블을 생성하여 보관 후, 센터가 생성될 때 등록시키는 방법
-> 현 정책에서는 센터 내 초기 가입자만 센터에 대한 정보를 입력할 수 있으므로, 두 번째 가입자부터는 임시 회원 테이블을 거치지 않아도 가입할 수 있어 불필요합니다.

2. 임시로 센터의 ID를 발급하면 어떨까.?
-> 현재 정책으로는 센터 회원 가입 API를 거친 후 승인까지의 텀이 존재하므로, 충분히 유저가 가입 이후에 센터 정보를 기입하지 않을 가능성이 커 시스템 내 데이터 정합성을 유지하기가 어렵다고 생각했습니다.

3. FK를 사용하지 않는 방법
FK를 사용하면 데이터 정합성을 보장할 수 있으나, 위와 같은 상황처럼 설계에 대한 제약이 많아진다고 생각하여 FK 없이 시스템을 설계하기로 결정하였습니다.
부가적으로, FK를 사용하는 경우 참조되는 FK 레코드에 대해 s-lock이 걸리게 되어 성능 저하 및 deadlock 발생 여지가 있음을 파악하게 되었습니다.

다만 MySQL을 사용하면 FK에 기본적으로 인덱스가 걸리지만, FK를 사용하지 않으므로 별도의 Index 처리가 필요합니다.
