### PR TITLE
[IDLE-000] swagger 필드 명세에서 is로 시작하는 필드명을 명시적으로 지정

### DIFF
--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/CreateJobPostingRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/CreateJobPostingRequest.kt
@@ -42,17 +42,17 @@ data class CreateJobPostingRequest(
     val mentalStatus: MentalStatus,
     @Schema(description = "질병")
     val disease: String,
-    @Schema(description = "식사 보조 여부")
+    @Schema(description = "식사 보조 여부", name = "isMealAssistance")
     val isMealAssistance: Boolean,
-    @Schema(description = "배변 보조 여부")
+    @Schema(description = "배변 보조 여부", name = "isBowelAssistance")
     val isBowelAssistance: Boolean,
-    @Schema(description = "산책 보조 여부")
+    @Schema(description = "산책 보조 여부", name = "isWalkingAssistance")
     val isWalkingAssistance: Boolean,
     @Schema(description = "일상 보조")
     val lifeAssistance: List<LifeAssistanceType>?,
     @Schema(description = "특이사항")
     val speciality: String,
-    @Schema(description = "경력자 우대 여부")
+    @Schema(description = "경력자 우대 여부", name = "isExperiencePreferred")
     val isExperiencePreferred: Boolean,
     @Schema(description = "접수 방법", example = "[CALLING, MESSAGE]")
     val applyMethod: List<ApplyMethodType>,


### PR DESCRIPTION
## 1. 📄 Summary
* Jackson에서는 직렬화 시, boolean 필드의 변수명이 is로 시작되는 경우 'is' prefix를 무시합니다.
* 따라서 swagger 명세 상에서 실제 필드와 불일치되는 현상이 발생하여, @Schema의 name 속성을 이용해 명시적으로 지정해 주었습니다.