### PR TITLE
[IDLE-215] 프로필 사진 등록 callback API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterService.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.application.user.center.service.domain
+
+import com.swm.idle.domain.user.center.entity.jpa.Center
+import com.swm.idle.domain.user.center.repository.CenterJpaRepository
+import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
+import org.springframework.stereotype.Service
+
+@Service
+class CenterService(
+    private val centerJpaRepository: CenterJpaRepository,
+) {
+
+    fun findByBusinessRegistrationNumber(businessRegistrationNumber: BusinessRegistrationNumber): Center? {
+        return centerJpaRepository.findByBusinessRegistrationNumber(businessRegistrationNumber.value)
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/UserFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/UserFacadeService.kt
@@ -1,15 +1,24 @@
 package com.swm.idle.application.user.common.service.facade
 
+import com.swm.idle.application.common.security.getUserAuthentication
+import com.swm.idle.application.user.center.service.domain.CenterManagerService
+import com.swm.idle.application.user.center.service.domain.CenterService
+import com.swm.idle.domain.user.center.exception.CenterException
+import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.domain.user.common.enum.ImageFileExtension
 import com.swm.idle.domain.user.common.enum.UserType
+import com.swm.idle.domain.user.common.exception.UserException
 import com.swm.idle.infrastructure.aws.s3.service.S3ImageService
 import com.swm.idle.support.common.uuid.UuidCreator
 import com.swm.idle.support.transfer.user.UserProfileImageUploadUrlResponse
 import org.springframework.stereotype.Service
+import java.util.*
 
 @Service
 class UserFacadeService(
     private val s3ImageService: S3ImageService,
+    private val centerManagerService: CenterManagerService,
+    private val centerService: CenterService,
 ) {
 
     fun getProfileImageUploadUrl(
@@ -26,9 +35,55 @@ class UserFacadeService(
 
         return UserProfileImageUploadUrlResponse(
             imageId = imageId,
-            extension = imageFileExtension,
+            imageFileExtension = imageFileExtension,
             uploadUrl = uploadUrl,
         )
+    }
+
+    fun createImageUploadCallback(
+        userType: UserType,
+        imageId: UUID,
+        imageFileExtension: ImageFileExtension,
+    ) {
+        try {
+            s3ImageService.findByIdAndExtension(
+                userType = userType,
+                imageId = imageId,
+                imageFileExtension = imageFileExtension,
+            )
+        } catch (e: Exception) {
+            UserException.ImageUploadNotCompleted()
+        }
+
+        if (userType == UserType.CENTER) {
+            updateCenterImageURL(
+                userType = userType,
+                imageId = imageId,
+                imageFileExtension = imageFileExtension,
+            )
+        }
+
+        // TODO("요양 보호사 프로필 업로드 로직 구현")
+    }
+
+    private fun updateCenterImageURL(
+        userType: UserType,
+        imageId: UUID,
+        imageFileExtension: ImageFileExtension,
+    ) {
+        val centerManager = getUserAuthentication().userId
+            .let { centerManagerService.getById(it) }
+
+        centerService.findByBusinessRegistrationNumber(
+            BusinessRegistrationNumber(centerManager.centerBusinessRegistrationNumber)
+        )?.also {
+            val profileImageUrl = s3ImageService.findByIdAndExtension(
+                userType = userType,
+                imageId = imageId,
+                imageFileExtension = imageFileExtension,
+            )
+            it.updateProfileImageUrl(profileImageUrl.toString())
+        } ?: throw CenterException.NotFoundException()
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
@@ -1,0 +1,80 @@
+package com.swm.idle.domain.user.center.entity.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "center")
+class Center(
+    id: UUID,
+    centerName: String,
+    ownerName: String,
+    businessRegistrationNumber: String,
+    officeNumber: String,
+    roadNameAddress: String,
+    lotNumberAddress: String,
+    detailedAddress: String,
+    profileImageUrl: String,
+    longitude: String,
+    latitude: String,
+    introduce: String?,
+) {
+
+    @Id
+    @Column(nullable = false)
+    var id: UUID = id
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var centerName: String = centerName
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var ownerName: String = ownerName
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var businessRegistrationNumber: String = businessRegistrationNumber
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var officeNumber: String = officeNumber
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var roadNameAddress: String = roadNameAddress
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var lotNumberAddress: String = lotNumberAddress
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var detailedAddress: String = detailedAddress
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var longitude: String = longitude
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var latitude: String = latitude
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var profileImageUrl: String? = profileImageUrl
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var introduce: String? = introduce
+        private set
+
+
+    fun updateProfileImageUrl(profileImageUrl: String) {
+        this.profileImageUrl = profileImageUrl
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/exception/CenterException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/exception/CenterException.kt
@@ -13,7 +13,11 @@ sealed class CenterException(
     class AlreadyExistUser(message: String = "이미 가입된 회원입니다.") :
         CenterException(codeNumber = 2, message = message)
 
+    class NotFoundException(message: String = "존재하지 않는 센터입니다.") :
+        CenterException(codeNumber = 3, message = message)
+
     companion object {
+
         const val CODE_PREFIX = "CENTER"
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/repository/CenterJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/repository/CenterJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.swm.idle.domain.user.center.repository
+
+import com.swm.idle.domain.user.center.entity.jpa.Center
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface CenterJpaRepository : JpaRepository<Center, UUID> {
+
+    fun findByBusinessRegistrationNumber(businessRegistrationNumber: String): Center?
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/exception/UserException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/exception/UserException.kt
@@ -13,7 +13,11 @@ sealed class UserException(
     class VerificationNumberNotFound(message: String = "인증번호가 만료되었거나 존재하지 않습니다.") :
         UserException(codeNumber = 2, message = message)
 
+    class ImageUploadNotCompleted(message: String = "S3 저장소에 이미지가 업로드 되지 않았거나, 업로드에 실패하였습니다.") :
+        UserException(codeNumber = 3, message = message)
+
     companion object {
+
         const val CODE_PREFIX = "USER"
     }
 

--- a/idle-infrastructure/aws/src/main/kotlin/com/swm/idle/infrastructure/aws/s3/service/S3ImageService.kt
+++ b/idle-infrastructure/aws/src/main/kotlin/com/swm/idle/infrastructure/aws/s3/service/S3ImageService.kt
@@ -5,6 +5,7 @@ import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.infrastructure.aws.s3.properties.S3BucketProperties
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetUrlRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
@@ -55,6 +56,24 @@ class S3ImageService(
 
     fun getDuration(expireMinutes: Long): Duration {
         return Duration.ofMinutes(expireMinutes)
+    }
+
+    fun findByIdAndExtension(
+        userType: UserType,
+        imageId: UUID,
+        imageFileExtension: ImageFileExtension,
+    ): URL {
+        val getObjectRequest = GetUrlRequest
+            .builder()
+            .bucket(s3BucketProperties.userProfileImage.bucketName)
+            .key(getKey(userType, imageId, imageFileExtension))
+            .build()
+
+        return s3Client
+            .utilities()
+            .getUrl(getObjectRequest)
+            .toString()
+            .let { URL(it) }
     }
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/api/UserApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/api/UserApi.kt
@@ -3,6 +3,7 @@ package com.swm.idle.presentation.user.api
 import com.swm.idle.domain.user.common.enum.ImageFileExtension
 import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.user.UserProfileImageUploadCallbackRequest
 import com.swm.idle.support.transfer.user.UserProfileImageUploadUrlResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 
@@ -19,7 +22,7 @@ interface UserApi {
 
     @Secured
     @Operation(summary = "프로필 이미지 업로드 URL 조회")
-    @GetMapping("/{user-type}/my/profile-image-upload-url")
+    @GetMapping("/{user-type}/my/profile-image/upload-url")
     @ResponseStatus(HttpStatus.OK)
     fun getProfileImageUploadUrl(
         @PathVariable("user-type")
@@ -27,5 +30,16 @@ interface UserApi {
         @Parameter(required = true)
         imageFileExtension: ImageFileExtension,
     ): UserProfileImageUploadUrlResponse
+
+    @Secured
+    @Operation(summary = "프로필 이미지 업로드 callback")
+    @PostMapping("/{user-type}/my/profile-image/upload-callback")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun profileImageUploadCallback(
+        @PathVariable("user-type")
+        userType: UserType,
+        @RequestBody
+        request: UserProfileImageUploadCallbackRequest,
+    )
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/controller/UserController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/controller/UserController.kt
@@ -4,6 +4,7 @@ import com.swm.idle.application.user.common.service.facade.UserFacadeService
 import com.swm.idle.domain.user.common.enum.ImageFileExtension
 import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.presentation.user.api.UserApi
+import com.swm.idle.support.transfer.user.UserProfileImageUploadCallbackRequest
 import com.swm.idle.support.transfer.user.UserProfileImageUploadUrlResponse
 import org.springframework.web.bind.annotation.RestController
 
@@ -19,6 +20,17 @@ class UserController(
         return userFacadeService.getProfileImageUploadUrl(
             userType = userType,
             imageFileExtension = imageFileExtension,
+        )
+    }
+
+    override fun profileImageUploadCallback(
+        userType: UserType,
+        request: UserProfileImageUploadCallbackRequest,
+    ) {
+        return userFacadeService.createImageUploadCallback(
+            userType = userType,
+            imageId = request.imageId,
+            imageFileExtension = request.imageFileExtension,
         )
     }
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/UserProfileImageUploadCallbackRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/UserProfileImageUploadCallbackRequest.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.support.transfer.user
+
+import com.swm.idle.domain.user.common.enum.ImageFileExtension
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
+
+@Schema(
+    name = "UserProfileImageUploadCallbackRequest",
+    description = "유저 프로필 이미지 업로드 callback Request"
+)
+data class UserProfileImageUploadCallbackRequest(
+    @Schema(
+        description = "s3 presigned url 생성 시 발급받은 이미지 ID",
+        example = "0190be5f-7edb-79fd-8f4e-839563469de8",
+    )
+    val imageId: UUID,
+    @Schema(description = "이미지 파일 확장자")
+    val imageFileExtension: ImageFileExtension,
+)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/UserProfileImageUploadUrlResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/UserProfileImageUploadUrlResponse.kt
@@ -13,7 +13,7 @@ data class UserProfileImageUploadUrlResponse(
     @Schema(description = "이미지 ID", example = "8bdf126a-2d71-4a1a-9d90-6b5e5db4e0c8")
     val imageId: UUID,
     @Schema(description = "이미지 파일 확장자", example = "jpg")
-    val extension: ImageFileExtension,
+    val imageFileExtension: ImageFileExtension,
     @Schema(description = "이미지 업로드 Url")
     val uploadUrl: URL,
 )


### PR DESCRIPTION
## 1. 📄 Summary
* s3 presigned url을 이용해 client에서 프로필 사진을 등록한 이후, 해당 프로필 정보를 서버 내에 업데이트하는 callback API를 구현했습니다.
* 센터와 요양 보호사 모두 같은 API를 이용하지만, 요양 보호사의 경우 아직 작업이 진행되지 않아 해당 로직은 추후 추가하려 합니다.
## 2. ✏️ Documentation
- 프로필 이미지 업로드 callback API
    - POST /api/v1/users/{user-type}/my/profile-image/upload-callback
        - request
            - method & path: `POST /api/v1/users/{user-type}/my/profile-image/upload-callback`
                - user-type : [”center”, “carer”]
                - body
                    
                    ```json
                    {
                    	"imageId" : "string", (required & not blank)
                    	"imageFileExtension": "string" (required & not blank)
                    }
                    ```
                    
        - response
            - 프로필 이미지 업로드 성공
                - status code: `204 No Content`
            - 프로필 이미지 업로드 실패
                - status code: `400 Bad Request`