### PR TITLE
[IDLE-131] 센터 아이디 중복 검사 API

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
@@ -44,6 +44,10 @@ class CenterAuthController(
         return response
     }
 
+    override fun validateIdentifier(identifier: String) {
+        centerAuthFacadeService.validateIdentifier(Identifier(identifier))
+    }
+
     override fun logout() {
         TODO("Not yet implemented")
     }
@@ -55,10 +59,6 @@ class CenterAuthController(
     }
 
     override fun withDraw() {
-        TODO("Not yet implemented")
-    }
-
-    override fun validateIdentifier(identifier: String) {
         TODO("Not yet implemented")
     }
 

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
@@ -76,4 +76,8 @@ class CenterAuthFacadeService(
             }
     }
 
+    fun validateIdentifier(identifier: Identifier) {
+        centerManagerService.validateDuplicateIdentifier(identifier)
+    }
+
 }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
@@ -69,7 +69,7 @@ interface CenterAuthApi {
         value = [
             ApiResponse(
                 responseCode = "204",
-                description = "중복되지 않는 아이디",
+                description = "사용 가능한 아이디",
             ),
             ApiResponse(
                 responseCode = "400",

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/exception/CenterException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/exception/CenterException.kt
@@ -10,6 +10,9 @@ sealed class CenterException(
     class ManagerNotFound(message: String = "존재하지 않는 센터 관리자 회원입니다.") :
         CenterException(codeNumber = 1, message = message)
 
+    class DuplicateIdentifier(message: String = "이미 존재하는 ID입니다.") :
+        CenterException(codeNumber = 2, message = message)
+
     companion object {
         const val CODE_PREFIX = "CENTER"
     }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/repository/CenterManagerJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/repository/CenterManagerJpaRepository.kt
@@ -10,4 +10,6 @@ interface CenterManagerJpaRepository : JpaRepository<CenterManager, UUID> {
 
     fun findByIdentifier(value: String): CenterManager?
 
+    fun existsByIdentifier(value: String): Boolean
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
@@ -2,6 +2,7 @@ package com.swm.idle.domain.center.service
 
 import com.swm.idle.domain.center.entity.CenterManager
 import com.swm.idle.domain.center.enums.CenterAccountStatus
+import com.swm.idle.domain.center.exception.CenterException
 import com.swm.idle.domain.center.repository.CenterManagerJpaRepository
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
 import com.swm.idle.domain.center.vo.Identifier
@@ -50,6 +51,12 @@ class CenterManagerService(
         return centerManagerJpaRepository
             .findById(id)
             .orElseThrow { PersistenceException.ResourceNotFound("유저(id: $id)를 찾을 수 없습니다.") }
+    }
+
+    fun validateDuplicateIdentifier(identifier: Identifier) {
+        if (centerManagerJpaRepository.existsByIdentifier(identifier.value)) {
+            throw CenterException.DuplicateIdentifier()
+        }
     }
 
 }


### PR DESCRIPTION
## Backgrounds

센터 관리자의 회원 가입 시, 아이디 중복 체크 기능이 필요합니다.

## Goals & Non-Goals

### Goals

- 센터 관리자는 회원 가입 시, 아이디 중복 체크 검사를 통해 허용된 아이디로만 가입할 수 있도록 합니다.

### Non goals

- 여러 센터 관리자가 동시적으로 중복된 아이디를 체크하는 경우는 발생하기가 어렵다고 판단되어, 제외하였습니다.

## **Methodology & Design(Proposal)**

### API

- API
    - [🆕 Sample] GET /api/v1/auth/center/validation/{identifier}
        - request
            - method & path: `GET /api/v1/auth/center/validation/{identifier}`
        - response
            - 사용 가능한 아이디
                - status code: `204 No Content`
            - 이미 존재하는 아이디가 있는 경우
                - status code: `400 Bad Request`

## Schedule

- [x]  설계 및 문서 작성
- [x]  아이디 중복 체크 API
- [ ]  dev 배포 및 QA

## Risks

- 여러 센터 관리자가 동시적으로 중복된 아이디를 체크하는 경우가 발생한다면 어떻게 처리할지?