### PR TITLE
[IDLE-000] 프로필 수정 API null 체킹 로직 추가

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
@@ -9,11 +9,13 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
 import java.math.BigDecimal
 import java.util.*
 
 @Entity
 @Table(name = "carer")
+@DynamicUpdate
 class Carer(
     id: UUID,
     phoneNumber: String,
@@ -93,22 +95,13 @@ class Carer(
         speciality: String?,
         jobSearchStatus: JobSearchStatus,
     ) {
-        if (experienceYear != null) {
-            this.experienceYear = experienceYear
-        }
+        this.experienceYear = experienceYear
         this.roadNameAddress = roadNameAddress
         this.lotNumberAddress = lotNumberAddress
         this.longitude = longitude
         this.latitude = latitude
-
-        if (introduce != null) {
-            this.introduce = introduce
-        }
-
-        if (speciality != null) {
-            this.speciality = speciality
-        }
-
+        this.introduce = introduce
+        this.speciality = speciality
         this.jobSearchStatus = jobSearchStatus
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
@@ -93,13 +93,22 @@ class Carer(
         speciality: String?,
         jobSearchStatus: JobSearchStatus,
     ) {
-        this.experienceYear = experienceYear
+        if (experienceYear != null) {
+            this.experienceYear = experienceYear
+        }
         this.roadNameAddress = roadNameAddress
         this.lotNumberAddress = lotNumberAddress
         this.longitude = longitude
         this.latitude = latitude
-        this.introduce = introduce
-        this.speciality = speciality
+
+        if (introduce != null) {
+            this.introduce = introduce
+        }
+
+        if (speciality != null) {
+            this.speciality = speciality
+        }
+
         this.jobSearchStatus = jobSearchStatus
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
@@ -4,11 +4,13 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
 import java.math.BigDecimal
 import java.util.*
 
 @Entity
 @Table(name = "center")
+@DynamicUpdate
 class Center(
     id: UUID,
     centerName: String,
@@ -75,10 +77,7 @@ class Center(
 
     fun update(officeNumber: String, introduce: String?) {
         this.officeNumber = officeNumber
-
-        if (introduce != null) {
-            this.introduce = introduce
-        }
+        this.introduce = introduce
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
@@ -75,7 +75,10 @@ class Center(
 
     fun update(officeNumber: String, introduce: String?) {
         this.officeNumber = officeNumber
-        this.introduce = introduce
+
+        if (introduce != null) {
+            this.introduce = introduce
+        }
     }
 
 }


### PR DESCRIPTION
## 1. 📄 Summary
* JPA에서 제공하는 더티 체킹 기능은 기본적으로 PATCH로 선언하였음에도 불구하고 PUT으로 전체 필드에 대해 update가 됩니다.
* 즉, PATCH의 동작방식으로 특정 컬럼을 제외하고 요청한 경우, 자동으로 null 값이 업데이트 되는 현상이 발생합니다.
* 이를 방지하기 위해, @DynamicUpdate 어노테이션을 이용해 변경된 사항만 변경 감지를 통해 업데이트 하도록 변경하였습니다.