### PR TITLE
[IDLE-224] JWT 토큰 만료 에러 필터 작성

### DIFF
--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/security/filter/JwtTokenExpiredHandleFilter.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/security/filter/JwtTokenExpiredHandleFilter.kt
@@ -40,7 +40,7 @@ class JwtTokenExpiredHandleFilter(
             message = "토큰이 만료되었습니다.",
         )
 
-        response.status = HttpStatus.BAD_REQUEST.value()
+        response.status = HttpStatus.UNAUTHORIZED.value()
         response.contentType =
             "${MediaType.APPLICATION_JSON_VALUE};charset=${Charsets.UTF_8.name()}"
         response.writer.write(objectMapper.writeValueAsString(errorResponse))

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/security/filter/JwtTokenExpiredHandleFilter.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/security/filter/JwtTokenExpiredHandleFilter.kt
@@ -1,0 +1,49 @@
+package com.swm.idle.presentation.common.security.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.swm.idle.presentation.common.exception.ErrorResponse
+import com.swm.idle.support.security.exception.JwtException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class JwtTokenExpiredHandleFilter(
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (exception: JwtException.TokenExpired) {
+            handleJwtTokenExpiredException(response, exception)
+        }
+    }
+
+    private fun handleJwtTokenExpiredException(
+        response: HttpServletResponse,
+        exception: JwtException.TokenExpired,
+    ) {
+        val errorResponse = ErrorResponse(
+            code = exception.code,
+            message = "토큰이 만료되었습니다.",
+        )
+
+        response.status = HttpStatus.BAD_REQUEST.value()
+        response.contentType =
+            "${MediaType.APPLICATION_JSON_VALUE};charset=${Charsets.UTF_8.name()}"
+        response.writer.write(objectMapper.writeValueAsString(errorResponse))
+    }
+
+}


### PR DESCRIPTION
## 🚨 문제 상황 
* 토큰 만료 시 발생하는 `JwtException.TokenExpired()` 에 대한 전역 에러 핸들러가 존재함에도 불구하고 핸들링이 되지 않아 500 에러가 주기적으로 발생하였습니다.
<img width="613" alt="스크린샷 2024-07-21 오전 2 41 59" src="https://github.com/user-attachments/assets/49747ebd-020d-4531-b487-4ab80af530c0">
 
<img width="587" alt="스크린샷 2024-07-21 오전 2 42 39" src="https://github.com/user-attachments/assets/0ad50dce-dcd0-4c39-b31f-5ccd8cf1c890">

## ✅ 해결한 방법
생각해 보니 원인은 간단했습니다. 전역 에러 핸들러의 경우에는 스프링 내에서 관리하고 있지만, Jwt에 대한 인증 처리는 필터에서 담당하므로 스프링 영역 밖에서 일어나기 때문에 핸들링이 되지 않았던 것입니다.

따라서 해당 에러의 경우 별도의 에러 핸들링을 위한 필터를 정의하고, `@Order(Ordered.HIGHEST_PRECEDENCE)` 어노테이션을 이용해 해당 필터를 모든 필터 중 가장 앞단에 위치시키도록 하였습니다.

## 📸 스크린샷
<img width="508" alt="스크린샷 2024-07-21 오전 2 55 18" src="https://github.com/user-attachments/assets/13868599-d83c-4fd4-ae45-c7b89b47f3d5">

