### PR TITLE
[IDLE-000] JWT Exception 401 처리

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/CustomExceptionHandler.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/CustomExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.api.common.exception
 
 import com.swm.idle.support.common.exception.CustomException
+import com.swm.idle.support.security.jwt.exception.JwtException
 import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
@@ -18,6 +19,15 @@ class CustomExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(CustomException::class)
     fun handleCustomException(exception: CustomException): ErrorResponse {
+        return ErrorResponse(
+            code = exception.code,
+            message = exception.message,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(JwtException::class)
+    fun handlerJwtException(exception: JwtException): ErrorResponse {
         return ErrorResponse(
             code = exception.code,
             message = exception.message,

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/exception/JwtException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/exception/JwtException.kt
@@ -1,23 +1,21 @@
 package com.swm.idle.support.security.jwt.exception
 
-import com.swm.idle.support.common.exception.CustomException
-
 sealed class JwtException(
-    codeNumber: Int,
-    message: String,
-) : CustomException(CODE_PREFIX, codeNumber, message) {
+    val code: String,
+    override val message: String,
+) : RuntimeException(message) {
 
     class TokenDecodeException(message: String = "유효하지 않은 토큰입니다.") :
-        JwtException(codeNumber = 1, message = message)
+        JwtException(code = "JWT-001", message = message)
 
     class TokenNotValid(message: String = "유효하지 않은 토큰입니다.") :
-        JwtException(codeNumber = 2, message = message)
+        JwtException(code = "JWT-002", message = message)
 
     class TokenExpired(message: String = "토큰이 만료되었습니다.") :
-        JwtException(codeNumber = 3, message = message)
+        JwtException(code = "JWT-003", message = message)
 
     class TokenNotFound(message: String = "토큰을 찾을 수 없습니다.") :
-        JwtException(codeNumber = 4, message = message)
+        JwtException(code = "JWT-004", message = message)
 
     companion object {
         const val CODE_PREFIX = "JWT"


### PR DESCRIPTION
## 1. 📄 Summary
* JWT Exception이 발생하는 경우에 대해 `400 Bad Request` 대신 `401 UnAuthorized`를 발생시키도록 변경했습니다.
