### PR TITLE
[IDLE-000] docker-compose spring active profile 설정

### DIFF
--- a/idle-api/compose-dev.yaml
+++ b/idle-api/compose-dev.yaml
@@ -6,6 +6,7 @@ services:
       - mysql-volume:/var/lib/mysql
     environment:
       - VERSION=${VERSION:-latest}
+      - SPRING_PROFILES_ACTIVE=dev
     pull_policy: always
     env_file:
       - .env


### PR DESCRIPTION
## 1. 📄 Summary
* 개발 서버 배포 시, 기준 spring profile을 `dev`로 명시하였습니다.