### PR TITLE
[IDLE-135] 센터 회원가입 API 유효성 검사 로직 추가

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
@@ -10,6 +10,8 @@ import com.swm.idle.api.auth.center.dto.ValidateIdentifierRequest
 import com.swm.idle.api.auth.center.facade.CenterAuthFacadeService
 import com.swm.idle.api.auth.center.spec.CenterAuthApi
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
+import com.swm.idle.domain.center.vo.Identifier
+import com.swm.idle.domain.center.vo.Password
 import com.swm.idle.domain.sms.vo.PhoneNumber
 import org.springframework.web.bind.annotation.RestController
 
@@ -20,8 +22,8 @@ class CenterAuthController(
 
     override fun join(request: JoinRequest) {
         centerAuthFacadeService.join(
-            identifier = request.identifier,
-            password = request.password,
+            identifier = Identifier(request.identifier),
+            password = Password(request.password),
             phoneNumber = PhoneNumber(request.phoneNumber),
             managerName = request.managerName,
             centerBusinessRegistrationNumber = BusinessRegistrationNumber(request.centerBusinessRegistrationNumber),

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
@@ -2,6 +2,8 @@ package com.swm.idle.api.auth.center.facade
 
 import com.swm.idle.domain.center.service.CenterManagerService
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
+import com.swm.idle.domain.center.vo.Identifier
+import com.swm.idle.domain.center.vo.Password
 import com.swm.idle.domain.sms.vo.PhoneNumber
 import org.springframework.stereotype.Service
 
@@ -10,8 +12,8 @@ class CenterAuthFacadeService(
     private val centerManagerService: CenterManagerService,
 ) {
     fun join(
-        identifier: String,
-        password: String,
+        identifier: Identifier,
+        password: Password,
         phoneNumber: PhoneNumber,
         managerName: String,
         centerBusinessRegistrationNumber: BusinessRegistrationNumber,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
@@ -4,6 +4,8 @@ import com.swm.idle.domain.center.entity.CenterManager
 import com.swm.idle.domain.center.enums.CenterAccountStatus
 import com.swm.idle.domain.center.repository.CenterManagerJpaRepository
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
+import com.swm.idle.domain.center.vo.Identifier
+import com.swm.idle.domain.center.vo.Password
 import com.swm.idle.domain.sms.vo.PhoneNumber
 import com.swm.idle.support.common.encrypt.PasswordEncryptor
 import com.swm.idle.support.common.uuid.UuidCreator
@@ -17,17 +19,17 @@ class CenterManagerService(
 
     @Transactional
     fun save(
-        identifier: String,
-        password: String,
+        identifier: Identifier,
+        password: Password,
         phoneNumber: PhoneNumber,
         managerName: String,
         centerBusinessRegistrationNumber: BusinessRegistrationNumber,
     ) {
-        val encryptedPassword = PasswordEncryptor.encrypt(rawPassword = password)
+        val encryptedPassword = PasswordEncryptor.encrypt(rawPassword = password.value)
 
         CenterManager(
             id = UuidCreator.create(),
-            identifier = identifier,
+            identifier = identifier.value,
             password = encryptedPassword,
             phoneNumber = phoneNumber.value,
             managerName = managerName,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/vo/Identifier.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/vo/Identifier.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.domain.center.vo
+
+@JvmInline
+value class Identifier(val value: String) {
+
+    init {
+        require(value.matches(Regex(VALIDATION_REGEX))) {
+            "올바르지 않은 아이디 형식입니다."
+        }
+    }
+
+    companion object {
+        const val VALIDATION_REGEX = "^[A-Za-z0-9]{6,20}\$"
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/vo/Password.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/vo/Password.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.domain.center.vo
+
+@JvmInline
+value class Password(val value: String) {
+
+    init {
+        require(value.matches(Regex(VALIDATION_REGEX))) {
+            "올바르지 않은 비밀번호 형식입니다."
+        }
+    }
+
+    companion object {
+        const val VALIDATION_REGEX =
+            "^(?=.*[A-Za-z])(?=.*\\d)(?!.*(.)\\1\\1)[A-Za-z\\d!@#\$%^&*()-_=+`~]{8,20}\$"
+    }
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 회원가입 API 유효성 검사 로직을 추가하였습니다.

정책은 아래와 같으며, 팀 문서에 반영해 두었습니다!

- **아이디 정책**
    - 최소 6자 ~ 최대 20자까지 허용
    - 사용 가능 문자 : 영문 대문자, 소문자, 숫자만 허용
    
- **비밀번호 정책**
    - 최소 8자 이상 ~ 최대 20자까지 허용
    - 사용 가능 문자 : 영문 대문자, 소문자, 숫자, 특수문자
    - 영문자와 숫자 반드시 하나씩 포함해야 함
    - 공백 문자 사용 금지
    - 연속된 문자 3개 이상 사용 금지
