### PR TITLE
[IDLE-231] 네이버맵 geocode API 적용

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
@@ -5,6 +5,7 @@ import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingJpaRepository
 import com.swm.idle.support.common.uuid.UuidCreator
 import org.springframework.stereotype.Service
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -14,7 +15,6 @@ class JobPostingService(
     private val jobPostingJpaRepository: JobPostingJpaRepository,
 ) {
 
-    // TODO : 지도 geo coding API 통해 좌표값 반환하여 저장 필요.
     fun create(
         centerId: UUID,
         jobPostingInfo: JobPostingInfo,
@@ -29,8 +29,8 @@ class JobPostingService(
                 payAmount = jobPostingInfo.payAmount,
                 roadNameAddress = jobPostingInfo.roadNameAddress,
                 lotNameAddress = jobPostingInfo.lotNameAddress,
-                longitude = null,
-                latitude = null,
+                longitude = BigDecimal(jobPostingInfo.longitude),
+                latitude = BigDecimal(jobPostingInfo.latitude),
                 clientName = jobPostingInfo.clientName,
                 gender = jobPostingInfo.gender,
                 birthYear = jobPostingInfo.birthYear.value,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/JobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/JobPostingFacadeService.kt
@@ -6,6 +6,7 @@ import com.swm.idle.application.jobposting.service.domain.JobPostingLifeAssistan
 import com.swm.idle.application.jobposting.service.domain.JobPostingService
 import com.swm.idle.application.jobposting.service.domain.JobPostingWeekdayService
 import com.swm.idle.application.jobposting.service.vo.JobPostingInfo
+import com.swm.idle.infrastructure.client.geocode.service.GeoCodeService
 import com.swm.idle.support.transfer.jobposting.CreateJobPostingRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,15 +17,22 @@ class JobPostingFacadeService(
     private val jobPostingLifeAssistanceService: JobPostingLifeAssistanceService,
     private val jobPostingWeekdayService: JobPostingWeekdayService,
     private val jobPostingApplyMethodService: JobPostingApplyMethodService,
+    private val geoCodeService: GeoCodeService,
 ) {
 
     @Transactional
     fun create(request: CreateJobPostingRequest) {
         val centerId = getUserAuthentication().userId
 
+        val geoCodeSearchResult = geoCodeService.search(request.roadNameAddress)
+
         jobPostingService.create(
             centerId = centerId,
-            jobPostingInfo = JobPostingInfo.of(request)
+            jobPostingInfo = JobPostingInfo.of(
+                request = request,
+                latitude = geoCodeSearchResult.addresses[0].y,
+                longitude = geoCodeSearchResult.addresses[0].x
+            )
         ).let { jobPosting ->
             request.lifeAssistance?.let {
                 jobPostingLifeAssistanceService.create(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/vo/JobPostingInfo.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/vo/JobPostingInfo.kt
@@ -14,6 +14,8 @@ data class JobPostingInfo(
     val payAmount: Int,
     val roadNameAddress: String,
     val lotNameAddress: String,
+    val latitude: String,
+    val longitude: String,
     val clientName: String,
     val gender: GenderType,
     val birthYear: BirthYear,
@@ -32,7 +34,11 @@ data class JobPostingInfo(
 
     companion object {
 
-        fun of(request: CreateJobPostingRequest): JobPostingInfo {
+        fun of(
+            request: CreateJobPostingRequest,
+            latitude: String,
+            longitude: String,
+        ): JobPostingInfo {
             return JobPostingInfo(
                 startTime = request.startTime,
                 endTime = request.endTime,
@@ -40,6 +46,8 @@ data class JobPostingInfo(
                 payAmount = request.payAmount,
                 roadNameAddress = request.roadNameAddress,
                 lotNameAddress = request.lotNameAddress,
+                latitude = latitude,
+                longitude = longitude,
                 clientName = request.clientName,
                 gender = request.gender,
                 birthYear = BirthYear(request.birthYear),

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/properties/ClientProperties.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/properties/ClientProperties.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.infrastructure.client.common.properties
+package com.swm.idle.infrastructure.client.businessregistration.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/service/BusinessRegistrationNumberValidationService.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/service/BusinessRegistrationNumberValidationService.kt
@@ -3,8 +3,8 @@ package com.swm.idle.infrastructure.client.businessregistration.service
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.infrastructure.client.businessregistration.dto.BusinessRegistrationNumberValidationResponse
 import com.swm.idle.infrastructure.client.businessregistration.exception.BusinessRegistrationException
+import com.swm.idle.infrastructure.client.businessregistration.properties.ClientProperties
 import com.swm.idle.infrastructure.client.businessregistration.util.BusinessRegistrationNumberValidationClient
-import com.swm.idle.infrastructure.client.common.properties.ClientProperties
 import org.springframework.stereotype.Service
 import java.net.URI
 
@@ -35,6 +35,7 @@ class BusinessRegistrationNumberValidationService(
     }
 
     companion object {
+
         const val QUERY_PARAMETER_PREFIX = "?"
         const val QUERY_PARAMETER_SUFFIX = "&"
         const val RESPONSE_TYPE = "json"

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/dto/GeoCodeSearchResultResponse.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/dto/GeoCodeSearchResultResponse.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.infrastructure.client.geocode.dto
+
+data class GeoCodeSearchResultResponse(
+    val addresses: List<AddressInfo>,
+) {
+
+    data class AddressInfo(
+        val roadAddress: String,
+        val jibunAddress: String,
+        val x: String,
+        val y: String,
+        val distance: Double,
+    )
+
+    constructor() : this(emptyList())
+
+}

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/properties/GeoCodeProperties.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/properties/GeoCodeProperties.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.infrastructure.client.geocode.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("geocode.naver")
+data class GeoCodeProperties(
+    val clientId: String,
+    val clientSecret: String,
+    val baseUrl: String,
+)

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/service/GeoCodeService.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/service/GeoCodeService.kt
@@ -1,0 +1,34 @@
+package com.swm.idle.infrastructure.client.geocode.service
+
+import com.swm.idle.infrastructure.client.geocode.dto.GeoCodeSearchResultResponse
+import com.swm.idle.infrastructure.client.geocode.properties.GeoCodeProperties
+import com.swm.idle.infrastructure.client.geocode.util.GeoCodeClient
+import org.springframework.stereotype.Service
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+
+@Service
+class GeoCodeService(
+    private val geoCodeClient: GeoCodeClient,
+    private val geoCodeProperties: GeoCodeProperties,
+) {
+
+    fun search(address: String): GeoCodeSearchResultResponse {
+        val uri = generateSearchUri(address)
+        return geoCodeClient.send(
+            uri,
+            geoCodeProperties.clientId,
+            geoCodeProperties.clientSecret,
+        )
+    }
+
+    private fun generateSearchUri(address: String): URI {
+        val baseUrl = geoCodeProperties.baseUrl
+        val encodedAddress: String = URLEncoder.encode(address, StandardCharsets.UTF_8)
+        val uriString = "$baseUrl?query=$encodedAddress"
+        return URI.create(uriString)
+    }
+
+}

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/util/GeoCodeClient.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/util/GeoCodeClient.kt
@@ -1,0 +1,23 @@
+package com.swm.idle.infrastructure.client.geocode.util
+
+import com.swm.idle.infrastructure.client.geocode.dto.GeoCodeSearchResultResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import java.net.URI
+
+@FeignClient(
+    name = "Geo-Code-Client",
+    url = "geo-code-search-url"
+)
+fun interface GeoCodeClient {
+
+    @GetMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun send(
+        uri: URI,
+        @RequestHeader("X-NCP-APIGW-API-KEY-ID") clientId: String,
+        @RequestHeader("X-NCP-APIGW-API-KEY") clientSecret: String,
+    ): GeoCodeSearchResultResponse
+
+}

--- a/idle-infrastructure/client/src/main/resources/application-client.yml
+++ b/idle-infrastructure/client/src/main/resources/application-client.yml
@@ -2,3 +2,9 @@ business-registration-number:
   api-key: ${BUSINESS_REGISTRATION_NUMBER_API_KEY}
   path: ${BUSINESS_REGISTRATION_NUMBER_API_PATH}
   search-type: ${BUSINESS_REGISTRATION_NUMBER_SEARCH_TYPE}
+
+geocode:
+  naver:
+    client-id: ${NAVER_MAP_API_CLIENT_ID}
+    client-secret: ${NAVER_MAP_API_CLIENT_SECRET}
+    base-url: ${NAVER_MAP_API_REQUEST_URL}


### PR DESCRIPTION
## 1. 📄 Summary
* 네이버맵 geocode API를 사용합니다.
* 공고 등록 시, 전달받은 도로명 주소를 이용하여 geocode API를 통해 위도 및 경도를 획득하여 함께 저장합니다.

## 2. ✏️ References
* [Naver Map API Reference](https://api.ncloud-docs.com/docs/ai-naver-mapsgeocoding-geocode)