### PR TITLE
[IDLE-87] 요양 보호사 로그아웃 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
@@ -1,14 +1,17 @@
 package com.swm.idle.application.user.carer.domain
 
+import com.swm.idle.domain.common.exception.PersistenceException
 import com.swm.idle.domain.user.carer.entity.Carer
 import com.swm.idle.domain.user.carer.repository.jpa.CarerJpaRepository
 import com.swm.idle.domain.user.common.enum.GenderType
 import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.support.common.uuid.UuidCreator
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.util.*
 
 @Service
 class CarerService(
@@ -43,6 +46,11 @@ class CarerService(
 
     fun findByPhoneNumber(phoneNumber: PhoneNumber): Carer? {
         return carerJpaRepository.findByPhoneNumber(phoneNumber.value)
+    }
+
+    fun getById(carerId: UUID): Carer {
+        return carerJpaRepository.findByIdOrNull(carerId)
+            ?: throw PersistenceException.ResourceNotFound("Carer(id=$carerId)를 찾을 수 없습니다")
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
@@ -1,6 +1,8 @@
 package com.swm.idle.application.user.carer.facade
 
+import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.user.carer.domain.CarerService
+import com.swm.idle.application.user.common.service.domain.RefreshTokenService
 import com.swm.idle.application.user.common.service.domain.UserPhoneVerificationService
 import com.swm.idle.application.user.common.service.util.JwtTokenService
 import com.swm.idle.application.user.vo.UserPhoneVerificationNumber
@@ -18,6 +20,7 @@ class CarerAuthFacadeService(
     private val carerService: CarerService,
     private val userPhoneVerificationService: UserPhoneVerificationService,
     private val jwtTokenService: JwtTokenService,
+    private val refreshTokenService: RefreshTokenService,
 ) {
 
     fun join(
@@ -63,6 +66,14 @@ class CarerAuthFacadeService(
             accessToken = jwtTokenService.generateAccessToken(carer),
             refreshToken = jwtTokenService.generateRefreshToken(carer),
         )
+    }
+
+    fun logout() {
+        val carer = getUserAuthentication().userId.let {
+            carerService.getById(it)
+        }
+
+        refreshTokenService.delete(carer.id)
     }
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
@@ -1,5 +1,6 @@
 package com.swm.idle.presentation.auth.carer.api
 
+import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
 import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
@@ -29,5 +30,9 @@ interface CarerAuthApi {
         @RequestBody request: CarerLoginRequest,
     ): LoginResponse
 
+    @Secured
+    @Operation(summary = "요양 보호사 로그아웃 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun logout()
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
@@ -35,4 +35,8 @@ class CarerAuthController(
         )
     }
 
+    override fun logout() {
+        carerAuthFacadeService.logout()
+    }
+
 }


### PR DESCRIPTION
## Backgrounds

요양 보호사의 로그아웃을 지원해야 합니다.

## Goals & Non-Goals

### Goals

- 요양 보호사는 로그인 이후 요청 시 로그아웃 처리가 가능하도록 합니다.

## **Methodology & Design(Proposal)**

### API

- API
    - [🆕 Sample] POST /api/v1/auth/carer/logout
        - request
            - method & path: `POST /api/v1/auth/carer/logout`
        - response
            - 사용 가능한 아이디
                - status code: `204 No Content`
            - 비 로그인 상태에서 로그아웃을 시도하는 경우(인증 처리가 되지 않은 사용자)
                - status code: `401 UnAuthorized`

## Schedule

- [x]  설계 및 문서 작성
- [x]  요양 보호사 로그아웃 API
- [ ]  dev 배포 및 QA
