### PR TITLE
[IDLE-189] S3 presigned URL 발급 API

### DIFF
--- a/.github/workflows/sonar_cloud.yaml
+++ b/.github/workflows/sonar_cloud.yaml
@@ -43,4 +43,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
         run: ./gradlew clean test jacocoTestReport sonar --info

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ kotest-extensions-testcontainers = { group = "io.kotest.extensions", name = "kot
 testcontainers-junit-jupiter = { group = "org.testcontainers", name = "junit-jupiter", version.ref = "testcontainers" }
 
 spring-cloud-starter-openfeign = { group = "org.springframework.cloud", name = "spring-cloud-starter-openfeign", version.ref = "spring-cloud-openfeign" }
-spring-cloud-aws-s3 = { group = "io.awspring.cloud", name = "spring-cloud-aws-s3", version.ref = "spring-cloud-aws-s3" }
+spring-cloud-starter-aws-s3 = { group = "io.awspring.cloud", name = "spring-cloud-aws-starter-s3", version.ref = "spring-cloud-aws-s3" }
 
 springdoc-openapi-starter-webmvc-ui = { group = "org.springdoc", name = "springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
 net-nurigo-sdk = { group = "net.nurigo", name = "sdk", version.ref = "cool-sms"}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -10,15 +10,15 @@ import com.swm.idle.domain.user.center.exception.CenterException
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.domain.user.center.vo.Identifier
 import com.swm.idle.domain.user.center.vo.Password
-import com.swm.idle.domain.user.common.enum.UserRoleType
+import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.infrastructure.client.businessregistration.exception.BusinessRegistrationException
 import com.swm.idle.infrastructure.client.businessregistration.service.BusinessRegistrationNumberValidationService
 import com.swm.idle.support.common.encrypt.PasswordEncryptor
-import com.swm.idle.support.mapper.auth.center.LoginResponse
-import com.swm.idle.support.mapper.auth.center.RefreshLoginTokenResponse
-import com.swm.idle.support.mapper.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.security.exception.SecurityException
+import com.swm.idle.support.transfer.auth.center.LoginResponse
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
+import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import org.springframework.stereotype.Service
 
 @Service
@@ -119,7 +119,7 @@ class CenterAuthFacadeService(
         deletedUserInfoService.save(
             id = centerManagerId,
             phoneNumber = PhoneNumber(centerManager.phoneNumber),
-            role = UserRoleType.CENTER_MANAGER,
+            role = UserType.CENTER,
             reason = reason,
         )
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/domain/DeletedUserInfoService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/domain/DeletedUserInfoService.kt
@@ -1,7 +1,7 @@
 package com.swm.idle.application.user.common.service.domain
 
 import com.swm.idle.domain.user.common.entity.jpa.DeletedUserInfo
-import com.swm.idle.domain.user.common.enum.UserRoleType
+import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.domain.user.common.repository.jpa.DeletedUserInfoRepository
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import org.springframework.stereotype.Service
@@ -18,7 +18,7 @@ class DeletedUserInfoService(
     fun save(
         id: UUID,
         phoneNumber: PhoneNumber,
-        role: UserRoleType,
+        role: UserType,
         reason: String,
     ) {
         deletedUserInfoRepository.save(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/UserFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/UserFacadeService.kt
@@ -1,0 +1,34 @@
+package com.swm.idle.application.user.common.service.facade
+
+import com.swm.idle.domain.user.common.enum.ImageFileExtension
+import com.swm.idle.domain.user.common.enum.UserType
+import com.swm.idle.infrastructure.aws.s3.service.S3ImageService
+import com.swm.idle.support.common.uuid.UuidCreator
+import com.swm.idle.support.transfer.user.UserProfileImageUploadUrlResponse
+import org.springframework.stereotype.Service
+
+@Service
+class UserFacadeService(
+    private val s3ImageService: S3ImageService,
+) {
+
+    fun getProfileImageUploadUrl(
+        userType: UserType,
+        imageFileExtension: ImageFileExtension,
+    ): UserProfileImageUploadUrlResponse {
+        val imageId = UuidCreator.create()
+
+        val uploadUrl = s3ImageService.getImageUploadUrl(
+            userType = userType,
+            imageId = imageId,
+            imageFileExtension = imageFileExtension,
+        )
+
+        return UserProfileImageUploadUrlResponse(
+            imageId = imageId,
+            extension = imageFileExtension,
+            uploadUrl = uploadUrl,
+        )
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/vo/UserPhoneVerificationNumber.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/vo/UserPhoneVerificationNumber.kt
@@ -4,7 +4,9 @@ package com.swm.idle.application.user.vo
 value class UserPhoneVerificationNumber(val value: String) {
 
     init {
-        require(value.length == 6)
+        require(value.length == 6) {
+            "올바르지 않은 형식의 인증번호입니다."
+        }
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/entity/jpa/DeletedUserInfo.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/entity/jpa/DeletedUserInfo.kt
@@ -1,6 +1,6 @@
 package com.swm.idle.domain.user.common.entity.jpa
 
-import com.swm.idle.domain.user.common.enum.UserRoleType
+import com.swm.idle.domain.user.common.enum.UserType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -15,7 +15,7 @@ import java.util.*
 class DeletedUserInfo(
     id: UUID,
     phoneNumber: String,
-    role: UserRoleType,
+    role: UserType,
     reason: String,
     deletedAt: LocalDateTime,
 ) {
@@ -31,7 +31,7 @@ class DeletedUserInfo(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    var role: UserRoleType = role
+    var role: UserType = role
         private set
 
     @Column(nullable = false)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/ImageFileExtension.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/ImageFileExtension.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.domain.user.common.enum
+
+enum class ImageFileExtension(val value: String) {
+    JPG("jpg"),
+    PNG("png"),
+    JPEG("jpeg"),
+    GIF("gif"),
+    SVG("svg"),
+    WEBP("webp"),
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserRoleType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserRoleType.kt
@@ -1,6 +1,0 @@
-package com.swm.idle.domain.user.common.enum
-
-enum class UserRoleType {
-    CENTER_MANAGER,
-    CARER;
-}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserType.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.domain.user.common.enum
+
+enum class UserType(val value: String) {
+    CENTER("center"),
+    CARER("carer");
+}

--- a/idle-infrastructure/aws/build.gradle.kts
+++ b/idle-infrastructure/aws/build.gradle.kts
@@ -7,6 +7,7 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation(project(":idle-domain"))
     implementation(libs.spring.boot.core)
-    implementation(libs.spring.cloud.aws.s3)
+    implementation(libs.spring.cloud.starter.aws.s3)
 }

--- a/idle-infrastructure/aws/src/main/kotlin/com/swm/idle/infrastructure/aws/s3/service/S3ImageService.kt
+++ b/idle-infrastructure/aws/src/main/kotlin/com/swm/idle/infrastructure/aws/s3/service/S3ImageService.kt
@@ -1,0 +1,60 @@
+package com.swm.idle.infrastructure.aws.s3.service
+
+import com.swm.idle.domain.user.common.enum.ImageFileExtension
+import com.swm.idle.domain.user.common.enum.UserType
+import com.swm.idle.infrastructure.aws.s3.properties.S3BucketProperties
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
+import java.net.URL
+import java.time.Duration
+import java.util.*
+
+@Service
+class S3ImageService(
+    private val s3Client: S3Client,
+    private val s3Presigner: S3Presigner,
+    private val s3BucketProperties: S3BucketProperties,
+) {
+
+    fun getImageUploadUrl(
+        userType: UserType,
+        imageId: UUID,
+        imageFileExtension: ImageFileExtension,
+    ): URL {
+        val objectRequest = PutObjectRequest.builder()
+            .bucket(s3BucketProperties.userProfileImage.bucketName)
+            .key(getKey(userType, imageId, imageFileExtension))
+            .build()
+
+        val signatureDuration =
+            getDuration(s3BucketProperties.userProfileImage.preSignedUrlExpireMinutes)
+
+        val preSignRequest = PutObjectPresignRequest
+            .builder()
+            .signatureDuration(signatureDuration)
+            .putObjectRequest(objectRequest)
+            .build()
+
+        return s3Presigner
+            .presignPutObject(preSignRequest)
+            .url()
+            .toString()
+            .let { URL(it) }
+    }
+
+    fun getKey(
+        userType: UserType,
+        imageId: UUID,
+        imageFileExtension: ImageFileExtension,
+    ): String {
+        return "${s3BucketProperties.userProfileImage.keyPrefix}${userType.value}/${imageId}.${imageFileExtension.value}"
+    }
+
+    fun getDuration(expireMinutes: Long): Duration {
+        return Duration.ofMinutes(expireMinutes)
+    }
+
+}

--- a/idle-infrastructure/aws/src/main/resources/application-aws.yaml
+++ b/idle-infrastructure/aws/src/main/resources/application-aws.yaml
@@ -1,9 +1,9 @@
 spring:
   cloud:
     aws:
-      iam:
-        access-key: ${AWS_ACCESS_KEY_ID}
-        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      credentials:
+        access-key: ${AWS_S3_ACCESS_KEY}
+        secret-key: ${AWS_S3_SECRET_KEY}
       region:
         static: ${AWS_REGION:ap-northeast-2}
 aws-bucket:

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
@@ -2,13 +2,13 @@ package com.swm.idle.presentation.auth.center.api
 
 import com.swm.idle.presentation.common.exception.ErrorResponse
 import com.swm.idle.presentation.common.security.annotation.Secured
-import com.swm.idle.support.mapper.auth.center.JoinRequest
-import com.swm.idle.support.mapper.auth.center.LoginRequest
-import com.swm.idle.support.mapper.auth.center.LoginResponse
-import com.swm.idle.support.mapper.auth.center.RefreshLoginTokenResponse
-import com.swm.idle.support.mapper.auth.center.RefreshTokenRequest
-import com.swm.idle.support.mapper.auth.center.ValidateBusinessRegistrationNumberResponse
-import com.swm.idle.support.mapper.auth.center.WithdrawRequest
+import com.swm.idle.support.transfer.auth.center.JoinRequest
+import com.swm.idle.support.transfer.auth.center.LoginRequest
+import com.swm.idle.support.transfer.auth.center.LoginResponse
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
+import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
+import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
+import com.swm.idle.support.transfer.auth.center.WithdrawRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
@@ -6,13 +6,13 @@ import com.swm.idle.domain.user.center.vo.Identifier
 import com.swm.idle.domain.user.center.vo.Password
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.center.api.CenterAuthApi
-import com.swm.idle.support.mapper.auth.center.JoinRequest
-import com.swm.idle.support.mapper.auth.center.LoginRequest
-import com.swm.idle.support.mapper.auth.center.LoginResponse
-import com.swm.idle.support.mapper.auth.center.RefreshLoginTokenResponse
-import com.swm.idle.support.mapper.auth.center.RefreshTokenRequest
-import com.swm.idle.support.mapper.auth.center.ValidateBusinessRegistrationNumberResponse
-import com.swm.idle.support.mapper.auth.center.WithdrawRequest
+import com.swm.idle.support.transfer.auth.center.JoinRequest
+import com.swm.idle.support.transfer.auth.center.LoginRequest
+import com.swm.idle.support.transfer.auth.center.LoginResponse
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
+import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
+import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
+import com.swm.idle.support.transfer.auth.center.WithdrawRequest
 import org.springframework.web.bind.annotation.RestController
 
 @RestController

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/api/AuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/api/AuthApi.kt
@@ -1,8 +1,8 @@
 package com.swm.idle.presentation.auth.common.api
 
 import com.swm.idle.presentation.common.exception.ErrorResponse
-import com.swm.idle.support.mapper.auth.common.ConfirmSmsVerificationRequest
-import com.swm.idle.support.mapper.auth.common.SendSmsVerificationRequest
+import com.swm.idle.support.transfer.auth.common.ConfirmSmsVerificationRequest
+import com.swm.idle.support.transfer.auth.common.SendSmsVerificationRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/controller/AuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/controller/AuthController.kt
@@ -4,8 +4,8 @@ import com.swm.idle.application.user.common.service.facade.AuthFacadeService
 import com.swm.idle.application.user.vo.UserPhoneVerificationNumber
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.common.api.AuthApi
-import com.swm.idle.support.mapper.auth.common.ConfirmSmsVerificationRequest
-import com.swm.idle.support.mapper.auth.common.SendSmsVerificationRequest
+import com.swm.idle.support.transfer.auth.common.ConfirmSmsVerificationRequest
+import com.swm.idle.support.transfer.auth.common.SendSmsVerificationRequest
 import org.springframework.web.bind.annotation.RestController
 
 @RestController

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/api/UserApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/api/UserApi.kt
@@ -1,0 +1,31 @@
+package com.swm.idle.presentation.user.api
+
+import com.swm.idle.domain.user.common.enum.ImageFileExtension
+import com.swm.idle.domain.user.common.enum.UserType
+import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.user.UserProfileImageUploadUrlResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@Tag(name = "User", description = "User API")
+@RequestMapping("/api/v1/users", produces = ["application/json"])
+interface UserApi {
+
+    @Secured
+    @Operation(summary = "프로필 이미지 업로드 URL 조회")
+    @GetMapping("/{user-type}/my/profile-image-upload-url")
+    @ResponseStatus(HttpStatus.OK)
+    fun getProfileImageUploadUrl(
+        @PathVariable("user-type")
+        userType: UserType,
+        @Parameter(required = true)
+        imageFileExtension: ImageFileExtension,
+    ): UserProfileImageUploadUrlResponse
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/controller/UserController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/controller/UserController.kt
@@ -1,0 +1,25 @@
+package com.swm.idle.presentation.user.controller
+
+import com.swm.idle.application.user.common.service.facade.UserFacadeService
+import com.swm.idle.domain.user.common.enum.ImageFileExtension
+import com.swm.idle.domain.user.common.enum.UserType
+import com.swm.idle.presentation.user.api.UserApi
+import com.swm.idle.support.transfer.user.UserProfileImageUploadUrlResponse
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class UserController(
+    private val userFacadeService: UserFacadeService,
+) : UserApi {
+
+    override fun getProfileImageUploadUrl(
+        userType: UserType,
+        imageFileExtension: ImageFileExtension,
+    ): UserProfileImageUploadUrlResponse {
+        return userFacadeService.getProfileImageUploadUrl(
+            userType = userType,
+            imageFileExtension = imageFileExtension,
+        )
+    }
+
+}

--- a/idle-support/transfer/build.gradle.kts
+++ b/idle-support/transfer/build.gradle.kts
@@ -7,5 +7,6 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation(project(":idle-domain"))
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/JoinRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/JoinRequest.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.center
+package com.swm.idle.support.transfer.auth.center
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/LoginRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/LoginRequest.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.center
+package com.swm.idle.support.transfer.auth.center
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/LoginResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/LoginResponse.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.center
+package com.swm.idle.support.transfer.auth.center
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/RefreshLoginTokenResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/RefreshLoginTokenResponse.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.center
+package com.swm.idle.support.transfer.auth.center
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/RefreshTokenRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/RefreshTokenRequest.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.center
+package com.swm.idle.support.transfer.auth.center
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/ValidateBusinessRegistrationNumberResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/ValidateBusinessRegistrationNumberResponse.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.center
+package com.swm.idle.support.transfer.auth.center
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/WithdrawRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/WithdrawRequest.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.center
+package com.swm.idle.support.transfer.auth.center
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/common/ConfirmSmsVerificationRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/common/ConfirmSmsVerificationRequest.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.common
+package com.swm.idle.support.transfer.auth.common
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/common/SendSmsVerificationRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/common/SendSmsVerificationRequest.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.mapper.auth.common
+package com.swm.idle.support.transfer.auth.common
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/UserProfileImageUploadUrlResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/UserProfileImageUploadUrlResponse.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.support.transfer.user
+
+import com.swm.idle.domain.user.common.enum.ImageFileExtension
+import io.swagger.v3.oas.annotations.media.Schema
+import java.net.URL
+import java.util.*
+
+@Schema(
+    name = "UserProfileImageUploadUrlResponse",
+    description = "유저 프로필 이미지 업로드 Url 응답"
+)
+data class UserProfileImageUploadUrlResponse(
+    @Schema(description = "이미지 ID", example = "8bdf126a-2d71-4a1a-9d90-6b5e5db4e0c8")
+    val imageId: UUID,
+    @Schema(description = "이미지 파일 확장자", example = "jpg")
+    val extension: ImageFileExtension,
+    @Schema(description = "이미지 업로드 Url")
+    val uploadUrl: URL,
+)


### PR DESCRIPTION
## Background

- 요양 보호사 및 센터의 프로필 내 이미지 업로드 및 조회 기능이 필요합니다.

## Goals & Non-Goals

### Goals

- pre-signed url을 이용해 서버에 불필요한 이미지 파일을 전달하는 task를 생략하여 더 빠른 업로드 및 response가 가능하도록 합니다.

## **Methodology & Design(Proposal)**

### API

- 프로필 이미지 업로드 url 조회
    - GET /api/v1/users/{user-type}/my/profile-image/upload-url?imageFileExtension={image-file-extension}
        - request
            - method & path: `GET /api/v1/users/{user-type}/my/profile-image/upload-url?imageFileExtension="{image-file-extension}"`
                - user-type : [”center”, “carer”]
                - image-file-extension : [”jpg”, “jpeg”, “png”, “svg”, “gif”, “webp”]
        - response
            - 프로필 이미지 pre-signed url 생성 성공
                - status code: `200 OK`
                - body