### PR TITLE
[IDLE-130] 비밀번호 암호화 라이브러리 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ subprojects {
         implementation(rootProject.libs.kotlin.reflect)
         implementation(rootProject.libs.kotlin.coroutines.core)
         implementation(rootProject.libs.uuid.creator)
+        implementation(rootProject.libs.jbcrypt)
 
         annotationProcessor(rootProject.libs.spring.boot.configuration.processor)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ springdoc-openapi = "2.3.0"
 
 cool-sms = "4.3.0"
 uuid-creator = "5.3.3"
+jbcrypt = "0.4"
 
 mysql = "8.0.33"
 
@@ -49,6 +50,7 @@ testcontainers-junit-jupiter = { group = "org.testcontainers", name = "junit-jup
 
 springdoc-openapi-starter-webmvc-ui = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
 net-nurigo-sdk = { group = "net.nurigo", name = "sdk", version.ref = "cool-sms"}
+jbcrypt = { group = "org.mindrot", name = "jbcrypt", version.ref = "jbcrypt" }
 
 [plugins]
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
@@ -5,6 +5,7 @@ import com.swm.idle.domain.center.enums.CenterAccountStatus
 import com.swm.idle.domain.center.repository.CenterManagerJpaRepository
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
 import com.swm.idle.domain.sms.vo.PhoneNumber
+import com.swm.idle.support.common.encrypt.PasswordEncryptor
 import com.swm.idle.support.common.uuid.UuidCreator
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,10 +23,12 @@ class CenterManagerService(
         managerName: String,
         centerBusinessRegistrationNumber: BusinessRegistrationNumber,
     ) {
+        val encryptedPassword = PasswordEncryptor.encrypt(rawPassword = password)
+
         CenterManager(
             id = UuidCreator.create(),
             identifier = identifier,
-            password = password,
+            password = encryptedPassword,
             phoneNumber = phoneNumber.value,
             managerName = managerName,
             status = CenterAccountStatus.PENDING,

--- a/idle-support/common/src/main/kotlin/com/swm/idle/support/common/encrypt/PasswordEncryptor.kt
+++ b/idle-support/common/src/main/kotlin/com/swm/idle/support/common/encrypt/PasswordEncryptor.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.support.common.encrypt
+
+import org.mindrot.jbcrypt.BCrypt
+
+object PasswordEncryptor {
+
+    fun encrypt(rawPassword: String): String {
+        return BCrypt.hashpw(rawPassword, BCrypt.gensalt())
+    }
+
+    fun matchPassword(
+        enteredPassword: String,
+        password: String,
+    ): Boolean {
+        return BCrypt.checkpw(password, enteredPassword)
+    }
+
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 비밀번호 암호화 라이브러리를 적용했습니다.
* 센터 회원가입 시, 해시된 비밀번호가 저장되는 로직을 추가하였습니다.

## 2. 📸 스크린샷
![image](https://github.com/3IDLES/idle-server/assets/59856002/850e9d2d-3d7d-466f-a6c3-e3880fc300e6)