### PR TITLE
[IDLE-69] 센터 관리자 회원 탈퇴 API

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/controller/CenterAuthController.kt
@@ -6,6 +6,7 @@ import com.swm.idle.api.auth.center.dto.LoginResponse
 import com.swm.idle.api.auth.center.dto.RefreshLoginTokenResponse
 import com.swm.idle.api.auth.center.dto.RefreshTokenRequest
 import com.swm.idle.api.auth.center.dto.ValidateBusinessRegistrationNumberResponse
+import com.swm.idle.api.auth.center.dto.WithdrawRequest
 import com.swm.idle.api.auth.center.facade.CenterAuthFacadeService
 import com.swm.idle.api.auth.center.spec.CenterAuthApi
 import com.swm.idle.domain.center.vo.BusinessRegistrationNumber
@@ -54,8 +55,11 @@ class CenterAuthController(
         return centerAuthFacadeService.refreshLoginToken(request.refreshToken)
     }
 
-    override fun withDraw() {
-        TODO("Not yet implemented")
+    override fun withdraw(request: WithdrawRequest) {
+        return centerAuthFacadeService.withDraw(
+            reason = request.reason,
+            password = Password(request.password)
+        )
     }
 
 }

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/dto/WithdrawRequest.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/dto/WithdrawRequest.kt
@@ -1,0 +1,14 @@
+package com.swm.idle.api.auth.center.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "Center Withdraw Request API",
+    description = "센터 회원 탈퇴 API"
+)
+data class WithdrawRequest(
+    @Schema(description = "회원 탈퇴 사유")
+    val reason: String,
+    @Schema(description = "회원 비밀번호")
+    val password: String,
+)

--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/center/spec/CenterAuthApi.kt
@@ -6,6 +6,7 @@ import com.swm.idle.api.auth.center.dto.LoginResponse
 import com.swm.idle.api.auth.center.dto.RefreshLoginTokenResponse
 import com.swm.idle.api.auth.center.dto.RefreshTokenRequest
 import com.swm.idle.api.auth.center.dto.ValidateBusinessRegistrationNumberResponse
+import com.swm.idle.api.auth.center.dto.WithdrawRequest
 import com.swm.idle.api.common.exception.ErrorResponse
 import com.swm.idle.api.common.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
@@ -59,10 +60,13 @@ interface CenterAuthApi {
         @RequestBody request: RefreshTokenRequest,
     ): RefreshLoginTokenResponse
 
+    @Secured
     @Operation(summary = "센터 회원 탈퇴 API")
     @PostMapping("/withdraw")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun withDraw()
+    fun withdraw(
+        @RequestBody request: WithdrawRequest,
+    )
 
     @Operation(summary = "아이디 중복 체크 API")
     @GetMapping("/validation/{identifier}")

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/CustomExceptionHandler.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/exception/CustomExceptionHandler.kt
@@ -1,7 +1,8 @@
 package com.swm.idle.api.common.exception
 
 import com.swm.idle.support.common.exception.CustomException
-import com.swm.idle.support.security.jwt.exception.JwtException
+import com.swm.idle.support.security.exception.JwtException
+import com.swm.idle.support.security.exception.SecurityException
 import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
@@ -28,6 +29,15 @@ class CustomExceptionHandler {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     @ExceptionHandler(JwtException::class)
     fun handlerJwtException(exception: JwtException): ErrorResponse {
+        return ErrorResponse(
+            code = exception.code,
+            message = exception.message,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(SecurityException::class)
+    fun handlerSecurityException(exception: SecurityException): ErrorResponse {
         return ErrorResponse(
             code = exception.code,
             message = exception.message,

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/context/UserSecurityContext.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/context/UserSecurityContext.kt
@@ -1,7 +1,7 @@
 package com.swm.idle.api.common.security.context
 
 import com.swm.idle.domain.user.vo.UserAuthentication
-import com.swm.idle.support.security.jwt.context.SecurityContext
+import com.swm.idle.support.security.context.SecurityContext
 
 class UserSecurityContext(
     private var userAuthentication: UserAuthentication,

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/filter/JwtAuthenticationFilter.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/filter/JwtAuthenticationFilter.kt
@@ -3,7 +3,7 @@ package com.swm.idle.api.common.security.filter
 import com.swm.idle.api.common.security.context.UserSecurityContext
 import com.swm.idle.domain.user.util.JwtTokenService
 import com.swm.idle.domain.user.vo.UserAuthentication
-import com.swm.idle.support.security.jwt.context.SecurityContextHolder
+import com.swm.idle.support.security.context.SecurityContextHolder
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/idle-api/src/main/kotlin/com/swm/idle/api/common/security/interceptor/JwtAuthorizationInterceptor.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/common/security/interceptor/JwtAuthorizationInterceptor.kt
@@ -2,8 +2,8 @@ package com.swm.idle.api.common.security.interceptor
 
 import com.swm.idle.api.common.security.annotation.Secured
 import com.swm.idle.domain.user.vo.UserAuthentication
-import com.swm.idle.support.security.jwt.context.SecurityContextHolder
-import com.swm.idle.support.security.jwt.exception.SecurityException
+import com.swm.idle.support.security.context.SecurityContextHolder
+import com.swm.idle.support.security.exception.SecurityException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Component

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/exception/CenterException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/exception/CenterException.kt
@@ -7,11 +7,8 @@ sealed class CenterException(
     message: String,
 ) : CustomException(CODE_PREFIX, codeNumber, message) {
 
-    class ManagerNotFound(message: String = "존재하지 않는 센터 관리자 회원입니다.") :
-        CenterException(codeNumber = 1, message = message)
-
     class DuplicateIdentifier(message: String = "이미 존재하는 ID입니다.") :
-        CenterException(codeNumber = 2, message = message)
+        CenterException(codeNumber = 1, message = message)
 
     companion object {
         const val CODE_PREFIX = "CENTER"

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/center/service/CenterManagerService.kt
@@ -63,4 +63,9 @@ class CenterManagerService(
         return centerManagerJpaRepository.existsById(centerManagerId)
     }
 
+    @Transactional
+    fun delete(centerManagerId: UUID) {
+        centerManagerJpaRepository.deleteById(centerManagerId)
+    }
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/util/UserAuthenticationProvider.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/util/UserAuthenticationProvider.kt
@@ -1,8 +1,8 @@
 package com.swm.idle.domain.common.util
 
 import com.swm.idle.domain.user.vo.UserAuthentication
-import com.swm.idle.support.security.jwt.context.SecurityContextHolder
-import com.swm.idle.support.security.jwt.exception.SecurityException
+import com.swm.idle.support.security.context.SecurityContextHolder
+import com.swm.idle.support.security.exception.SecurityException
 
 fun getUserAuthentication(): UserAuthentication {
     val userAuthentication: UserAuthentication? =

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserRoleType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserRoleType.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.domain.user.common.enum
+
+enum class UserRoleType {
+    CENTER_MANAGER,
+    CARER;
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/entity/DeletedUserInfo.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/entity/DeletedUserInfo.kt
@@ -1,0 +1,42 @@
+package com.swm.idle.domain.user.entity
+
+import com.swm.idle.domain.user.common.enum.UserRoleType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "deleted_user_info")
+class DeletedUserInfo(
+    id: UUID,
+    phoneNumber: String,
+    role: UserRoleType,
+    reason: String,
+    deletedAt: LocalDateTime,
+) {
+
+    @Id
+    @Column(nullable = false)
+    var id: UUID = id
+        private set
+
+    @Column(nullable = false)
+    var phoneNumber: String = phoneNumber
+        private set
+
+    @Column(nullable = false)
+    var role: UserRoleType = role
+        private set
+
+    @Column(nullable = false)
+    var reason: String = reason
+        private set
+
+    @Column(nullable = false)
+    var deletedAt: LocalDateTime = deletedAt
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/repository/DeletedUserInfoRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/repository/DeletedUserInfoRepository.kt
@@ -1,0 +1,8 @@
+package com.swm.idle.domain.user.repository
+
+import com.swm.idle.domain.user.entity.DeletedUserInfo
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface DeletedUserInfoRepository : JpaRepository<DeletedUserInfo, UUID> {
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/DeletedUserInfoService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/DeletedUserInfoService.kt
@@ -1,0 +1,35 @@
+package com.swm.idle.domain.user.service
+
+import com.swm.idle.domain.sms.vo.PhoneNumber
+import com.swm.idle.domain.user.common.enum.UserRoleType
+import com.swm.idle.domain.user.entity.DeletedUserInfo
+import com.swm.idle.domain.user.repository.DeletedUserInfoRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.*
+
+@Service
+class DeletedUserInfoService(
+    private val deletedUserInfoRepository: DeletedUserInfoRepository,
+) {
+
+    @Transactional
+    fun save(
+        id: UUID,
+        phoneNumber: PhoneNumber,
+        role: UserRoleType,
+        reason: String,
+    ) {
+        deletedUserInfoRepository.save(
+            DeletedUserInfo(
+                id = id,
+                phoneNumber = phoneNumber.value,
+                role = role,
+                reason = reason,
+                deletedAt = LocalDateTime.now(),
+            )
+        )
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/RefreshTokenService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/service/RefreshTokenService.kt
@@ -5,7 +5,7 @@ import com.swm.idle.domain.user.repository.UserRefreshTokenRepository
 import com.swm.idle.domain.user.util.JwtTokenService
 import com.swm.idle.domain.user.vo.JwtTokens
 import com.swm.idle.domain.user.vo.UserTokenClaims
-import com.swm.idle.support.security.jwt.exception.JwtException
+import com.swm.idle.support.security.exception.JwtException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -43,6 +43,7 @@ class RefreshTokenService(
         }
     }
 
+    @Transactional
     fun delete(userId: UUID) {
         userRefreshTokenRepository.deleteById(userId)
     }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/util/JwtTokenService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/util/JwtTokenService.kt
@@ -7,8 +7,8 @@ import com.swm.idle.domain.user.common.enum.UserTokenType
 import com.swm.idle.domain.user.entity.UserRefreshTokenRedisHash
 import com.swm.idle.domain.user.repository.UserRefreshTokenRepository
 import com.swm.idle.domain.user.vo.UserTokenClaims
-import com.swm.idle.support.security.jwt.util.JwtTokenProvider
-import com.swm.idle.support.security.jwt.vo.JwtClaims
+import com.swm.idle.support.security.util.JwtTokenProvider
+import com.swm.idle.support.security.vo.JwtClaims
 import org.springframework.stereotype.Service
 import java.time.Instant
 import java.util.*

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/UserAuthentication.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/vo/UserAuthentication.kt
@@ -1,7 +1,7 @@
 package com.swm.idle.domain.user.vo
 
 import com.swm.idle.domain.sms.vo.PhoneNumber
-import com.swm.idle.support.security.jwt.common.Authentication
+import com.swm.idle.support.security.common.Authentication
 import java.util.*
 
 data class UserAuthentication(

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/common/Authentication.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/common/Authentication.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.security.jwt.common
+package com.swm.idle.support.security.common
 
 import java.security.Principal
 

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/context/SecurityContext.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/context/SecurityContext.kt
@@ -1,6 +1,6 @@
-package com.swm.idle.support.security.jwt.context
+package com.swm.idle.support.security.context
 
-import com.swm.idle.support.security.jwt.common.Authentication
+import com.swm.idle.support.security.common.Authentication
 
 interface SecurityContext<T : Authentication> {
 

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/context/SecurityContextHolder.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/context/SecurityContextHolder.kt
@@ -1,6 +1,6 @@
-package com.swm.idle.support.security.jwt.context
+package com.swm.idle.support.security.context
 
-import com.swm.idle.support.security.jwt.common.Authentication
+import com.swm.idle.support.security.common.Authentication
 
 object SecurityContextHolder {
 

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/JwtException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/JwtException.kt
@@ -1,21 +1,23 @@
-package com.swm.idle.support.security.jwt.exception
+package com.swm.idle.support.security.exception
+
+import com.swm.idle.support.common.exception.CustomException
 
 sealed class JwtException(
-    val code: String,
-    override val message: String,
-) : RuntimeException(message) {
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
 
     class TokenDecodeException(message: String = "유효하지 않은 토큰입니다.") :
-        JwtException(code = "JWT-001", message = message)
+        JwtException(codeNumber = 1, message = message)
 
     class TokenNotValid(message: String = "유효하지 않은 토큰입니다.") :
-        JwtException(code = "JWT-002", message = message)
+        JwtException(codeNumber = 2, message = message)
 
     class TokenExpired(message: String = "토큰이 만료되었습니다.") :
-        JwtException(code = "JWT-003", message = message)
+        JwtException(codeNumber = 3, message = message)
 
     class TokenNotFound(message: String = "토큰을 찾을 수 없습니다.") :
-        JwtException(code = "JWT-004", message = message)
+        JwtException(codeNumber = 4, message = message)
 
     companion object {
         const val CODE_PREFIX = "JWT"

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/SecurityException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/SecurityException.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.security.jwt.exception
+package com.swm.idle.support.security.exception
 
 import com.swm.idle.support.common.exception.CustomException
 

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/SecurityException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/SecurityException.kt
@@ -10,6 +10,12 @@ sealed class SecurityException(
     class UnAuthorizedRequest(message: String = "인증되지 않은 사용자입니다.") :
         SecurityException(codeNumber = 1, message = message)
 
+    class InvalidLoginRequest(message: String = "올바르지 않은 아이디 또는 비밀번호입니다.") :
+        SecurityException(codeNumber = 2, message = message)
+
+    class InvalidPassword(message: String = "올바르지 않은 비밀번호입니다.") :
+        SecurityException(codeNumber = 3, message = message)
+
     companion object {
         const val CODE_PREFIX = "SECURITY"
     }

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/util/JwtTokenProvider.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/util/JwtTokenProvider.kt
@@ -1,11 +1,11 @@
-package com.swm.idle.support.security.jwt.util
+package com.swm.idle.support.security.util
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.JWTDecodeException
 import com.auth0.jwt.exceptions.TokenExpiredException
-import com.swm.idle.support.security.jwt.exception.JwtException
-import com.swm.idle.support.security.jwt.vo.JwtClaims
+import com.swm.idle.support.security.exception.JwtException
+import com.swm.idle.support.security.vo.JwtClaims
 
 object JwtTokenProvider {
 

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/vo/JwtClaims.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/vo/JwtClaims.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.security.jwt.vo
+package com.swm.idle.support.security.vo
 
 import com.auth0.jwt.interfaces.DecodedJWT
 import java.time.Instant

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/vo/JwtClaimsBuilder.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/vo/JwtClaimsBuilder.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.security.jwt.vo
+package com.swm.idle.support.security.vo
 
 import java.time.Instant
 import java.util.*


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 관리자 회원 탈퇴 API 구현
* Security Exception 401 error 발생을 위한 별도의 핸들러 구현
* Security 모듈 내 디렉토리 구조 변경(jwt 디렉토리 삭제)

## 2. 💻 Documentation
## Background

- AOS 및 IOS의 앱 심사를 위해, 회원 탈퇴 API가 필요합니다.
- 탈퇴를 결심한 유저들에 대해 탈퇴 사유를 입력받아 타겟층 및 유저 분석에 지표로 사용할 수 있습니다.

## Goals & Non-Goals

### Goals

- 센터 관리자는 가입 후 서비스 이용을 더 이상 희망하지 않을 때, 회원 탈퇴가 가능해야 합니다.
- 탈퇴는 sort delete를 통해 탈퇴한 회원의 정보와 이력을 별도로 관리할 수 있어야 합니다.

## Policy

- 회원 탈퇴 사유를 아래와 같이 받으면 어떨까요?
    - 디자이너님께서 전달해 주신 레퍼런스 자료를 바탕으로 하기로 결정했습니다.
    
    ![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/fc3a76f7-5128-4bde-97c2-162ff3c9fb9a/39a270e6-d42b-430e-9696-381d58366fda/Untitled.png)
    

## **Methodology & Design(Proposal)**

### API

- API
    - [🆕 Sample] POST /api/v1/auth/center/withdraw
        - request
            - method & path: `POST /api/v1/auth/center/withdraw`
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
            - 인증되지 않은 사용자가 탈퇴를 시도하는 경우(로그인 필요)
                - status code: `401 UnAuthorized`
            - 탈퇴 시, 잘못된 비밀번호를 입력한 경우
                - status code: `401 UnAuthorized`

## Schedule
- [x]  설계 및 문서 작성(진행 중)
- [x]  회원 탈퇴 정책 논의
- [x]  센터 관리자 회원가입 API 작성
- [x]  dev 배포
