### PR TITLE
[IDLE-88] 요양 보호사 회원 탈퇴 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
@@ -2,12 +2,14 @@ package com.swm.idle.application.user.carer.facade
 
 import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.user.carer.domain.CarerService
+import com.swm.idle.application.user.common.service.domain.DeletedUserInfoService
 import com.swm.idle.application.user.common.service.domain.RefreshTokenService
 import com.swm.idle.application.user.common.service.domain.UserPhoneVerificationService
 import com.swm.idle.application.user.common.service.util.JwtTokenService
 import com.swm.idle.application.user.vo.UserPhoneVerificationNumber
 import com.swm.idle.domain.user.carer.exception.CarerException
 import com.swm.idle.domain.user.common.enum.GenderType
+import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.domain.user.common.exception.UserException
 import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.domain.user.common.vo.PhoneNumber
@@ -21,6 +23,7 @@ class CarerAuthFacadeService(
     private val userPhoneVerificationService: UserPhoneVerificationService,
     private val jwtTokenService: JwtTokenService,
     private val refreshTokenService: RefreshTokenService,
+    private val deletedUserInfoService: DeletedUserInfoService,
 ) {
 
     fun join(
@@ -74,6 +77,19 @@ class CarerAuthFacadeService(
         }
 
         refreshTokenService.delete(carer.id)
+    }
+
+    fun withdraw(reason: String) {
+        val carer = getUserAuthentication().userId.let {
+            carerService.getById(it)
+        }
+
+        deletedUserInfoService.save(
+            id = carer.id,
+            phoneNumber = PhoneNumber(carer.phoneNumber),
+            role = UserType.CARER,
+            reason = reason,
+        )
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -106,7 +106,7 @@ class CenterAuthFacadeService(
         )
     }
 
-    fun withDraw(
+    fun withdraw(
         reason: String,
         password: Password,
     ) {

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
@@ -3,6 +3,7 @@ package com.swm.idle.presentation.auth.carer.api
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
 import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
+import com.swm.idle.support.transfer.auth.carer.CarerWithdrawRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -32,7 +33,16 @@ interface CarerAuthApi {
 
     @Secured
     @Operation(summary = "요양 보호사 로그아웃 API")
+    @PostMapping("/logout")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun logout()
+
+    @Secured
+    @Operation(summary = "요양 보호사 회원 탈퇴 API")
+    @PostMapping("/withdraw")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun withdraw(
+        @RequestBody request: CarerWithdrawRequest,
+    )
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
@@ -7,6 +7,7 @@ import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.carer.api.CarerAuthApi
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
 import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
+import com.swm.idle.support.transfer.auth.carer.CarerWithdrawRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.web.bind.annotation.RestController
 
@@ -37,6 +38,10 @@ class CarerAuthController(
 
     override fun logout() {
         carerAuthFacadeService.logout()
+    }
+
+    override fun withdraw(request: CarerWithdrawRequest) {
+        carerAuthFacadeService.withdraw(request.reason)
     }
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
@@ -56,7 +56,7 @@ class CenterAuthController(
     }
 
     override fun withdraw(request: WithdrawRequest) {
-        return centerAuthFacadeService.withDraw(
+        return centerAuthFacadeService.withdraw(
             reason = request.reason,
             password = Password(request.password)
         )

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/carer/CarerWithdrawRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/carer/CarerWithdrawRequest.kt
@@ -1,0 +1,12 @@
+package com.swm.idle.support.transfer.auth.carer
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "Carer Withdraw Request",
+    description = "요양 보호사 회원 탈퇴 요청"
+)
+data class CarerWithdrawRequest(
+    @Schema(description = "회원 탈퇴 사유")
+    val reason: String,
+)


### PR DESCRIPTION
## Background

- AOS 및 IOS의 앱 심사를 위해, 회원 탈퇴 API가 필요합니다.
- 이탈 예정인 유저들에게서 탈퇴 사유를 입력받아 타겟층 및 유저 분석에 지표로 사용할 수 있습니다.

## Goals & Non-Goals

### Goals

- 요양 보호사는 가입 후 서비스 이용을 더 이상 희망하지 않을 때, 회원 탈퇴가 가능해야 합니다.
- 탈퇴는 soft delete를 통해 탈퇴한 회원의 정보와 이력을 별도로 관리할 수 있어야 합니다.

## Policy

- 요양 보호사의 회원 탈퇴
    - 회원 탈퇴 사유를 입력받아야 합니다.
    - 요양 보호사는 아이디 패스워드로 로그인 하지 않으므로, SMS 인증을 거쳐 탈퇴하도록 합니다.

## **Methodology & Design(Proposal)**

### API

- API
    - [🆕 Sample] POST /api/v1/auth/carer/withdraw
        - request
            - method & path: `POST /api/v1/auth/carer/withdraw`
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`

## Schedule

- [x]  설계 및 문서 작성
- [x]  요양 보호사 회원 탈퇴 API
