### PR TITLE
[IDLE-244] 요양 보호사 Token Refresh API 구현

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
@@ -14,6 +14,7 @@ import com.swm.idle.domain.user.common.exception.UserException
 import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.support.security.exception.SecurityException
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.stereotype.Service
 
@@ -97,6 +98,16 @@ class CarerAuthFacadeService(
             role = UserType.CARER,
             reason = reason,
         )
+    }
+
+    fun refreshLoginToken(refreshToken: String): RefreshLoginTokenResponse {
+        return refreshTokenService.create(refreshToken)
+            .let {
+                RefreshLoginTokenResponse(
+                    accessToken = it.accessToken,
+                    refreshToken = it.refreshToken,
+                )
+            }
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/domain/RefreshTokenService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/domain/RefreshTokenService.kt
@@ -1,8 +1,10 @@
 package com.swm.idle.application.user.common.service.domain
 
+import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterManagerService
 import com.swm.idle.application.user.common.service.util.JwtTokenService
 import com.swm.idle.application.user.vo.UserTokenClaims
+import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.domain.user.common.repository.redis.UserRefreshTokenRepository
 import com.swm.idle.domain.user.common.vo.JwtTokens
 import com.swm.idle.support.security.exception.JwtException
@@ -15,6 +17,7 @@ class RefreshTokenService(
     private val jwtTokenService: JwtTokenService,
     private val userRefreshTokenRepository: UserRefreshTokenRepository,
     private val centerManagerService: CenterManagerService,
+    private val carerService: CarerService,
 ) {
 
     @Transactional
@@ -29,11 +32,14 @@ class RefreshTokenService(
 
         validateRefreshToken(token)
 
-        val centerManager = centerManagerService.getById(token.userId)
+        val user = when (token.userType) {
+            UserType.CARER -> carerService.getById(token.userId)
+            UserType.CENTER -> centerManagerService.getById(token.userId)
+        }
 
         return JwtTokens(
-            accessToken = jwtTokenService.generateAccessToken(centerManager),
-            refreshToken = jwtTokenService.generateRefreshToken(centerManager)
+            accessToken = jwtTokenService.generateAccessToken(user),
+            refreshToken = jwtTokenService.generateRefreshToken(user)
         )
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/util/JwtTokenService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/util/JwtTokenService.kt
@@ -97,6 +97,7 @@ class JwtTokenService(
 
         return UserTokenClaims.RefreshToken(
             userId = UUID.fromString(jwtClaims.customClaims["userId"] as String),
+            userType = UserType.from(jwtClaims.customClaims["userType"] as String),
         )
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/vo/UserTokenClaims.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/vo/UserTokenClaims.kt
@@ -1,5 +1,6 @@
 package com.swm.idle.application.user.vo
 
+import com.swm.idle.domain.user.common.enum.UserType
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import java.util.*
 
@@ -12,6 +13,7 @@ sealed class UserTokenClaims {
 
     data class RefreshToken(
         val userId: UUID,
+        val userType: UserType,
     ) : UserTokenClaims()
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
@@ -4,6 +4,8 @@ import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
 import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
 import com.swm.idle.support.transfer.auth.carer.CarerWithdrawRequest
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
+import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -44,5 +46,12 @@ interface CarerAuthApi {
     fun withdraw(
         @RequestBody request: CarerWithdrawRequest,
     )
+
+    @Operation(summary = "요양 보호사 Refresh Login Token API")
+    @PostMapping("/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    fun refreshLoginToken(
+        @RequestBody request: RefreshTokenRequest,
+    ): RefreshLoginTokenResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
@@ -8,6 +8,8 @@ import com.swm.idle.presentation.auth.carer.api.CarerAuthApi
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
 import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
 import com.swm.idle.support.transfer.auth.carer.CarerWithdrawRequest
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
+import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.web.bind.annotation.RestController
 
@@ -42,6 +44,10 @@ class CarerAuthController(
 
     override fun withdraw(request: CarerWithdrawRequest) {
         carerAuthFacadeService.withdraw(request.reason)
+    }
+
+    override fun refreshLoginToken(request: RefreshTokenRequest): RefreshLoginTokenResponse {
+        return carerAuthFacadeService.refreshLoginToken(request.refreshToken)
     }
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
@@ -53,7 +53,7 @@ interface CenterAuthApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun logout()
 
-    @Operation(summary = "Refresh Login Token API")
+    @Operation(summary = "센터 Refresh Login Token API")
     @PostMapping("/refresh")
     @ResponseStatus(HttpStatus.OK)
     fun refreshLoginToken(


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사 Token Refresh API를 구현하였습니다

## 2. ✏️ Documentation
### API

- API
  - Refresh Token 갱신 API
      - [🆕 Sample] POST /api/v1/auth/carer/refresh
          - request
              - method & path: `POST /api/v1/auth/carer/refresh`
              - body
                  
                  ```json
                  {
                    "refreshToken": "string"
                  }
                  ```
                  
          - response
              - 정상 처리된 경우
                  - status code: `200 OK`
                  - body
                      
                      ```json
                      {
                        "accessToken": "string",
                        "refreshToken": "string"
                      }
                      ```
                      
              - 유효하지 않은 토큰인 경우
                  - status code: `401 UnAuthorized`
              - Refresh Token이 만료된 경우
                  - status code: `401 UnAuthorized`

## 3. 🤔 고민했던 점
기존 센터 관리자에 대해 Refresh Token API를 구성하다 보니, 요양 보호사 역시 같은 기능을 제공하도록 확장해야 했습니다.

JwtClaims
```kotlin
data class JwtClaims(
    val registeredClaims: RegisteredClaims,
    val customClaims: MutableMap<String, Any> = mutableMapOf(),
) {

    data class RegisteredClaims(
        val sub: String? = null,
        val exp: Date? = Date.from(Instant.now().plusSeconds(DEFAULT_EXPIRATION_TIME_SEC)),
        val iat: Date? = Date.from(Instant.now()),
        val nbf: Date? = Date.from(Instant.now()),
        val iss: String? = null,
        val aud: List<String>? = null,
        val jti: String? = null,
    )

    val sub: String?
        get() = registeredClaims.sub
    val exp: Date?
        get() = registeredClaims.exp
    val iat: Date?
        get() = registeredClaims.iat
    val nbf: Date?
        get() = registeredClaims.nbf
    val iss: String?
        get() = registeredClaims.iss
    val aud: List<String>?
        get() = registeredClaims.aud
    val jti: String?
        get() = registeredClaims.jti

    companion object {

        const val DEFAULT_EXPIRATION_TIME_SEC: Long = 60 * 60

        fun from(claims: DecodedJWT): JwtClaims {
            val registeredClaims = RegisteredClaims(
                sub = claims.subject,
                exp = claims.expiresAt,
                iat = claims.issuedAt,
                nbf = claims.notBefore,
                iss = claims.issuer,
                aud = claims.audience,
                jti = claims.id,
            )
            val customClaims: MutableMap<String, Any> = mutableMapOf()
            claims.claims
                .filter { it.key !in registeredClaims::class.members.map { member -> member.name } }
                .forEach { (key, value) ->
                    customClaims[key] = value.`as`(Any::class.java)
                }
            return JwtClaims(registeredClaims, customClaims)
        }

    }
```

이를 위해, 기존 로직에서 자체적으로 관리하던 customClaim 내에 해당 토큰을 발급받은 유저에 대한 Type을 넣어 관리할 수 있도록 하였습니다.

JwtTokenService

```kotlin
    fun resolveRefreshToken(refreshToken: String): UserTokenClaims.RefreshToken {
        val jwtClaims: JwtClaims = JwtTokenProvider
            .verifyToken(refreshToken, jwtTokenProperties.refresh.secret)
            .getOrThrow()

        return UserTokenClaims.RefreshToken(
            userId = UUID.fromString(jwtClaims.customClaims["userId"] as String),
            userType = UserType.from(jwtClaims.customClaims["userType"] as String),
        )
    }
```

이에 따라 Refresh Token을 신규 발급하는 로직도 아래 코드와 같이 when 조건절을 통해 분기하였습니다.

```kotlin
    @Transactional
    fun create(refreshToken: String): JwtTokens {
        lateinit var token: UserTokenClaims.RefreshToken

        try {
            token = jwtTokenService.resolveRefreshToken(refreshToken)
        } catch (e: JwtException.TokenExpired) {
            throw JwtException.TokenNotValid()
        }

        validateRefreshToken(token)

        val user = when (token.userType) {
            UserType.CARER -> carerService.getById(token.userId)
            UserType.CENTER -> centerManagerService.getById(token.userId)
        }

        return JwtTokens(
            accessToken = jwtTokenService.generateAccessToken(user),
            refreshToken = jwtTokenService.generateRefreshToken(user)
        )
    }
```