### PR TITLE
[IDLE-000] spring batch db driver 명시적 지정

### DIFF
--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/config/BatchConfig.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/config/BatchConfig.kt
@@ -1,9 +1,11 @@
 package com.swm.idle.batch.common.config
 
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ComponentScan(basePackages = ["com.swm.idle.batch"])
+@EnableAutoConfiguration
 class BatchConfig {
 }

--- a/idle-batch/src/main/resources/application-batch.yml
+++ b/idle-batch/src/main/resources/application-batch.yml
@@ -4,3 +4,5 @@ spring:
       initialize-schema: always
     job:
       enabled: false
+    datasource:
+      driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 1. 📄 Summary
* spring batch 설정 내에서 아래와 같은 에러가 발생되었습니다.
* Factory method 'batchDataSourceInitializer' threw exception with message: Failed to determine DatabaseDriver