### PR TITLE
[IDLE-86] 요양 보호사 로그인 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/common/properties/JwtTokenProperties.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/common/properties/JwtTokenProperties.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.application.common.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+
 @ConfigurationProperties(value = "auth.jwt")
 data class JwtTokenProperties(
     val issuer: String,
@@ -9,8 +10,13 @@ data class JwtTokenProperties(
 ) {
 
     data class TokenProperties(
-        val expireSeconds: Long,
+        val carer: ExpirationPolicy,
+        val center: ExpirationPolicy,
         val secret: String,
     )
 
+    data class ExpirationPolicy(
+        val expireSeconds: Long,
+    )
 }
+

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 @Service
-class CarerAuthService(
+class CarerService(
     private val carerJpaRepository: CarerJpaRepository,
 ) {
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
@@ -1,15 +1,23 @@
 package com.swm.idle.application.user.carer.facade
 
-import com.swm.idle.application.user.carer.domain.CarerAuthService
+import com.swm.idle.application.user.carer.domain.CarerService
+import com.swm.idle.application.user.common.service.domain.UserPhoneVerificationService
+import com.swm.idle.application.user.common.service.util.JwtTokenService
+import com.swm.idle.application.user.vo.UserPhoneVerificationNumber
 import com.swm.idle.domain.user.carer.exception.CarerException
 import com.swm.idle.domain.user.common.enum.GenderType
+import com.swm.idle.domain.user.common.exception.UserException
 import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.domain.user.common.vo.PhoneNumber
+import com.swm.idle.support.security.exception.SecurityException
+import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.stereotype.Service
 
 @Service
 class CarerAuthFacadeService(
-    private val carerAuthService: CarerAuthService,
+    private val carerService: CarerService,
+    private val userPhoneVerificationService: UserPhoneVerificationService,
+    private val jwtTokenService: JwtTokenService,
 ) {
 
     fun join(
@@ -22,11 +30,11 @@ class CarerAuthFacadeService(
         longitude: String,
         latitude: String,
     ) {
-        carerAuthService.findByPhoneNumber(phoneNumber)?.let {
+        carerService.findByPhoneNumber(phoneNumber)?.let {
             throw CarerException.AlreadyExistCarer()
         }
 
-        carerAuthService.create(
+        carerService.create(
             carerName = carerName,
             birthYear = birthYear,
             gender = genderType,
@@ -35,6 +43,25 @@ class CarerAuthFacadeService(
             lotNumberAddress = lotNumberAddress,
             longitude = longitude,
             latitude = latitude,
+        )
+    }
+
+    fun login(
+        phoneNumber: PhoneNumber,
+        verificationNumber: UserPhoneVerificationNumber,
+    ): LoginResponse {
+        userPhoneVerificationService.findByPhoneNumber(phoneNumber)?.let {
+            if (it.first != phoneNumber || it.second != verificationNumber) {
+                throw UserException.InvalidVerificationNumber()
+            }
+        } ?: throw UserException.VerificationNumberNotFound()
+
+        val carer = carerService.findByPhoneNumber(phoneNumber)
+            ?: throw SecurityException.UnregisteredUser()
+
+        return LoginResponse(
+            accessToken = jwtTokenService.generateAccessToken(carer),
+            refreshToken = jwtTokenService.generateRefreshToken(carer),
         )
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -16,9 +16,9 @@ import com.swm.idle.infrastructure.client.businessregistration.exception.Busines
 import com.swm.idle.infrastructure.client.businessregistration.service.BusinessRegistrationNumberValidationService
 import com.swm.idle.support.common.encrypt.PasswordEncryptor
 import com.swm.idle.support.security.exception.SecurityException
-import com.swm.idle.support.transfer.auth.center.LoginResponse
 import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
+import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.stereotype.Service
 
 @Service
@@ -80,6 +80,7 @@ class CenterAuthFacadeService(
     }
 
     fun refreshLoginToken(refreshToken: String): RefreshLoginTokenResponse {
+        // 이거 센터인지 요양 보호사인지 열어가지구 확인할 수 있도록 해야 함! 이 로직 추가 필요.
         return refreshTokenService.create(refreshToken)
             .let {
                 RefreshLoginTokenResponse(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/util/JwtTokenService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/util/JwtTokenService.kt
@@ -2,11 +2,15 @@ package com.swm.idle.application.user.common.service.util
 
 import com.swm.idle.application.common.properties.JwtTokenProperties
 import com.swm.idle.application.user.vo.UserTokenClaims
+import com.swm.idle.domain.user.carer.entity.Carer
 import com.swm.idle.domain.user.center.entity.jpa.CenterManager
+import com.swm.idle.domain.user.common.entity.jpa.User
 import com.swm.idle.domain.user.common.entity.redis.UserRefreshTokenRedisHash
 import com.swm.idle.domain.user.common.enum.UserTokenType
+import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.domain.user.common.repository.redis.UserRefreshTokenRepository
 import com.swm.idle.domain.user.common.vo.PhoneNumber
+import com.swm.idle.support.security.exception.JwtException
 import com.swm.idle.support.security.util.JwtTokenProvider
 import com.swm.idle.support.security.vo.JwtClaims
 import org.springframework.stereotype.Service
@@ -19,31 +23,45 @@ class JwtTokenService(
     private val userRefreshTokenRepository: UserRefreshTokenRepository,
 ) {
 
-    fun generateAccessToken(centerManager: CenterManager): String {
+    fun generateAccessToken(user: User): String {
+        val (expireSeconds, userType) = when (user) {
+            is CenterManager -> jwtTokenProperties.access.center.expireSeconds to UserType.CENTER
+            is Carer -> jwtTokenProperties.access.carer.expireSeconds to UserType.CARER
+            else -> throw IllegalArgumentException(NOT_SUPPORTED_USER_TYPE)
+        }
+
         val jwtClaims = JwtClaims {
             registeredClaims {
                 iss = jwtTokenProperties.issuer
-                exp = Date.from(Instant.now().plusSeconds(jwtTokenProperties.access.expireSeconds))
+                exp = Date.from(Instant.now().plusSeconds(expireSeconds))
             }
             customClaims {
                 this["type"] = UserTokenType.ACCESS_TOKEN.name
-                this["userId"] = centerManager.id.toString()
-                this["phoneNumber"] = centerManager.phoneNumber
+                this["userId"] = user.id.toString()
+                this["phoneNumber"] = user.phoneNumber
+                this["userType"] = userType.value
             }
         }
 
         return JwtTokenProvider.createToken(jwtClaims, jwtTokenProperties.access.secret)
     }
 
-    fun generateRefreshToken(centerManager: CenterManager): String {
+    fun generateRefreshToken(user: User): String {
+        val (expireSeconds, userType) = when (user) {
+            is CenterManager -> jwtTokenProperties.refresh.center.expireSeconds to UserType.CENTER
+            is Carer -> jwtTokenProperties.refresh.carer.expireSeconds to UserType.CARER
+            else -> throw JwtException.NotSupportUserTokenType()
+        }
+
         val jwtClaims = JwtClaims {
             registeredClaims {
                 iss = jwtTokenProperties.issuer
-                exp = Date.from(Instant.now().plusSeconds(jwtTokenProperties.refresh.expireSeconds))
+                exp = Date.from(Instant.now().plusSeconds(expireSeconds))
             }
             customClaims {
                 this["type"] = UserTokenType.REFRESH_TOKEN.name
-                this["userId"] = centerManager.id.toString()
+                this["userId"] = user.id.toString()
+                this["userType"] = userType.value
             }
         }
 
@@ -52,9 +70,10 @@ class JwtTokenService(
             .also {
                 userRefreshTokenRepository.save(
                     UserRefreshTokenRedisHash(
-                        id = centerManager.id,
+                        id = user.id,
                         refreshToken = it,
-                        expireSeconds = jwtTokenProperties.refresh.expireSeconds
+                        userType = userType.value,
+                        expireSeconds = expireSeconds,
                     )
                 )
             }
@@ -79,6 +98,11 @@ class JwtTokenService(
         return UserTokenClaims.RefreshToken(
             userId = UUID.fromString(jwtClaims.customClaims["userId"] as String),
         )
+    }
+
+    companion object {
+
+        const val NOT_SUPPORTED_USER_TYPE = "지원되지 않는 유저 타입입니다."
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/vo/UserTokenClaims.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/vo/UserTokenClaims.kt
@@ -8,10 +8,10 @@ sealed class UserTokenClaims {
     data class AccessToken(
         val userId: UUID,
         val phoneNumber: PhoneNumber,
-    ): UserTokenClaims()
+    ) : UserTokenClaims()
 
     data class RefreshToken(
         val userId: UUID,
-    ): UserTokenClaims()
+    ) : UserTokenClaims()
 
 }

--- a/idle-application/src/main/resources/application-application.yml
+++ b/idle-application/src/main/resources/application-application.yml
@@ -2,8 +2,14 @@ auth:
   jwt:
     issuer: ${JWT_ISSUER:idle}
     access:
-      expire-seconds: ${JWT_ACCESS_EXPIRE_SECONDS}
+      carer:
+        expire-seconds: ${JWT_CARER_ACCESS_EXPIRE_SECONDS}
+      center:
+        expire-seconds: ${JWT_CENTER_ACCESS_EXPIRE_SECONDS}
       secret: ${JWT_ACCESS_SECRET_SIGNATURE}
     refresh:
-      expire-seconds: ${JWT_REFRESH_EXPIRE_SECONDS}
+      carer:
+        expire-seconds: ${JWT_CARER_REFRESH_EXPIRE_SECONDS}
+      center:
+        expire-seconds: ${JWT_CENTER_REFRESH_EXPIRE_SECONDS}
       secret: ${JWT_REFRESH_SECRET_SIGNATURE}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/Carer.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/Carer.kt
@@ -2,12 +2,12 @@ package com.swm.idle.domain.user.carer.entity
 
 import com.swm.idle.domain.user.carer.enums.CarerAccountStatus
 import com.swm.idle.domain.user.carer.enums.JobSearchStatus
+import com.swm.idle.domain.user.common.entity.jpa.User
 import com.swm.idle.domain.user.common.enum.GenderType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.math.BigDecimal
 import java.util.*
@@ -30,20 +30,20 @@ class Carer(
     profileImageUrl: String? = null,
     jobSearchStatus: JobSearchStatus = JobSearchStatus.YES,
     carerAccountStatus: CarerAccountStatus = CarerAccountStatus.ACTIVE,
-) {
+) : User(id, phoneNumber, carerName) {
 
-    @Id
-    @Column(nullable = false)
-    var id: UUID = id
-        private set
+//    @Id
+//    @Column(nullable = false)
+//    var id: UUID = id
+//        private set
 
-    @Column(nullable = false, columnDefinition = "varchar(255)")
-    var phoneNumber: String = phoneNumber
-        private set
-
-    @Column(nullable = false, columnDefinition = "varchar(255)")
-    var carerName: String = carerName
-        private set
+//    @Column(nullable = false, columnDefinition = "varchar(255)")
+//    var phoneNumber: String = phoneNumber
+//        private set
+//
+//    @Column(nullable = false, columnDefinition = "varchar(255)")
+//    var carerName: String = carerName
+//        private set
 
     @Column(nullable = false)
     var birthYear: Int = birthYear

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
@@ -1,11 +1,11 @@
 package com.swm.idle.domain.user.center.entity.jpa
 
 import com.swm.idle.domain.user.center.enums.CenterAccountStatus
+import com.swm.idle.domain.user.common.entity.jpa.User
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.util.*
 
@@ -19,12 +19,12 @@ class CenterManager(
     phoneNumber: String,
     status: CenterAccountStatus,
     centerBusinessRegistrationNumber: String,
-) {
+) : User(id, phoneNumber, managerName) {
 
-    @Id
-    @Column(nullable = false)
-    var id: UUID = id
-        private set
+//    @Id
+//    @Column(nullable = false)
+//    var id: UUID = id
+//        private set
 
     @Column(nullable = false, columnDefinition = "varchar(255)")
     var identifier: String = identifier
@@ -34,13 +34,13 @@ class CenterManager(
     var password: String = password
         private set
 
-    @Column(nullable = false, columnDefinition = "varchar(255)")
-    var managerName: String = managerName
-        private set
+//    @Column(nullable = false, columnDefinition = "varchar(255)")
+//    var managerName: String = managerName
+//        private set
 
-    @Column(nullable = false, columnDefinition = "varchar(255)")
-    var phoneNumber: String = phoneNumber
-        private set
+//    @Column(nullable = false, columnDefinition = "varchar(255)")
+//    var phoneNumber: String = phoneNumber
+//        private set
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "varchar(255)")

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/entity/jpa/User.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/entity/jpa/User.kt
@@ -1,0 +1,28 @@
+package com.swm.idle.domain.user.common.entity.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import java.util.*
+
+@MappedSuperclass
+open class User(
+    id: UUID,
+    phoneNumber: String,
+    name: String,
+) {
+
+    @Id
+    @Column(nullable = false)
+    var id: UUID = id
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var phoneNumber: String = phoneNumber
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var name: String = name
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/entity/redis/UserRefreshTokenRedisHash.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/entity/redis/UserRefreshTokenRedisHash.kt
@@ -9,6 +9,7 @@ import java.util.*
 class UserRefreshTokenRedisHash(
     id: UUID,
     refreshToken: String,
+    userType: String,
     expireSeconds: Long,
 ) {
 
@@ -17,6 +18,9 @@ class UserRefreshTokenRedisHash(
         private set
 
     var refreshToken: String = refreshToken
+        private set
+
+    var userType: String = userType
         private set
 
     @TimeToLive

--- a/idle-presentation/build.gradle.kts
+++ b/idle-presentation/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
 
     developmentOnly(libs.spring.boot.devtools)
-    developmentOnly(libs.spring.boot.docker.compose)
+//    developmentOnly(libs.spring.boot.docker.compose)
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
@@ -1,6 +1,8 @@
 package com.swm.idle.presentation.auth.carer.api
 
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
+import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
+import com.swm.idle.support.transfer.auth.common.LoginResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -19,5 +21,13 @@ interface CarerAuthApi {
     fun join(
         @RequestBody request: CarerJoinRequest,
     )
+
+    @Operation(summary = "요양 보호사 로그인 API")
+    @PostMapping("/login")
+    @ResponseStatus(HttpStatus.OK)
+    fun login(
+        @RequestBody request: CarerLoginRequest,
+    ): LoginResponse
+
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
@@ -1,10 +1,13 @@
 package com.swm.idle.presentation.auth.carer.controller
 
 import com.swm.idle.application.user.carer.facade.CarerAuthFacadeService
+import com.swm.idle.application.user.vo.UserPhoneVerificationNumber
 import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.carer.api.CarerAuthApi
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
+import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
+import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -22,6 +25,13 @@ class CarerAuthController(
             lotNumberAddress = request.lotNumberAddress,
             longitude = request.longitude,
             latitude = request.latitude,
+        )
+    }
+
+    override fun login(request: CarerLoginRequest): LoginResponse {
+        return carerAuthFacadeService.login(
+            phoneNumber = PhoneNumber(request.phoneNumber),
+            verificationNumber = UserPhoneVerificationNumber(request.verificationNumber),
         )
     }
 

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
@@ -2,13 +2,13 @@ package com.swm.idle.presentation.auth.center.api
 
 import com.swm.idle.presentation.common.exception.ErrorResponse
 import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.auth.center.CenterLoginRequest
 import com.swm.idle.support.transfer.auth.center.JoinRequest
-import com.swm.idle.support.transfer.auth.center.LoginRequest
-import com.swm.idle.support.transfer.auth.center.LoginResponse
 import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
+import com.swm.idle.support.transfer.auth.common.LoginResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -44,7 +44,7 @@ interface CenterAuthApi {
     @Operation(summary = "센터 로그인 API")
     @PostMapping("/login")
     fun login(
-        @RequestBody request: LoginRequest,
+        @RequestBody request: CenterLoginRequest,
     ): LoginResponse
 
     @Secured

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
@@ -6,13 +6,13 @@ import com.swm.idle.domain.user.center.vo.Identifier
 import com.swm.idle.domain.user.center.vo.Password
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.center.api.CenterAuthApi
+import com.swm.idle.support.transfer.auth.center.CenterLoginRequest
 import com.swm.idle.support.transfer.auth.center.JoinRequest
-import com.swm.idle.support.transfer.auth.center.LoginRequest
-import com.swm.idle.support.transfer.auth.center.LoginResponse
 import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
+import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -36,7 +36,7 @@ class CenterAuthController(
         )
     }
 
-    override fun login(request: LoginRequest): LoginResponse {
+    override fun login(request: CenterLoginRequest): LoginResponse {
         return centerAuthFacadeService.login(
             identifier = Identifier(request.identifier),
             password = Password(request.password),

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/JwtException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/JwtException.kt
@@ -19,7 +19,11 @@ sealed class JwtException(
     class TokenNotFound(message: String = "토큰을 찾을 수 없습니다.") :
         JwtException(codeNumber = 4, message = message)
 
+    class NotSupportUserTokenType(message: String = "지원하지 않는 유저 토큰 타입입니다.") :
+        JwtException(codeNumber = 5, message = message)
+
     companion object {
+
         const val CODE_PREFIX = "JWT"
     }
 

--- a/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/SecurityException.kt
+++ b/idle-support/security/src/main/kotlin/com/swm/idle/support/security/exception/SecurityException.kt
@@ -16,7 +16,11 @@ sealed class SecurityException(
     class InvalidPassword(message: String = "올바르지 않은 비밀번호입니다.") :
         SecurityException(codeNumber = 3, message = message)
 
+    class UnregisteredUser(message: String = "가입되지 않은 사용자입니다.") :
+        SecurityException(codeNumber = 4, message = message)
+
     companion object {
+
         const val CODE_PREFIX = "SECURITY"
     }
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/carer/CarerLoginRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/carer/CarerLoginRequest.kt
@@ -1,0 +1,14 @@
+package com.swm.idle.support.transfer.auth.carer
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "Carer Login Request",
+    description = "요양 보호사 로그인 요청"
+)
+data class CarerLoginRequest(
+    @Schema(description = "핸드폰 번호", example = "010-0000-0000")
+    val phoneNumber: String,
+    @Schema(description = "인증 번호", example = "123456")
+    val verificationNumber: String,
+)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/CenterLoginRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/CenterLoginRequest.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
     name = "Center Login API",
     description = "센터 로그인 API"
 )
-data class LoginRequest(
+data class CenterLoginRequest(
     @Schema(description = "아이디(ID)")
     val identifier: String,
     @Schema(description = "비밀번호")

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/common/LoginResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/common/LoginResponse.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.support.transfer.auth.center
+package com.swm.idle.support.transfer.auth.common
 
 import io.swagger.v3.oas.annotations.media.Schema
 


### PR DESCRIPTION
## Background

요양 보호사분들은 주로 50~60대 혹은 그 이상의 여성분들이 대부분이며, 앱 및 핸드폰 사용에 친화적이지 않은 분들이 많습니다. 저희 서비스에서는 최대한 간소화된 형태의 로그인 절차를 통해 요양 보호사들의 앱 진입장벽을 낮춰야 합니다.

## Goals & Non-Goals

### Goals

- 요양 보호사는 핸드폰 번호 인증을 통해 로그인 할 수 있어야 합니다.
    - 초기 로그인 시에만 로그인을 진행하고, 반복적으로 로그인 할 필요가 없도록 설계해야 합니다.

## Policy

### 토큰 TTL

- access token과 refresh token의 TTL은 아래와 같이 설정하였습니다.
    - access token : 10 Min**(600s)**
    - refresh token: 180 days**(15,552,000s)**

## **Methodology & Design(Proposal)**

### Flow
<img width="1507" alt="스크린샷 2024-07-22 오후 7 50 15" src="https://github.com/user-attachments/assets/9813c448-7085-4fdc-bea7-953762aa10ec">

- 401 에러가 발생하면, 회원가입한 정보가 없다는 뜻이므로 회원가입 API를 이용해 회원가입 해야 합니다.

### API

- API
    - [인증 번호 메세지 발송 API] POST /api/v1/auth/common/send
        - request
            - method & path: `POST /api/v1/auth/common/send`
            - body
                
                ```json
                {
                  "phoneNumber": "string" (required & not blank), (010-0000-0000의 형태를 가져야 합니다.)
                }
                
                ```
                
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
            - 전화번호 형식에 맞지 않는 경우
                - status code: `400 Bad Request`
            - 인증 메세지를 짧은 시간 내에 반복 호출하는 경우(세부사항은 위 정책에 따름)
                - status code: `400 Bad Request`
        - 해당 API는 기존에 존재하던 인증 번호 메세지 발송 API를 사용합니다. 자세한 내용은 아래 문서 참고 부탁드립니다.
            
            [[전화번호 인증 API](https://www.notion.so/API-5fdaba86ef0e4041b893f49615107288?pvs=21)](https://www.notion.so/API-5fdaba86ef0e4041b893f49615107288?pvs=21)
            
    - [요양 보호사 로그인 API] POST /api/v1/auth/carer/login
        - request
            - method & path: `POST /api/v1/auth/carer/login`
            - body
                
                ```json
                {
                	"phoneNumber": "string" (required & not blank), (010-0000-0000의 형태를 가져야 합니다.),
                  "verificationNumber": "string" (required & not blank)
                }
                ```
                
        - response
            - 정상 처리된 경우
                - status code: `200 OK`
                - body
                    
                    ```json
                    {
                       "accessToken": "string",
                       "refreshToken": "string"
                    }
                    ```
                    
            - 인증번호가 맞지 않는 경우
                - status code: `400 Bad Request`
            - 인증번호가 만료된 경우(인증번호를 찾을 수 없는 경우)
                - status code: `400 Bad Request`
            - **미가입 회원이 로그인을 시도한 경우(회원 정보를 찾을 수 없는 경우)**
                - status code: `401 UnAuthorized`

## Schedule

- [x]  설계 및 문서 작성
- [x]  요양 보호사 로그인 API 작성
- [x]  dev 배포
- [ ]  Client API 연동 및 상호 QA
