### PR TITLE
[IDLE-000] 전화번호 인증 반복 시도 시, 미사용 인증 번호 삭제 로직 추가

### DIFF
--- a/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/facade/AuthFacadeService.kt
+++ b/idle-api/src/main/kotlin/com/swm/idle/api/auth/core/facade/AuthFacadeService.kt
@@ -19,6 +19,11 @@ class AuthFacadeService(
 
     @Transactional
     fun sendVerificationMessage(phoneNumber: PhoneNumber) {
+
+        smsVerificationService.findByPhoneNumber(phoneNumber)?.let {
+            smsVerificationService.deleteByPhoneNumber(phoneNumber)
+        }
+
         CoroutineScope(Dispatchers.IO).launch {
             smsService.sendVerificationMessage(
                 phoneNumber = phoneNumber

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/sms/service/SmsVerificationService.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/sms/service/SmsVerificationService.kt
@@ -34,4 +34,8 @@ class SmsVerificationService(
             .orElse(null)
     }
 
+    fun deleteByPhoneNumber(phoneNumber: PhoneNumber) {
+        smsVerificationNumberRedisRepository.deleteById(phoneNumber.value)
+    }
+
 }


### PR DESCRIPTION
## 1. 📄 Summary
* 전화번호 인증을 반복적으로 시도할 경우, 이전 인증번호는 더 이상 사용할 수 없으므로 삭제 처리 되어야 합니다.
