### PR TITLE
[IDLE-68] 센터 로그아웃 API 및 일부 에러 정책 변경

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
@@ -36,12 +36,10 @@ class CenterAuthController(
     }
 
     override fun login(request: LoginRequest): LoginResponse {
-        val response = centerAuthFacadeService.login(
+        return centerAuthFacadeService.login(
             identifier = Identifier(request.identifier),
             password = Password(request.password),
         )
-
-        return response
     }
 
     override fun validateIdentifier(identifier: String) {
@@ -49,13 +47,11 @@ class CenterAuthController(
     }
 
     override fun logout() {
-        TODO("Not yet implemented")
+        centerAuthFacadeService.logout()
     }
 
     override fun refreshLoginToken(request: RefreshTokenRequest): RefreshLoginTokenResponse {
-        val response = centerAuthFacadeService.refreshLoginToken(request.refreshToken)
-
-        return response
+        return centerAuthFacadeService.refreshLoginToken(request.refreshToken)
     }
 
     override fun withDraw() {

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
@@ -3,11 +3,12 @@ package com.swm.idle.api.auth.center.facade
 import com.swm.idle.api.auth.center.dto.LoginResponse
 import com.swm.idle.api.auth.center.dto.RefreshLoginTokenResponse
 import com.swm.idle.api.auth.center.dto.ValidateBusinessRegistrationNumberResponse
-import com.swm.idle.domain.center.exception.CenterException
 import com.swm.idle.domain.center.service.CenterManagerService
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
 import com.swm.idle.domain.center.vo.Identifier
 import com.swm.idle.domain.center.vo.Password
+import com.swm.idle.domain.common.exception.PersistenceException
+import com.swm.idle.domain.common.util.getUserAuthentication
 import com.swm.idle.domain.sms.vo.PhoneNumber
 import com.swm.idle.domain.user.service.RefreshTokenService
 import com.swm.idle.domain.user.util.JwtTokenService
@@ -23,6 +24,7 @@ class CenterAuthFacadeService(
     private val jwtTokenService: JwtTokenService,
     private val refreshTokenService: RefreshTokenService,
 ) {
+
     fun join(
         identifier: Identifier,
         password: Password,
@@ -78,6 +80,18 @@ class CenterAuthFacadeService(
 
     fun validateIdentifier(identifier: Identifier) {
         centerManagerService.validateDuplicateIdentifier(identifier)
+    }
+
+    fun logout() {
+        val centerManagerId = getUserAuthentication().userId
+
+        if (centerManagerService.existsById(centerManagerId).not()) {
+            throw PersistenceException.ResourceNotFound("센터 관리자(id: $centerManagerId)를 찾을 수 없습니다.")
+        }
+
+        refreshTokenService.delete(
+            userId = centerManagerId,
+        )
     }
 
 }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/facade/CenterAuthFacadeService.kt
@@ -60,7 +60,8 @@ class CenterAuthFacadeService(
     ): LoginResponse {
         val centerManager = centerManagerService.findByIdentifier(identifier)?.takeIf {
             PasswordEncryptor.matchPassword(password.value, it.password)
-        } ?: throw CenterException.ManagerNotFound()
+        }
+            ?: throw PersistenceException.ResourceNotFound("센터 관리자 identifier: $identifier 가 존재하지 않습니다.")
 
         return LoginResponse(
             accessToken = jwtTokenService.generateAccessToken(centerManager),

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
@@ -7,6 +7,7 @@ import com.swm.idle.api.auth.center.dto.RefreshLoginTokenResponse
 import com.swm.idle.api.auth.center.dto.RefreshTokenRequest
 import com.swm.idle.api.auth.center.dto.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.api.common.exception.ErrorResponse
+import com.swm.idle.api.common.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -45,6 +46,7 @@ interface CenterAuthApi {
         @RequestBody request: LoginRequest,
     ): LoginResponse
 
+    @Secured
     @Operation(summary = "센터 로그아웃 API")
     @PostMapping("/logout")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ApiException.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/ApiException.kt
@@ -10,9 +10,6 @@ sealed class ApiException(
     class InvalidParameter(message: String = "") :
         ApiException(codeNumber = 1, message = message)
 
-    class UnauthorizedRequest(message: String = "인증되지 않은 사용자입니다.") :
-        ApiException(codeNumber = 2, message = message)
-
     companion object {
         const val CODE_PREFIX = "API"
     }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/interceptor/JwtAuthorizationInterceptor.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/interceptor/JwtAuthorizationInterceptor.kt
@@ -1,9 +1,9 @@
 package com.swm.idle.api.common.security.interceptor
 
-import com.swm.idle.api.common.exception.ApiException
 import com.swm.idle.api.common.security.annotation.Secured
 import com.swm.idle.domain.user.vo.UserAuthentication
 import com.swm.idle.support.security.jwt.context.SecurityContextHolder
+import com.swm.idle.support.security.jwt.exception.SecurityException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Component
@@ -23,7 +23,7 @@ class JwtAuthorizationInterceptor : HandlerInterceptor {
         }
 
         if (hasSecuredAnnotation(handler) && isNotAuthenticated()) {
-            throw ApiException.UnauthorizedRequest()
+            throw SecurityException.UnAuthorizedRequest()
         }
 
         return super.preHandle(request, response, handler)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
@@ -59,4 +59,8 @@ class CenterManagerService(
         }
     }
 
+    fun existsById(centerManagerId: UUID): Boolean {
+        return centerManagerJpaRepository.existsById(centerManagerId)
+    }
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/exception/PersistenceException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/exception/PersistenceException.kt
@@ -1,7 +1,6 @@
 package com.swm.idle.domain.common.exception
 
 import com.swm.idle.support.common.exception.CustomException
-import com.swm.idle.support.security.jwt.exception.JwtException.Companion.CODE_PREFIX
 
 sealed class PersistenceException(
     codeNumber: Int,
@@ -10,5 +9,9 @@ sealed class PersistenceException(
 
     class ResourceNotFound(message: String = "") :
         PersistenceException(codeNumber = 1, message = message)
+
+    companion object {
+        const val CODE_PREFIX = "PERSISTENCE"
+    }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/util/UserAuthenticationProvider.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/util/UserAuthenticationProvider.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.domain.common.util
+
+import com.swm.idle.domain.user.vo.UserAuthentication
+import com.swm.idle.support.security.jwt.context.SecurityContextHolder
+import com.swm.idle.support.security.jwt.exception.SecurityException
+
+fun getUserAuthentication(): UserAuthentication {
+    val userAuthentication: UserAuthentication? =
+        SecurityContextHolder.getContext<UserAuthentication>()
+            ?.getAuthentication()
+
+    return userAuthentication ?: run {
+        throw SecurityException.UnAuthorizedRequest()
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/RefreshTokenService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/RefreshTokenService.kt
@@ -8,6 +8,7 @@ import com.swm.idle.domain.user.vo.UserTokenClaims
 import com.swm.idle.support.security.jwt.exception.JwtException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @Service
 class RefreshTokenService(
@@ -40,6 +41,10 @@ class RefreshTokenService(
         if (userRefreshTokenRepository.existsById(token.userId).not()) {
             throw JwtException.TokenNotFound()
         }
+    }
+
+    fun delete(userId: UUID) {
+        userRefreshTokenRepository.deleteById(userId)
     }
 
 }

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -31,7 +31,7 @@ spring:
       on-profile: local
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: true
     properties:
         hibernate.format_sql: true

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/exception/SecurityException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/jwt/exception/SecurityException.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.support.security.jwt.exception
+
+import com.swm.idle.support.common.exception.CustomException
+
+sealed class SecurityException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class UnAuthorizedRequest(message: String = "인증되지 않은 사용자입니다.") :
+        SecurityException(codeNumber = 1, message = message)
+
+    companion object {
+        const val CODE_PREFIX = "SECURITY"
+    }
+
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 로그아웃 API를 구현하였습니다.
* 에러 정책을 일부 수정하였습니다. 해당 내용에 대해서는 에러 문서상에 업데이트 해 두었습니다. 

## 2. ✏️ Documentation
## Backgrounds

센터 관리자의 로그아웃 요청 시, 로그아웃 API가 필요합니다.

## Goals & Non-Goals

### Goals

- 센터 관리자는 로그인 이후 요청 시 로그아웃 처리가 가능하도록 합니다.

## **Methodology & Design(Proposal)**

### API

- API
    - [🆕 Sample] POST /api/v1/auth/center/logout
        - request
            - method & path: `POST /api/v1/auth/center/logout`
        - response
            - 사용 가능한 아이디
                - status code: `204 No Content`
            - 비 로그인 상태에서 로그아웃을 시도하는 경우(권한이 없는 사용자)
                - status code: `401 UnAuthorized`

## Schedule

- [x]  설계 및 문서 작성
- [x]  센터 로그아웃 API
- [x]  dev 배포 및 QA
