### PR TITLE
[IDLE-233] 요양 보호사 회원가입 시, 토큰을 발급하도록 변경한다.

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
@@ -28,8 +28,8 @@ class CarerService(
         lotNumberAddress: String,
         longitude: String,
         latitude: String,
-    ) {
-        carerJpaRepository.save(
+    ): Carer {
+        return carerJpaRepository.save(
             Carer(
                 id = UuidCreator.create(),
                 birthYear = birthYear.value,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
@@ -35,12 +35,12 @@ class CarerAuthFacadeService(
         lotNumberAddress: String,
         longitude: String,
         latitude: String,
-    ) {
+    ): LoginResponse {
         carerService.findByPhoneNumber(phoneNumber)?.let {
             throw CarerException.AlreadyExistCarer()
         }
 
-        carerService.create(
+        val savedCarer = carerService.create(
             carerName = carerName,
             birthYear = birthYear,
             gender = genderType,
@@ -49,6 +49,11 @@ class CarerAuthFacadeService(
             lotNumberAddress = lotNumberAddress,
             longitude = longitude,
             latitude = latitude,
+        )
+
+        return LoginResponse(
+            accessToken = jwtTokenService.generateAccessToken(savedCarer),
+            refreshToken = jwtTokenService.generateRefreshToken(savedCarer),
         )
     }
 

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
@@ -22,7 +22,7 @@ interface CarerAuthApi {
     @ResponseStatus(HttpStatus.CREATED)
     fun join(
         @RequestBody request: CarerJoinRequest,
-    )
+    ): LoginResponse
 
     @Operation(summary = "요양 보호사 로그인 API")
     @PostMapping("/login")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
@@ -16,8 +16,8 @@ class CarerAuthController(
     private val carerAuthFacadeService: CarerAuthFacadeService,
 ) : CarerAuthApi {
 
-    override fun join(request: CarerJoinRequest) {
-        carerAuthFacadeService.join(
+    override fun join(request: CarerJoinRequest): LoginResponse {
+        return carerAuthFacadeService.join(
             carerName = request.carerName,
             birthYear = BirthYear(request.birthYear),
             genderType = request.genderType,


### PR DESCRIPTION
## 1. 📄 Summary
* SMS 인증을 통해 로그인하는 요양 보호사의 경우, 회원가입 Flow 이후에 재 로그인하는 프로세스가 다소 번거롭다는 피드백을 개선하기 위해 요양 보호사 회원 가입 시 JWT를 발급하도록 변경하였습니다.