### PR TITLE
[IDLE-66] 인증과 인가 처리를 위한 필터 및 인터셉터 구현

### DIFF
--- a/idle-api/build.gradle.kts
+++ b/idle-api/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     implementation(project(":idle-domain"))
     implementation(project(":idle-support:logging"))
     implementation(project(":idle-support:common"))
+    implementation(project(":idle-support:security"))
     implementation(project(":idle-infrastructure:sms"))
     implementation(project(":idle-infrastructure:client"))
 

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ApiException.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ApiException.kt
@@ -10,6 +10,9 @@ sealed class ApiException(
     class InvalidParameter(message: String = "") :
         ApiException(codeNumber = 1, message = message)
 
+    class UnauthorizedRequest(message: String = "인증되지 않은 사용자입니다.") :
+        ApiException(codeNumber = 2, message = message)
+
     companion object {
         const val CODE_PREFIX = "API"
     }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/annotation/Secured.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/annotation/Secured.kt
@@ -1,0 +1,8 @@
+package com.swm.idle.api.common.security.annotation
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@SecurityRequirement(name = "AccessToken")
+annotation class Secured

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/context/UserSecurityContext.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/context/UserSecurityContext.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.api.common.security.context
+
+import com.swm.idle.domain.user.vo.UserAuthentication
+import com.swm.idle.support.security.jwt.context.SecurityContext
+
+class UserSecurityContext(
+    private var userAuthentication: UserAuthentication,
+) : SecurityContext<UserAuthentication> {
+
+    override fun getAuthentication(): UserAuthentication {
+        return userAuthentication
+    }
+
+    override fun setAuthentication(authentication: UserAuthentication) {
+        this.userAuthentication = authentication
+    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/filter/JwtAuthenticationFilter.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,52 @@
+package com.swm.idle.api.common.security.filter
+
+import com.swm.idle.api.common.security.context.UserSecurityContext
+import com.swm.idle.domain.user.util.JwtTokenService
+import com.swm.idle.domain.user.vo.UserAuthentication
+import com.swm.idle.support.security.jwt.context.SecurityContextHolder
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtTokenService: JwtTokenService,
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        extractToken(request)?.let {
+            processToken(it)
+        }
+        filterChain.doFilter(request, response)
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val bearerToken: String? = request.getHeader(TOKEN_REQUEST_HEADER_KEY)
+        return if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
+            bearerToken.substring(TOKEN_PREFIX.length)
+        } else null
+    }
+
+    private fun processToken(token: String) {
+        with(jwtTokenService.resolveAccessToken(token)) {
+            UserAuthentication.from(this)
+        }.let { userAuthentication ->
+            UserSecurityContext(userAuthentication)
+        }.also { securityContext ->
+            SecurityContextHolder.setContext(securityContext)
+        }
+    }
+
+    companion object {
+        const val TOKEN_PREFIX = "Bearer "
+        const val TOKEN_REQUEST_HEADER_KEY = "Authorization"
+    }
+
+}

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/interceptor/JwtAuthorizationInterceptor.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/interceptor/JwtAuthorizationInterceptor.kt
@@ -1,0 +1,42 @@
+package com.swm.idle.api.common.security.interceptor
+
+import com.swm.idle.api.common.exception.ApiException
+import com.swm.idle.api.common.security.annotation.Secured
+import com.swm.idle.domain.user.vo.UserAuthentication
+import com.swm.idle.support.security.jwt.context.SecurityContextHolder
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class JwtAuthorizationInterceptor : HandlerInterceptor {
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        if (handler !is HandlerMethod) {
+            return super.preHandle(request, response, handler)
+        }
+
+        if (hasSecuredAnnotation(handler) && isNotAuthenticated()) {
+            throw ApiException.UnauthorizedRequest()
+        }
+
+        return super.preHandle(request, response, handler)
+    }
+
+    private fun hasSecuredAnnotation(handler: Any): Boolean {
+        return (handler as HandlerMethod).hasMethodAnnotation(Secured::class.java)
+    }
+
+    private fun isNotAuthenticated(): Boolean {
+        return SecurityContextHolder
+            .getContext<UserAuthentication>()
+            .let { it == null }
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/util/JwtTokenService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/util/JwtTokenService.kt
@@ -2,9 +2,11 @@ package com.swm.idle.domain.user.util
 
 import com.swm.idle.domain.center.entity.CenterManager
 import com.swm.idle.domain.common.properties.JwtTokenProperties
+import com.swm.idle.domain.sms.vo.PhoneNumber
 import com.swm.idle.domain.user.common.enum.UserTokenType
 import com.swm.idle.domain.user.entity.UserRefreshTokenRedisHash
 import com.swm.idle.domain.user.repository.UserRefreshTokenRepository
+import com.swm.idle.domain.user.vo.UserTokenClaims
 import com.swm.idle.support.security.jwt.util.JwtTokenProvider
 import com.swm.idle.support.security.jwt.vo.JwtClaims
 import org.springframework.stereotype.Service
@@ -26,6 +28,7 @@ class JwtTokenService(
             customClaims {
                 this["type"] = UserTokenType.ACCESS_TOKEN.name
                 this["userId"] = centerManager.id.toString()
+                this["phoneNumber"] = centerManager.phoneNumber
             }
         }
 
@@ -55,6 +58,17 @@ class JwtTokenService(
                     )
                 )
             }
+    }
+
+    fun resolveAccessToken(accessToken: String): UserTokenClaims.AccessToken {
+        val jwtClaims: JwtClaims = JwtTokenProvider
+            .verifyToken(accessToken, jwtTokenProperties.access.secret)
+            .getOrThrow()
+
+        return UserTokenClaims.AccessToken(
+            userId = UUID.fromString(jwtClaims.customClaims["userId"] as String),
+            phoneNumber = PhoneNumber(jwtClaims.customClaims["phoneNumber"] as String),
+        )
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/UserAuthentication.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/UserAuthentication.kt
@@ -1,0 +1,25 @@
+package com.swm.idle.domain.user.vo
+
+import com.swm.idle.domain.sms.vo.PhoneNumber
+import com.swm.idle.support.security.jwt.common.Authentication
+import java.util.*
+
+data class UserAuthentication(
+    val userId: UUID,
+    val phoneNumber: PhoneNumber,
+) : Authentication {
+
+    companion object {
+        fun from(claims: UserTokenClaims.AccessToken): UserAuthentication {
+            return UserAuthentication(
+                userId = claims.userId,
+                phoneNumber = claims.phoneNumber,
+            )
+        }
+    }
+
+    override fun getName(): String {
+        return userId.toString()
+    }
+
+}

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/common/Authentication.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/common/Authentication.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.support.security.jwt.common
+
+import java.security.Principal
+
+interface Authentication : Principal {
+}

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/context/SecurityContext.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/context/SecurityContext.kt
@@ -1,0 +1,11 @@
+package com.swm.idle.support.security.jwt.context
+
+import com.swm.idle.support.security.jwt.common.Authentication
+
+interface SecurityContext<T : Authentication> {
+
+    fun getAuthentication(): T
+
+    fun setAuthentication(authentication: T)
+
+}

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/context/SecurityContextHolder.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/context/SecurityContextHolder.kt
@@ -1,0 +1,22 @@
+package com.swm.idle.support.security.jwt.context
+
+import com.swm.idle.support.security.jwt.common.Authentication
+
+object SecurityContextHolder {
+
+    private val securityContextHolder = ThreadLocal<SecurityContext<*>>()
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Authentication> getContext(): SecurityContext<T>? {
+        return securityContextHolder.get() as SecurityContext<T>?
+    }
+
+    fun <T : Authentication> setContext(context: SecurityContext<T>) {
+        securityContextHolder.set(context)
+    }
+
+    fun clearContext() {
+        securityContextHolder.remove()
+    }
+
+}

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/exception/JwtException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/exception/JwtException.kt
@@ -1,0 +1,23 @@
+package com.swm.idle.support.security.jwt.exception
+
+import com.swm.idle.support.common.exception.CustomException
+
+sealed class JwtException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class TokenDecodeException(message: String = "유효하지 않은 토큰입니다.") :
+        JwtException(codeNumber = 1, message = message)
+
+    class TokenNotValid(message: String = "유효하지 않은 토큰입니다.") :
+        JwtException(codeNumber = 2, message = message)
+
+    class TokenExpired(message: String = "토큰이 만료되었습니다.") :
+        JwtException(codeNumber = 3, message = message)
+
+    companion object {
+        const val CODE_PREFIX = "JWT"
+    }
+
+}

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/util/JwtTokenProvider.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/util/JwtTokenProvider.kt
@@ -2,6 +2,9 @@ package com.swm.idle.support.security.jwt.util
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.JWTDecodeException
+import com.auth0.jwt.exceptions.TokenExpiredException
+import com.swm.idle.support.security.jwt.exception.JwtException
 import com.swm.idle.support.security.jwt.vo.JwtClaims
 
 object JwtTokenProvider {
@@ -14,6 +17,35 @@ object JwtTokenProvider {
             .withIssuer(jwtClaims.iss).withAudience(*jwtClaims.aud?.toTypedArray() ?: arrayOf())
             .withIssuedAt(jwtClaims.iat).withNotBefore(jwtClaims.nbf).withExpiresAt(jwtClaims.exp)
             .withPayload(jwtClaims.customClaims).sign(Algorithm.HMAC256(secret))
+    }
+
+    fun verifyToken(
+        token: String,
+        secret: String,
+    ): Result<JwtClaims> {
+        val algorithm: Algorithm = Algorithm.HMAC256(secret)
+        return verifyTokenWithAlgorithm(token, algorithm)
+    }
+
+    private fun verifyTokenWithAlgorithm(
+        token: String,
+        algorithm: Algorithm,
+    ): Result<JwtClaims> {
+        return runCatching {
+            JWT.require(algorithm).build().verify(token)
+        }.mapCatching { jwtClaims ->
+            JwtClaims.from(jwtClaims)
+        }.onFailure { exception ->
+            handleException(exception)
+        }
+    }
+
+    private fun handleException(exception: Throwable): Nothing {
+        when (exception) {
+            is JWTDecodeException -> throw JwtException.TokenDecodeException()
+            is TokenExpiredException -> throw JwtException.TokenExpired()
+            else -> throw JwtException.TokenNotValid()
+        }
     }
 
 }


### PR DESCRIPTION
## 1. 📄 Summary
* 인증 처리를 위한 필터 & 인가 처리를 위한 인터셉터를 구현하였습니다.
* Spring Security 없이 필요한 interface와 구현체를 직접 구현하였습니다.
* Spring AOP를 이용해 `@Secured` 어노테이션을 만들어 인증 처리가 필요한 API에 전역적으로 적용 가능하도록 구현했습니다.

### JwtAuthenticationFilter(인증 필터)

* UserAuthentication : SecurityContext에 보관할 인증 객체 interface

* Access Token을 아래와 같이 생성하고, customClaim 내에 필요한 center manager 정보를 저장합니다.

```kotlin
    fun generateAccessToken(centerManager: CenterManager): String {
        val jwtClaims = JwtClaims {
            registeredClaims {
                iss = jwtTokenProperties.issuer
                exp = Date.from(Instant.now().plusSeconds(jwtTokenProperties.access.expireSeconds))
            }
            customClaims {
                this["type"] = UserTokenType.ACCESS_TOKEN.name
                this["userId"] = centerManager.id.toString()
                this["phoneNumber"] = centerManager.phoneNumber
            }
        }

        return JwtTokenProvider.createToken(jwtClaims, jwtTokenProperties.access.secret)
    }
```

이후 검증 과정에서 AccessToken을 decode하여 verfiy한 후, SecurityContextHolder내 Security Context에 저장합니다.
```kotlin
    private fun processToken(token: String) {
        with(jwtTokenService.resolveAccessToken(token)) {
            UserAuthentication.from(this)
        }.let { userAuthentication ->
            UserSecurityContext(userAuthentication)
        }.also { securityContext ->
            SecurityContextHolder.setContext(securityContext)
        }
    }
```

Security Context Holder에서는 Thread local을 사용하여 스레드가 담당하는 요청 내에서 전역적으로 인증 정보를 공유할 수 있도록 합니다.
```kotlin
object SecurityContextHolder {

    private val securityContextHolder = ThreadLocal<SecurityContext<*>>()

    @Suppress("UNCHECKED_CAST")
    fun <T : Authentication> getContext(): SecurityContext<T>? {
        return securityContextHolder.get() as SecurityContext<T>?
    }

    fun <T : Authentication> setContext(context: SecurityContext<T>) {
        securityContextHolder.set(context)
    }

    fun clearContext() {
        securityContextHolder.remove()
    }

}
```

### JwtAuthrizationInterceptor(인가 인터셉터)
* `@Secured` 어노테이션을 통해 인증된 사용자만 접근할 수 있도록 제한합니다.
* 스프링 2.x 버전부터, 정적 리소스를 요청하는 경우에도 Interceptor가 실행됩니다.
* 이때, `HandlerMethod(RequestMappingHandlerMapping)` 이 아닌 `ResourceHttpRequestHandler` 객체가 핸들러 객체로 사용됩니다. 따라서 `@RequestMapping` 하위 구현체의 요청만 처리하기 위해 아래 if문을 구현하였습니다.

```kotlin
if (handler !is HandlerMethod) {
```

구현 코드는 아래와 같습니다.
```kotlin
@Component
class JwtAuthorizationInterceptor : HandlerInterceptor {

    override fun preHandle(
        request: HttpServletRequest,
        response: HttpServletResponse,
        handler: Any,
    ): Boolean {
        if (handler !is HandlerMethod) {
            return super.preHandle(request, response, handler)
        }

        if (hasSecuredAnnotation(handler) && isNotAuthenticated()) {
            throw ApiException.UnauthorizedRequest()
        }

        return super.preHandle(request, response, handler)
    }

    private fun hasSecuredAnnotation(handler: Any): Boolean {
        return (handler as HandlerMethod).hasMethodAnnotation(Secured::class.java)
    }

    private fun isNotAuthenticated(): Boolean {
        return SecurityContextHolder
            .getContext<UserAuthentication>()
            .let { it == null }
    }

}
```