### PR TITLE
[IDLE-223] users 공통 API path variable 소문자로 변경

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/UserType.kt
@@ -3,4 +3,14 @@ package com.swm.idle.domain.user.common.enum
 enum class UserType(val value: String) {
     CENTER("center"),
     CARER("carer");
+
+    companion object {
+
+        fun from(value: String): UserType {
+            return entries.find { it.value.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException("지원하지 않는 도메인 타입입니다.: $value")
+        }
+
+    }
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/common/api/UserApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/common/api/UserApi.kt
@@ -6,6 +6,7 @@ import com.swm.idle.support.transfer.user.common.UserProfileImageUploadCallbackR
 import com.swm.idle.support.transfer.user.common.UserProfileImageUploadUrlResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,6 +26,7 @@ interface UserApi {
     @ResponseStatus(HttpStatus.OK)
     fun getProfileImageUploadUrl(
         @PathVariable("user-type")
+        @Schema(description = "user type", example = "carer | center")
         userType: String,
         @Parameter(required = true)
         imageFileExtension: ImageFileExtension,
@@ -36,6 +38,7 @@ interface UserApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun profileImageUploadCallback(
         @PathVariable("user-type")
+        @Schema(description = "user type", example = "carer | center")
         userType: String,
         @RequestBody
         request: UserProfileImageUploadCallbackRequest,

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/common/controller/UserController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/common/controller/UserController.kt
@@ -18,7 +18,7 @@ class UserController(
         imageFileExtension: ImageFileExtension,
     ): UserProfileImageUploadUrlResponse {
         return userFacadeService.getProfileImageUploadUrl(
-            userType = UserType.valueOf(userType),
+            userType = UserType.from(userType),
             imageFileExtension = imageFileExtension,
         )
     }
@@ -28,7 +28,7 @@ class UserController(
         request: UserProfileImageUploadCallbackRequest,
     ) {
         return userFacadeService.createImageUploadCallback(
-            userType = UserType.valueOf(userType),
+            userType = UserType.from(userType),
             imageId = request.imageId,
             imageFileExtension = request.imageFileExtension,
         )


### PR DESCRIPTION
## 1. 📄 Summary
* 클라이언트쪽 요청에 따라 두 유저(carer, center)가 공통으로 사용하는 API에 대해 path variable을 대문자 대신 소문자로 관리하도록 변경하였습니다.
* 현재 변경사항이 적용된 API는 pre-signed url 조회 및 콜백 API 두 가지입니다.
* 해당 pathvariable 오입력에 따른 에러 처리는 `API-001`을 따릅니다.

* 변경 전 
http://localhost:8080/api/v1/users/CARER/my/profile-image/upload-url?imageFileExtension=JPG

* 변경 후
* http://localhost:8080/api/v1/users/carer/my/profile-image/upload-url?imageFileExtension=JPG
