### PR TITLE
[IDLE-228] 구인 공고 크롤링 및 배치 시스템 구축

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,9 @@ val allProjects = project.allprojects
     .filter { it.name != "idle-support" }
     .filter { it.name != "idle-domain" }
     .filter { it.name != "idle-infrastructure" }
-    .filter { it.name != "idle-api" }
+    .filter { it.name != "idle-application" }
+    .filter { it.name != "idle-presentation" }
+    .filter { it.name != "idle-batch" }
     .toList()
 
 project(":idle-support:jacoco") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ kotlin-coroutines = "1.8.0"
 
 auth0-java-jwt = "4.4.0"
 auth0-jwks-rsa = "0.22.1"
+selenium = "4.23.0"
 
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
@@ -38,6 +39,7 @@ spring-boot-docker-compose = { group = "org.springframework.boot", name = "sprin
 
 spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-boot-starter-web", version.ref = "spring-boot" }
 spring-boot-starter-data-jpa = { group = "org.springframework.boot", name = "spring-boot-starter-data-jpa", version.ref = "spring-boot" }
+spring-boot-starter-batch = { group = "org.springframework.boot", name = "spring-boot-starter-batch", version.ref = "spring-boot" }
 spring-boot-starter-data-redis = { group = "org.springframework.boot", name = "spring-boot-starter-data-redis", version.ref = "spring-boot" }
 
 mysql-connector-java = { group = "mysql", name = "mysql-connector-java", version.ref = "mysql" }
@@ -65,6 +67,9 @@ jbcrypt = { group = "org.mindrot", name = "jbcrypt", version.ref = "jbcrypt" }
 
 java-jwt = { group = "com.auth0", name = "java-jwt", version.ref = "auth0-java-jwt" }
 jwks-rsa = { group = "com.auth0", name = "jwks-rsa", version.ref = "auth0-jwks-rsa" }
+
+selenium-java = { group = "org.seleniumhq.selenium", name = "selenium-java", version.ref = "selenium"}
+selenium-chrome-driver = { group = "org.seleniumhq.selenium", name = "selenium-chrome-driver", version.ref = "selenium"}
 
 [plugins]
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/CrawledJobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/CrawledJobPostingService.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.application.jobposting.service.domain
+
+import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
+import com.swm.idle.domain.jobposting.repository.jpa.CrawledJobPostingRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CrawledJobPostingService(
+    private val crawledJobPostingRepository: CrawledJobPostingRepository,
+) {
+
+    @Transactional
+    fun saveAll(crawledJobPostings: List<CrawledJobPosting>) {
+        crawledJobPostingRepository.saveAll(crawledJobPostings)
+    }
+
+}

--- a/idle-batch/build.gradle.kts
+++ b/idle-batch/build.gradle.kts
@@ -1,0 +1,17 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true
+
+dependencies {
+    implementation(project(":idle-support:common"))
+    implementation(project(":idle-domain"))
+    implementation(project(":idle-application"))
+
+    implementation(rootProject.libs.spring.boot.starter.batch)
+    implementation(rootProject.libs.selenium.java)
+    implementation(rootProject.libs.selenium.chrome.driver)
+}

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/config/BatchConfig.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/config/BatchConfig.kt
@@ -1,0 +1,9 @@
+package com.swm.idle.batch.common.config
+
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ComponentScan(basePackages = ["com.swm.idle.batch"])
+class BatchConfig {
+}

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
@@ -1,0 +1,49 @@
+package com.swm.idle.batch.common.dto
+
+import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
+import com.swm.idle.support.common.uuid.UuidCreator
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+data class CrawledJobPostingDto(
+    val title: String,
+    val content: String,
+    val clientAddress: String,
+    val createdAt: String,
+    val payInfo: String,
+    val workTime: String,
+    val workSchedule: String,
+    val applyDeadline: String,
+    val recruitmentProcess: String,
+    val applyMethod: String,
+    val requiredDocument: String,
+    val centerName: String,
+    val centerAddress: String,
+    val directUrl: String,
+) {
+
+    fun toDomain(): CrawledJobPosting {
+        return CrawledJobPosting(
+            id = UuidCreator.create(),
+            title = title,
+            content = content,
+            clientAddress = clientAddress,
+            createdAt = LocalDateTime.parse(
+                createdAt,
+                DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")
+            ),
+            payInfo = payInfo,
+            workTime = workTime,
+            workSchedule = workSchedule,
+            applyDeadline = applyDeadline,
+            recruitmentProcess = recruitmentProcess,
+            applyMethod = applyMethod,
+            requiredDocument = requiredDocument,
+            centerName = centerName,
+            centerAddress = centerAddress,
+            directUrl = directUrl,
+        )
+    }
+
+}
+

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -1,0 +1,25 @@
+package com.swm.idle.batch.common.scheduler
+
+import com.swm.idle.batch.job.CrawlingJob
+import org.springframework.batch.core.JobParameters
+import org.springframework.batch.core.JobParametersBuilder
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class CrawlingJobScheduler(
+    private val jobLauncher: JobLauncher,
+    private val crawlingJobConfig: CrawlingJob,
+) {
+
+    @Scheduled(cron = "0 0 3 ? * TUE,WED,THU,FRI,SAT")
+    fun scheduleJob() {
+        val jobParameters: JobParameters = JobParametersBuilder()
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+        jobLauncher.run(crawlingJobConfig.crawlingJob(), jobParameters)
+    }
+
+}
+

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJob.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJob.kt
@@ -1,0 +1,33 @@
+package com.swm.idle.batch.job
+
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.PlatformTransactionManager
+
+@Configuration
+class CrawlingJob(
+    private val jobRepository: JobRepository,
+    private val transactionManager: PlatformTransactionManager,
+    private val crawlingJobPostingTasklet: CrawlingJobPostingTasklet,
+) {
+
+    @Bean
+    fun crawlingJob(): Job {
+        return JobBuilder("crawlingJob", jobRepository)
+            .start(crawlingJobPostStep())
+            .build()
+    }
+
+    @Bean
+    fun crawlingJobPostStep(): Step {
+        return StepBuilder("crawlingJobPostStep", jobRepository)
+            .tasklet(crawlingJobPostingTasklet, transactionManager)
+            .build()
+    }
+
+}

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJobPostingTasklet.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJobPostingTasklet.kt
@@ -1,0 +1,29 @@
+package com.swm.idle.batch.job
+
+import com.swm.idle.application.jobposting.service.domain.CrawledJobPostingService
+import com.swm.idle.batch.common.dto.CrawledJobPostingDto
+import com.swm.idle.batch.util.WorknetCrawler
+import org.springframework.batch.core.StepContribution
+import org.springframework.batch.core.scope.context.ChunkContext
+import org.springframework.batch.core.step.tasklet.Tasklet
+import org.springframework.batch.repeat.RepeatStatus
+import org.springframework.stereotype.Component
+
+@Component
+class CrawlingJobPostingTasklet(
+    private val crawledJobPostingService: CrawledJobPostingService,
+) : Tasklet {
+
+    override fun execute(contribution: StepContribution, chunkContext: ChunkContext): RepeatStatus {
+        WorknetCrawler.run()?.let {
+            crawledJobPostingService.saveAll(
+                it.stream()
+                    .map(CrawledJobPostingDto::toDomain)
+                    .toList()
+            )
+        }
+
+        return RepeatStatus.FINISHED
+    }
+
+}

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/util/WorknetCrawler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/util/WorknetCrawler.kt
@@ -1,0 +1,204 @@
+package com.swm.idle.batch.util
+
+import com.swm.idle.batch.common.dto.CrawledJobPostingDto
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+import java.time.Duration
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+object WorknetCrawler {
+
+    private const val CRAWLING_TARGET_URL_FORMAT =
+        "https://www.work.go.kr/empInfo/empInfoSrch/list/dtlEmpSrchList.do?careerTo=&keywordJobCd=&occupation=550100%2C550104&templateInfo=&shsyWorkSecd=&rot2WorkYn=&payGbn=&resultCnt=50&keywordJobCont=&cert=&cloDateStdt=&moreCon=&minPay=&codeDepth2Info=11000&isChkLocCall=&sortFieldInfo=DATE&major=&resrDutyExcYn=&eodwYn=&sortField=DATE&staArea=&sortOrderBy=DESC&keyword=&termSearchGbn=D-0&carrEssYns=&benefitSrchAndOr=O&disableEmpHopeGbn=&webIsOut=&actServExcYn=&maxPay=&keywordStaAreaNm=&emailApplyYn=&listCookieInfo=DTL&pageCode=&codeDepth1Info=11000&keywordEtcYn=&publDutyExcYn=&keywordJobCdSeqNo=&exJobsCd=&templateDepthNmInfo=&computerPreferential=&regDateStdt={today}&employGbn=&empTpGbcd=&region=&infaYn=&resultCntInfo=50&siteClcd=WORK%2CP&cloDateEndt=&sortOrderByInfo=DESC&currntPageNo=1&indArea=&careerTypes=&searchOn=Y&tlmgYn=&subEmpHopeYn=&academicGbn=&templateDepthNoInfo=&foriegn=&mealOfferClcd=&station=&moerButtonYn=Y&holidayGbn=&srcKeyword=&enterPriseGbn=all&academicGbnoEdu=noEdu&cloTermSearchGbn=all&keywordWantedTitle=&stationNm=&benefitGbn=&keywordFlag=&notSrcKeyword=&essCertChk=&isEmptyHeader=&depth2SelCode=&_csrf=355cf055-ee67-497a-9695-a65cabc28829&keywordBusiNm=&preferentialGbn=&rot3WorkYn=&pfMatterPreferential=&regDateEndt={today}&staAreaLineInfo1=11000&staAreaLineInfo2=1&pageIndex={pageIndex}&termContractMmcnt=&careerFrom=&laborHrShortYn=#viewSPL"
+
+    private const val JOB_POSTING_COUNT_PER_PAGE = 50
+    private val driver: WebDriver = ChromeDriver()
+    private val postings = mutableListOf<CrawledJobPostingDto>()
+
+    fun run(): List<CrawledJobPostingDto>? {
+        val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+        val today = LocalDate.now().minusDays(1).format(formatter)
+        val crawlingUrl = CRAWLING_TARGET_URL_FORMAT
+            .replace("{today}", today)
+            .replace("{pageIndex}", "1")
+
+        driver.get(crawlingUrl)
+
+        val jobPostingCountText =
+            driver.findElement(By.xpath("//*[@id=\"srcFrm\"]/div[3]/div[1]/p[2]/em")).text
+        val jobPostingCount = jobPostingCountText.replace(",", "").toInt()
+
+        if (jobPostingCount == 0) {
+            return null
+        }
+
+        val pageCount = jobPostingCount / JOB_POSTING_COUNT_PER_PAGE
+
+        for (i in 1..pageCount) {
+            if (i >= 2) {
+                val updatedCrawlingUrl = crawlingUrl
+                    .replace("{today}", today)
+                    .replace(Regex("pageIndex=\\d+"), "pageIndex=${i}")
+                driver.get(updatedCrawlingUrl)
+            }
+            val wait = WebDriverWait(driver, Duration.ofSeconds(5))
+            wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("#list1")))
+
+            crawlPosts(1, JOB_POSTING_COUNT_PER_PAGE, postings)
+        }
+
+        val lastPageJobPostingCount = jobPostingCount % JOB_POSTING_COUNT_PER_PAGE
+
+        if (lastPageJobPostingCount > 0) {
+            val updateCrawlingUrl = crawlingUrl
+                .replace("{today}", today)
+                .replace(Regex("pageIndex=\\d+"), "pageIndex=${pageCount + 1}")
+            driver.get(updateCrawlingUrl)
+
+            val wait = WebDriverWait(driver, Duration.ofSeconds(5))
+            wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("#list1")))
+
+            crawlPosts(1, lastPageJobPostingCount, postings)
+        }
+
+        driver.quit()
+
+        return postings
+    }
+
+    private fun crawlPosts(
+        start: Int,
+        end: Int,
+        postings: MutableList<CrawledJobPostingDto>,
+    ) {
+        for (i in start..end) {
+            val originalWindow = driver.windowHandle
+
+            val em = driver.findElement(By.id("list$i"))
+            val thirdTd = em.findElements(By.tagName("td"))[2]
+            val jobPostingDetail = thirdTd.findElement(By.cssSelector(".cp-info .cp-info-in a"))
+            jobPostingDetail.click()
+
+            val wait = WebDriverWait(driver, Duration.ofSeconds(20))
+            wait.until(ExpectedConditions.numberOfWindowsToBe(2))
+
+            val allWindows = driver.windowHandles
+
+            for (windowHandle in allWindows) {
+                if (windowHandle != originalWindow) {
+                    driver.switchTo().window(windowHandle)
+                    break
+                }
+            }
+
+            val crawledJobPostingDto = CrawledJobPostingDto(
+                title = getTitle(),
+                content = getContent(),
+                clientAddress = getClientAddress(),
+                createdAt = getCreatedAt(),
+                payInfo = getPayInfo(),
+                workTime = getWorkTime(),
+                workSchedule = getWorkSchedule(),
+                applyDeadline = getApplyDeadline(),
+                recruitmentProcess = getRecruitmentProcess(),
+                applyMethod = getApplyMethod(),
+                requiredDocument = getRequiredDocument(),
+                centerName = getCenterName(),
+                centerAddress = getCenterAddress(),
+                directUrl = driver.currentUrl,
+            )
+
+            postings.add(crawledJobPostingDto)
+
+            driver.close()
+            driver.switchTo().window(originalWindow)
+        }
+    }
+
+    private fun getClientAddress(): String {
+        try {
+            val address =
+                driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[15]/div/table/tbody/tr[4]/td/p[2]")).text
+            return address.replace("지도보기", "").trim()
+        } catch (e: Exception) {
+            val address =
+                driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[17]/div/table/tbody/tr[4]/td/p[2]")).text
+            return address.replace("지도보기", "").trim()
+        }
+    }
+
+    private fun getRequiredDocument(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[7]/table/tbody/tr/td[4]")).text
+    }
+
+    private fun getApplyMethod(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[7]/table/tbody/tr/td[3]")).text
+    }
+
+    private fun getRecruitmentProcess(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[7]/table/tbody/tr/td[2]")).text
+    }
+
+    private fun getApplyDeadline(): String {
+        val applyDeadline =
+            driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[7]/table/tbody/tr/td[1]")).text
+
+        return if (applyDeadline.contains("채용시까지")) {
+            LocalDate.now().plusDays(15).format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+        } else {
+            applyDeadline
+        }
+    }
+
+    private fun getWorkSchedule(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[6]/table/tbody/tr/td[3]")).text
+    }
+
+    private fun getWorkTime(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[6]/table/tbody/tr/td[2]")).text
+            .replace("(근무시간) ", "")
+            .substringBefore("주 소정근로시간").trim()
+    }
+
+    private fun getPayInfo(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[2]/div[1]/div[1]/div[2]/div[2]/div/ul/li[2]/span")).text
+    }
+
+    private fun getCenterName(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[2]/div[1]/div[2]/div[2]/ul/li[1]/div")).text
+    }
+
+    private fun getCreatedAt(): String {
+        try {
+            return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[16]/table/tbody/tr/td[1]")).text
+        } catch (e: Exception) {
+            return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[18]/table/tbody/tr/td[1]")).text
+        }
+    }
+
+    private fun getCenterAddress(): String {
+        try {
+            val address =
+                driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[15]/div/table/tbody/tr[1]/td")).text
+            return address.replace("지도보기", "").trim().replace(Regex("\\(\\d{5}\\)"), "").trim()
+        } catch (e: Exception) {
+            val address =
+                driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[17]/div/table/tbody/tr[1]/td")).text
+            return address.replace("지도보기", "").trim().replace(Regex("\\(\\d{5}\\)"), "").trim()
+        }
+    }
+
+    private fun getContent(): String {
+        return driver.findElement(By.xpath("//*[@id=\"contents\"]/section/div/div[3]/div[3]/table/tbody/tr/td")).text
+    }
+
+    private fun getTitle(): String {
+        val em = driver.findElement(By.cssSelector(".left"))
+        return em.findElement(By.cssSelector(".tit-area .tit")).text
+    }
+
+}

--- a/idle-batch/src/main/resources/application-batch.yml
+++ b/idle-batch/src/main/resources/application-batch.yml
@@ -1,0 +1,4 @@
+spring:
+  batch:
+    jdbc:
+      initialize-schema: always

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
@@ -1,0 +1,91 @@
+package com.swm.idle.domain.jobposting.entity.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "crawled_job_posting")
+class CrawledJobPosting(
+    id: UUID,
+    title: String,
+    content: String,
+    clientAddress: String,
+    payInfo: String,
+    workTime: String,
+    workSchedule: String,
+    applyDeadline: String,
+    recruitmentProcess: String,
+    applyMethod: String,
+    requiredDocument: String,
+    centerName: String,
+    centerAddress: String,
+    directUrl: String,
+    createdAt: LocalDateTime,
+) {
+
+    @Id
+    @Column(nullable = false)
+    var id: UUID = id
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var title: String = title
+        private set
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var content: String = content
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var clientAddress: String = clientAddress
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var payInfo: String = payInfo
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var workTime: String = workTime
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var workSchedule: String = workSchedule
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var applyDeadline: String = applyDeadline
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var recruitmentProcess: String = recruitmentProcess
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var applyMethod: String = applyMethod
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var requiredDocument: String = requiredDocument
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var centerName: String = centerName
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var centerAddress: String = centerAddress
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var directUrl: String = directUrl
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var createdAt: LocalDateTime = createdAt
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/CrawledJobPostingRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/CrawledJobPostingRepository.kt
@@ -1,0 +1,9 @@
+package com.swm.idle.domain.jobposting.repository.jpa
+
+import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface CrawledJobPostingRepository : JpaRepository<CrawledJobPosting, UUID> {
+
+}

--- a/idle-presentation/build.gradle.kts
+++ b/idle-presentation/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     implementation(project(":idle-domain"))
     implementation(project(":idle-application"))
+    implementation(project(":idle-batch"))
     implementation(project(":idle-support:logging"))
     implementation(project(":idle-support:common"))
     implementation(project(":idle-support:transfer"))

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.presentation
 
 import com.swm.idle.application.common.config.ApplicationConfig
+import com.swm.idle.batch.common.config.BatchConfig
 import com.swm.idle.domain.common.config.DomainConfig
 import com.swm.idle.domain.common.config.RedisConfig
 import com.swm.idle.infrastructure.aws.common.AwsConfig
@@ -19,6 +20,7 @@ import org.springframework.context.annotation.Import
         ClientConfig::class,
         SmsConfig::class,
         AwsConfig::class,
+        BatchConfig::class,
     ]
 )
 class IdleServerApplication

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,9 @@ project(":idle-application").projectDir = file("idle-application")
 include(":idle-domain")
 project(":idle-domain").projectDir = file("idle-domain")
 
+include(":idle-batch")
+project(":idle-batch").projectDir = file("idle-batch")
+
 // infrastructure modules
 include(":idle-infrastructure:aws")
 project(":idle-infrastructure:aws").projectDir = file("idle-infrastructure/aws")


### PR DESCRIPTION
## 1. 📄 Summary
* 초기 서비스의 cold start 문제를 해결하기 위해, 구인 공고 크롤링 스크립트를 구현하였습니다.
* 매일 1천건의 공고를 크롤링하여 DB에 저장하기 위해, Spring Batch 시스템을 구축하였습니다.
* Spring Scheduler를 이용하여 스케줄링 주기를 설정하였습니다.

## 2. 🤔 고민했던 점
Spring Batch에서 지원하는 Tasklet 방식과 Chunk 방식 중 어느 방식을 적용할지에 대해 고민해 보았습니다.
두 방식의 가장 큰 차이점은, 배치 작업을 한번에 처리할지, Chunk Size 단위로 나누어 처리할지에 따라 수행 방식을 결정할 수 있다는 점입니다.

우선 저희 서비스에서는 `Tasklet` 방식을 채택하였고, 그 이유는 다음과 같습니다.

* 현재 배치 작업은 매일 등록되는 공고를 일괄적으로 크롤링하여 DB에 일괄 저장하는 것입니다. 
* Job의 수행 방식도 단순한 형태일 뿐더러, 일일 평균 1천건의 데이터는 한 Task로 일괄적으로 처리하여도 큰 무리가 없다고 판단하였습니다.

물론, 데이터의 양이 더욱 많아지거나 모니터링을 통해 수행 시간이 길어지는 경우 트랜잭션의 단위를 줄이기 위해 Chunk 방식을 고려할 것입니다.
