### PR TITLE
[IDLE-176] 센터 프로필 수정 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterService.kt
@@ -5,6 +5,7 @@ import com.swm.idle.domain.user.center.repository.CenterJpaRepository
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.support.common.uuid.UuidCreator
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 @Service
@@ -16,6 +17,7 @@ class CenterService(
         return centerJpaRepository.findByBusinessRegistrationNumber(businessRegistrationNumber.value)
     }
 
+    @Transactional
     fun create(
         officeNumber: String,
         centerName: String,
@@ -41,6 +43,17 @@ class CenterService(
                 introduce = introduce,
                 profileImageUrl = null,
             )
+        )
+    }
+
+    fun update(
+        center: Center,
+        officeNumber: String,
+        introduce: String?,
+    ) {
+        center.update(
+            officeNumber = officeNumber,
+            introduce = introduce,
         )
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -38,7 +38,7 @@ class CenterAuthFacadeService(
         centerBusinessRegistrationNumber: BusinessRegistrationNumber,
     ) {
         centerManagerService.findByPhoneNumber(phoneNumber)?.let {
-            throw CenterException.AlreadyExistUser()
+            throw CenterException.AlreadyExistCenterManager()
         }
 
         centerManagerService.save(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
@@ -6,6 +6,7 @@ import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.user.center.exception.CenterException
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CenterFacadeService(
@@ -29,7 +30,7 @@ class CenterFacadeService(
 
         centerService.findByBusinessRegistrationNumber(BusinessRegistrationNumber(centerManager.centerBusinessRegistrationNumber))
             ?.let {
-                throw CenterException.NotFoundException()
+                throw CenterException.AlreadyExistCenter()
             } ?: also {
             centerService.create(
                 officeNumber = officeNumber,
@@ -43,6 +44,22 @@ class CenterFacadeService(
                 introduce = introduce,
             )
         }
+    }
+
+    @Transactional
+    fun update(officeNumber: String, introduce: String?) {
+        val centerManager = getUserAuthentication().userId.let {
+            centerManagerService.getById(it)
+        }
+
+        centerService.findByBusinessRegistrationNumber(BusinessRegistrationNumber(centerManager.centerBusinessRegistrationNumber))
+            ?.let {
+                centerService.update(
+                    center = it,
+                    officeNumber = officeNumber,
+                    introduce = introduce,
+                )
+            } ?: throw CenterException.NotFoundException()
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
@@ -73,4 +73,9 @@ class Center(
         this.profileImageUrl = profileImageUrl
     }
 
+    fun update(officeNumber: String, introduce: String?) {
+        this.officeNumber = officeNumber
+        this.introduce = introduce
+    }
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/exception/CenterException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/exception/CenterException.kt
@@ -10,11 +10,14 @@ sealed class CenterException(
     class DuplicateIdentifier(message: String = "이미 존재하는 ID입니다.") :
         CenterException(codeNumber = 1, message = message)
 
-    class AlreadyExistUser(message: String = "이미 가입된 회원입니다.") :
+    class AlreadyExistCenterManager(message: String = "이미 가입된 센터 관리자입니다.") :
         CenterException(codeNumber = 2, message = message)
 
-    class NotFoundException(message: String = "존재하지 않는 센터입니다.") :
+    class AlreadyExistCenter(message: String = "등록된 센터 정보가 이미 존재합니다.") :
         CenterException(codeNumber = 3, message = message)
+
+    class NotFoundException(message: String = "존재하지 않는 센터입니다.") :
+        CenterException(codeNumber = 4, message = message)
 
     companion object {
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/exception/UserException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/exception/UserException.kt
@@ -13,7 +13,7 @@ sealed class UserException(
     class VerificationNumberNotFound(message: String = "인증번호가 만료되었거나 존재하지 않습니다.") :
         UserException(codeNumber = 2, message = message)
 
-    class ImageUploadNotCompleted(message: String = "S3 저장소에 이미지가 업로드 되지 않았거나, 업로드에 실패하였습니다.") :
+    class ImageUploadNotCompleted(message: String = "이미지가 S3 저장소에 아직 업로드되지 않았습니다.") :
         UserException(codeNumber = 3, message = message)
 
     companion object {

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -20,7 +20,7 @@ spring:
       on-profile: local
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
         hibernate.format_sql: true

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/center/api/CenterApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/center/api/CenterApi.kt
@@ -2,9 +2,11 @@ package com.swm.idle.presentation.user.center.api
 
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.user.center.CreateCenterProfileRequest
+import com.swm.idle.support.transfer.user.center.UpdateCenterProfileRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -20,6 +22,14 @@ interface CenterApi {
     @ResponseStatus(HttpStatus.CREATED)
     fun createCenterProfile(
         @RequestBody request: CreateCenterProfileRequest,
+    )
+
+    @Secured
+    @Operation(summary = "센터 프로필 수정 API")
+    @PatchMapping("/my/profile")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun updateCenterProfile(
+        @RequestBody request: UpdateCenterProfileRequest,
     )
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/center/controller/CenterController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/center/controller/CenterController.kt
@@ -3,6 +3,7 @@ package com.swm.idle.presentation.user.center.controller
 import com.swm.idle.application.user.center.service.facade.CenterFacadeService
 import com.swm.idle.presentation.user.center.api.CenterApi
 import com.swm.idle.support.transfer.user.center.CreateCenterProfileRequest
+import com.swm.idle.support.transfer.user.center.UpdateCenterProfileRequest
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -19,6 +20,13 @@ class CenterController(
             detailedAddress = request.detailedAddress,
             longitude = request.longitude,
             latitude = request.latitude,
+            introduce = request.introduce,
+        )
+    }
+
+    override fun updateCenterProfile(request: UpdateCenterProfileRequest) {
+        centerFacadeService.update(
+            officeNumber = request.officeNumber,
             introduce = request.introduce,
         )
     }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/UpdateCenterProfileRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/UpdateCenterProfileRequest.kt
@@ -1,0 +1,15 @@
+package com.swm.idle.support.transfer.user.center
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "UpdateCenterProfileRequest",
+    description = "센터 프로필 수정 요청"
+)
+data class UpdateCenterProfileRequest(
+    @Schema(description = "담당자 연락처")
+    val officeNumber: String,
+
+    @Schema(description = "소개")
+    val introduce: String? = null,
+)


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 프로필 수정 API를 구현하였습니다.

<img width="302" alt="스크린샷 2024-07-20 오전 11 27 12" src="https://github.com/user-attachments/assets/19b742c4-0e60-4bab-b897-0332f668dbe8">

## 2. ✏️ Documentation
- [센터 프로필 수정 API] PATCH /api/v1/users/center/my/profile
    - request
        - method & path: `PATCH /api/v1/users/center/my/profile`
        - body
            
            ```json
            {
              "officeNumber": "string", (required & not null)
            	"introduce": "string", (optional)
            }
            ```
            
    - response
        - 정상 처리된 경우
            - status code: `204 No Content`
        - 센터에 속해있지 않은 관리자가 센터 정보를 수정하려고 하는 경우
            - status code: `401 UnAuthorized`
            
## 3. 🤔 고민했던 점
이미지 업로드를 위한 pre-signed url을 사용하면서 프로필 수정 API와 이미지 수정은 별도의 API로 분리하게 되었습니다.
금일 아침 클라이언트 분들과 데일리 스크럼을 거치며 해당 이슈에 관해 논의한 결과 크게 두 가지 선택지가 존재했습니다.

**1. pre-signed url API를 이용해 먼저 이미지를 업로드 후, 저장 버튼을 누를 시 나머지 내용에 대한 수정이 이루어지는 경우**

-> 이 경우 사전에 이미지를 업로드하여 저장 버튼을 누를 때, 빠르게 수정을 완료할 수 있다는 장점은 있었지만 API가 분리되어 서로 다른 트랜잭션에서 동작하므로 이에 대한 롤백 처리가 현실적으로 어렵다고 판단했습니다.


**2. 저장 버튼을 누를 때, 이미지 업로드 및 프로필 수정 API 호출**

-> 최종적으로 2번 방법을 선택했습니다. 클라이언트 쪽에서 S3에 이미지 업로드 후, 동기 방식으로 성공 응답을 확인한 후에 연쇄적으로 pre-signed url callback API 및 프로필 수정 API를 호출하기로 합의하였습니다. 
사진 크기에 따라 이미지 업로드 시간이 다소 소요될 것으로 보고, progress bar 등의 애니메이션을 클라이언트 쪽에서 넣어 좋은 UX를 유지하기 위한 장치를 마련하고자 합니다.