### PR TITLE
[IDLE-67] 센터 로그인 API 및 JWT 토큰 발급 로직 구현

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,9 @@ mysql = "8.0.33"
 
 kotlin-coroutines = "1.8.0"
 
+auth0-java-jwt = "4.4.0"
+auth0-jwks-rsa = "0.22.1"
+
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
@@ -53,6 +56,9 @@ spring-cloud-starter-openfeign = { group = "org.springframework.cloud", name = "
 springdoc-openapi-starter-webmvc-ui = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
 net-nurigo-sdk = { group = "net.nurigo", name = "sdk", version.ref = "cool-sms"}
 jbcrypt = { group = "org.mindrot", name = "jbcrypt", version.ref = "jbcrypt" }
+
+java-jwt = { group = "com.auth0", name = "java-jwt", version.ref = "auth0-java-jwt" }
+jwks-rsa = { group = "com.auth0", name = "jwks-rsa", version.ref = "auth0-jwks-rsa" }
 
 [plugins]
 

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
@@ -36,7 +36,12 @@ class CenterAuthController(
     }
 
     override fun login(request: LoginRequest): LoginResponse {
-        TODO("Not yet implemented")
+        val response = centerAuthFacadeService.login(
+            identifier = Identifier(request.identifier),
+            password = Password(request.password),
+        )
+
+        return response
     }
 
     override fun logout() {

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/dto/LoginRequest.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/dto/LoginRequest.kt
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "센터 로그인 API"
 )
 data class LoginRequest(
+    @Schema(description = "아이디(ID)")
     val identifier: String,
+    @Schema(description = "비밀번호")
     val password: String,
 )

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
@@ -1,19 +1,25 @@
 package com.swm.idle.api.auth.center.facade
 
+//import com.swm.idle.domain.user.util.JwtTokenService
+import com.swm.idle.api.auth.center.dto.LoginResponse
 import com.swm.idle.api.auth.center.dto.ValidateBusinessRegistrationNumberResponse
+import com.swm.idle.domain.center.exception.CenterException
 import com.swm.idle.domain.center.service.CenterManagerService
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
 import com.swm.idle.domain.center.vo.Identifier
 import com.swm.idle.domain.center.vo.Password
 import com.swm.idle.domain.sms.vo.PhoneNumber
+import com.swm.idle.domain.user.util.JwtTokenService
 import com.swm.idle.infrastructure.client.center.service.CenterAuthClientService
 import com.swm.idle.infrastructure.client.common.exception.ClientException
+import com.swm.idle.support.common.encrypt.PasswordEncryptor
 import org.springframework.stereotype.Service
 
 @Service
 class CenterAuthFacadeService(
     private val centerManagerService: CenterManagerService,
     private val centerAuthClientService: CenterAuthClientService,
+    private val jwtTokenService: JwtTokenService,
 ) {
     fun join(
         identifier: Identifier,
@@ -41,6 +47,20 @@ class CenterAuthFacadeService(
         return ValidateBusinessRegistrationNumberResponse(
             businessRegistrationNumber = item.bno,
             companyName = item.company,
+        )
+    }
+
+    fun login(
+        identifier: Identifier,
+        password: Password,
+    ): LoginResponse {
+        val centerManager = centerManagerService.findByIdentifier(identifier)?.takeIf {
+            PasswordEncryptor.matchPassword(password.value, it.password)
+        } ?: throw CenterException.ManagerNotFound()
+
+        return LoginResponse(
+            accessToken = jwtTokenService.generateAccessToken(centerManager),
+            refreshToken = jwtTokenService.generateRefreshToken(centerManager),
         )
     }
 

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
@@ -1,6 +1,5 @@
 package com.swm.idle.api.auth.center.facade
 
-//import com.swm.idle.domain.user.util.JwtTokenService
 import com.swm.idle.api.auth.center.dto.LoginResponse
 import com.swm.idle.api.auth.center.dto.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.domain.center.exception.CenterException

--- a/idle-domain/build.gradle.kts
+++ b/idle-domain/build.gradle.kts
@@ -8,6 +8,7 @@ jar.enabled = true
 
 dependencies {
     implementation(project(":idle-support:common"))
+    implementation(project(":idle-support:security"))
 
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.data.redis)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/exception/CenterException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/exception/CenterException.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.domain.center.exception
+
+import com.swm.idle.support.common.exception.CustomException
+
+sealed class CenterException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class ManagerNotFound(message: String = "존재하지 않는 센터 관리자 회원입니다.") :
+        CenterException(codeNumber = 1, message = message)
+
+    companion object {
+        const val CODE_PREFIX = "CENTER"
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/repository/CenterManagerJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/repository/CenterManagerJpaRepository.kt
@@ -7,4 +7,7 @@ import java.util.*
 
 @Repository
 interface CenterManagerJpaRepository : JpaRepository<CenterManager, UUID> {
+
+    fun findByIdentifier(value: String): CenterManager?
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
@@ -40,4 +40,8 @@ class CenterManagerService(
         }
     }
 
+    fun findByIdentifier(identifier: Identifier): CenterManager? {
+        return centerManagerJpaRepository.findByIdentifier(identifier.value)
+    }
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/DomainConfig.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/DomainConfig.kt
@@ -1,9 +1,13 @@
 package com.swm.idle.domain.common.config
 
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ComponentScan(basePackages = ["com.swm.idle.domain"])
+@EnableConfigurationProperties
+@ConfigurationPropertiesScan(basePackages = ["com.swm.idle.domain"])
 class DomainConfig {
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/properties/JwtTokenProperties.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/properties/JwtTokenProperties.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.domain.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(value = "auth.jwt")
+data class JwtTokenProperties(
+    val issuer: String,
+    val access: TokenProperties,
+    val refresh: TokenProperties,
+) {
+
+    data class TokenProperties(
+        val expireSeconds: Long,
+        val secret: String,
+    )
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserTokenType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserTokenType.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.domain.user.common.enum
+
+enum class UserTokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN,
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/entity/UserRefreshTokenRedisHash.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/entity/UserRefreshTokenRedisHash.kt
@@ -1,0 +1,26 @@
+package com.swm.idle.domain.user.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+import java.util.*
+
+@RedisHash("user_refresh_token")
+class UserRefreshTokenRedisHash(
+    id: UUID,
+    refreshToken: String,
+    expireSeconds: Long,
+) {
+
+    @Id
+    var id: UUID = id
+        private set
+
+    var refreshToken: String = refreshToken
+        private set
+
+    @TimeToLive
+    var expireSeconds: Long = expireSeconds
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/repository/UserRefreshTokenRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/repository/UserRefreshTokenRepository.kt
@@ -1,0 +1,8 @@
+package com.swm.idle.domain.user.repository
+
+import com.swm.idle.domain.user.entity.UserRefreshTokenRedisHash
+import org.springframework.data.repository.CrudRepository
+import java.util.*
+
+interface UserRefreshTokenRepository : CrudRepository<UserRefreshTokenRedisHash, UUID> {
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/util/JwtTokenService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/util/JwtTokenService.kt
@@ -1,0 +1,60 @@
+package com.swm.idle.domain.user.util
+
+import com.swm.idle.domain.center.entity.CenterManager
+import com.swm.idle.domain.common.properties.JwtTokenProperties
+import com.swm.idle.domain.user.common.enum.UserTokenType
+import com.swm.idle.domain.user.entity.UserRefreshTokenRedisHash
+import com.swm.idle.domain.user.repository.UserRefreshTokenRepository
+import com.swm.idle.support.security.jwt.util.JwtTokenProvider
+import com.swm.idle.support.security.jwt.vo.JwtClaims
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.*
+
+@Service
+class JwtTokenService(
+    private val jwtTokenProperties: JwtTokenProperties,
+    private val userRefreshTokenRepository: UserRefreshTokenRepository,
+) {
+
+    fun generateAccessToken(centerManager: CenterManager): String {
+        val jwtClaims = JwtClaims {
+            registeredClaims {
+                iss = jwtTokenProperties.issuer
+                exp = Date.from(Instant.now().plusSeconds(jwtTokenProperties.access.expireSeconds))
+            }
+            customClaims {
+                this["type"] = UserTokenType.ACCESS_TOKEN.name
+                this["userId"] = centerManager.id.toString()
+            }
+        }
+
+        return JwtTokenProvider.createToken(jwtClaims, jwtTokenProperties.access.secret)
+    }
+
+    fun generateRefreshToken(centerManager: CenterManager): String {
+        val jwtClaims = JwtClaims {
+            registeredClaims {
+                iss = jwtTokenProperties.issuer
+                exp = Date.from(Instant.now().plusSeconds(jwtTokenProperties.refresh.expireSeconds))
+            }
+            customClaims {
+                this["type"] = UserTokenType.REFRESH_TOKEN.name
+                this["userId"] = centerManager.id.toString()
+            }
+        }
+
+        return JwtTokenProvider
+            .createToken(jwtClaims, jwtTokenProperties.refresh.secret)
+            .also {
+                userRefreshTokenRepository.save(
+                    UserRefreshTokenRedisHash(
+                        id = centerManager.id,
+                        refreshToken = it,
+                        expireSeconds = jwtTokenProperties.refresh.expireSeconds
+                    )
+                )
+            }
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/UserTokenClaims.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/UserTokenClaims.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.domain.user.vo
+
+import com.swm.idle.domain.sms.vo.PhoneNumber
+import java.util.*
+
+sealed class UserTokenClaims {
+
+    data class AccessToken(
+        val userId: UUID,
+        val phoneNumber: PhoneNumber,
+    ): UserTokenClaims()
+
+    data class RefreshToken(
+        val userId: UUID,
+    ): UserTokenClaims()
+
+}

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -14,6 +14,16 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
+auth:
+  jwt:
+    issuer: ${JWT_ISSUER:idle}
+    access:
+      expire-seconds: ${JWT_ACCESS_EXPIRE_SECONDS}
+      secret: ${JWT_ACCESS_SECRET_SIGNATURE}
+    refresh:
+      expire-seconds: ${JWT_REFRESH_EXPIRE_SECONDS}
+      secret: ${JWT_REFRESH_SECRET_SIGNATURE}
+
 ---
 spring:
   config:

--- a/idle-support/common/src/main/kotlin/com/swm/idle/support/common/encrypt/PasswordEncryptor.kt
+++ b/idle-support/common/src/main/kotlin/com/swm/idle/support/common/encrypt/PasswordEncryptor.kt
@@ -12,7 +12,7 @@ object PasswordEncryptor {
         enteredPassword: String,
         password: String,
     ): Boolean {
-        return BCrypt.checkpw(password, enteredPassword)
+        return BCrypt.checkpw(enteredPassword, password)
     }
 
 }

--- a/idle-support/security/build.gradle.kts
+++ b/idle-support/security/build.gradle.kts
@@ -7,4 +7,7 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation(project(":idle-support:common"))
+    implementation(libs.java.jwt)
+    implementation(libs.jwks.rsa)
 }

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/util/JwtTokenProvider.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/util/JwtTokenProvider.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.support.security.jwt.util
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.swm.idle.support.security.jwt.vo.JwtClaims
+
+object JwtTokenProvider {
+
+    fun createToken(
+        jwtClaims: JwtClaims,
+        secret: String,
+    ): String {
+        return JWT.create().withJWTId(jwtClaims.jti).withSubject(jwtClaims.sub)
+            .withIssuer(jwtClaims.iss).withAudience(*jwtClaims.aud?.toTypedArray() ?: arrayOf())
+            .withIssuedAt(jwtClaims.iat).withNotBefore(jwtClaims.nbf).withExpiresAt(jwtClaims.exp)
+            .withPayload(jwtClaims.customClaims).sign(Algorithm.HMAC256(secret))
+    }
+
+}

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/vo/JwtClaims.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/vo/JwtClaims.kt
@@ -1,0 +1,62 @@
+package com.swm.idle.support.security.jwt.vo
+
+import com.auth0.jwt.interfaces.DecodedJWT
+import java.time.Instant
+import java.util.*
+
+data class JwtClaims(
+    val registeredClaims: RegisteredClaims,
+    val customClaims: MutableMap<String, Any> = mutableMapOf(),
+) {
+
+    data class RegisteredClaims(
+        val sub: String? = null,
+        val exp: Date? = Date.from(Instant.now().plusSeconds(DEFAULT_EXPIRATION_TIME_SEC)),
+        val iat: Date? = Date.from(Instant.now()),
+        val nbf: Date? = Date.from(Instant.now()),
+        val iss: String? = null,
+        val aud: List<String>? = null,
+        val jti: String? = null,
+    )
+
+    val sub: String?
+        get() = registeredClaims.sub
+    val exp: Date?
+        get() = registeredClaims.exp
+    val iat: Date?
+        get() = registeredClaims.iat
+    val nbf: Date?
+        get() = registeredClaims.nbf
+    val iss: String?
+        get() = registeredClaims.iss
+    val aud: List<String>?
+        get() = registeredClaims.aud
+    val jti: String?
+        get() = registeredClaims.jti
+
+    companion object {
+
+        const val DEFAULT_EXPIRATION_TIME_SEC: Long = 60 * 60
+
+        fun from(claims: DecodedJWT): JwtClaims {
+            val registeredClaims = RegisteredClaims(
+                sub = claims.subject,
+                exp = claims.expiresAt,
+                iat = claims.issuedAt,
+                nbf = claims.notBefore,
+                iss = claims.issuer,
+                aud = claims.audience,
+                jti = claims.id,
+            )
+            val customClaims: MutableMap<String, Any> = mutableMapOf()
+            claims.claims
+                .filter { it.key !in registeredClaims::class.members.map { member -> member.name } }
+                .forEach { (key, value) ->
+                    customClaims[key] = value.`as`(Any::class.java)
+                }
+            return JwtClaims(registeredClaims, customClaims)
+        }
+
+    }
+
+}

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/vo/JwtClaimsBuilder.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/vo/JwtClaimsBuilder.kt
@@ -1,0 +1,42 @@
+package com.swm.idle.support.security.jwt.vo
+
+import java.time.Instant
+import java.util.*
+
+@DslMarker
+annotation class JwtClaimsDsl
+
+@JwtClaimsDsl
+class JwtClaimsBuilder {
+    private var registeredClaims = JwtClaims.RegisteredClaims()
+    private val customClaims = mutableMapOf<String, Any>()
+
+    fun registeredClaims(init: RegisteredClaimsBuilder.() -> Unit) {
+        val builder = RegisteredClaimsBuilder().apply(init)
+        registeredClaims = builder.build()
+    }
+
+    fun customClaims(block: MutableMap<String, Any>.() -> Unit) {
+        customClaims.apply(block)
+    }
+
+    fun build(): JwtClaims = JwtClaims(registeredClaims, customClaims)
+}
+
+
+@JwtClaimsDsl
+class RegisteredClaimsBuilder {
+    var sub: String? = null
+    var exp: Date? = Date.from(Instant.now().plusSeconds(JwtClaims.DEFAULT_EXPIRATION_TIME_SEC))
+    var iat: Date? = Date.from(Instant.now())
+    var nbf: Date? = Date.from(Instant.now())
+    var iss: String? = null
+    var aud: List<String>? = null
+    var jti: String? = null
+
+    fun build(): JwtClaims.RegisteredClaims =
+        JwtClaims.RegisteredClaims(sub, exp, iat, nbf, iss, aud, jti)
+}
+
+fun JwtClaims(init: JwtClaimsBuilder.() -> Unit): JwtClaims = JwtClaimsBuilder().apply(init).build()
+


### PR DESCRIPTION
## Backgrounds

센터 관리자의 회원 가입을 위해 로그인 API가 필요합니다.

## Goals & Non-Goals

### Goals

- 센터 관리자는 ID, PW로 로그인을 진행합니다.
    - ID, PW에 대한 DB 검증이 이루어져야 합니다.
    - 인증된 사용자의 경우, access token과 refresh token을 발급하여 반환합니다.
- 로그인에는 jwt token을 이용합니다.

### Non goals

- 인증이 필요한 API에 대해 토큰을 검증하는 로직은 해당 API에서 제외합니다.

## Policy

- access token과 refresh token의 TTL은 아래와 같이 설정하였습니다.
    - access token : 10 Min(600s)
    - refresh token: 14 days(1209600s)

## **Methodology & Design(Proposal)**

### API

- API
    - [🆕 Sample] POST /api/v1/auth/center/login
        - request
            - method & path: `POST /api/v1/auth/center/login`
            - body
                
                ```json
                {
                  "identifier": "string", (required & not null)
                  "password": "string", (required & not null)
                }
                ```
                
        - response
            - 정상 처리된 경우
                - status code: `200 OK`
                - body
                    
                    ```json
                    {
                      "accessToken": "string",
                      "refreshToken": "string"
                    }
                    ```
                    
            - 가입되지 않은 사용자인 경우
                - status code: `401 UnAuthorized`

## Schedule

- [x]  설계 및 문서 작성
- [x]  로그인 API 명세 및 구현
- [x]  Access, Refresh Token 생성 로직 구현
- [x]  Refresh Token 저장 로직 구현
- [x]  1차 dev 배포 및 QA