### PR TITLE
[IDLE-291] 기존 API에서 지오코딩 API를 통해 위도, 경도를 획득하도록 변경

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
@@ -77,6 +77,21 @@ class CarerService(
         )
     }
 
+    fun updateWithoutAddress(
+        carer: Carer,
+        experienceYear: Int?,
+        introduce: String?,
+        speciality: String?,
+        jobSearchStatus: JobSearchStatus,
+    ) {
+        carer.updateWithoutAddress(
+            experienceYear = experienceYear,
+            introduce = introduce,
+            speciality = speciality,
+            jobSearchStatus = jobSearchStatus,
+        )
+    }
+
     @Transactional
     fun delete(id: UUID) {
         carerJpaRepository.deleteById(id)

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
@@ -5,6 +5,7 @@ import com.swm.idle.application.user.center.service.domain.CenterManagerService
 import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.user.center.exception.CenterException
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
+import com.swm.idle.infrastructure.client.geocode.service.GeoCodeService
 import com.swm.idle.support.transfer.user.center.GetCenterProfileResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,6 +15,7 @@ import java.util.*
 class CenterFacadeService(
     private val centerService: CenterService,
     private val centerManagerService: CenterManagerService,
+    private val geoCodeService: GeoCodeService,
 ) {
 
     fun create(
@@ -22,8 +24,6 @@ class CenterFacadeService(
         roadNameAddress: String,
         lotNumberAddress: String,
         detailedAddress: String,
-        longitude: String,
-        latitude: String,
         introduce: String?,
     ) {
         val centerManager = getUserAuthentication().userId.let {
@@ -34,6 +34,9 @@ class CenterFacadeService(
             ?.let {
                 throw CenterException.AlreadyExistCenter()
             } ?: also {
+
+            val result = geoCodeService.search(roadNameAddress)
+
             centerService.create(
                 officeNumber = officeNumber,
                 centerName = centerName,
@@ -41,8 +44,8 @@ class CenterFacadeService(
                 roadNameAddress = roadNameAddress,
                 lotNumberAddress = lotNumberAddress,
                 detailedAddress = detailedAddress,
-                longitude = longitude,
-                latitude = latitude,
+                latitude = result.addresses[0].y,
+                longitude = result.addresses[0].x,
                 introduce = introduce,
             )
         }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
@@ -105,4 +105,16 @@ class Carer(
         this.jobSearchStatus = jobSearchStatus
     }
 
+    fun updateWithoutAddress(
+        experienceYear: Int?,
+        introduce: String?,
+        speciality: String?,
+        jobSearchStatus: JobSearchStatus,
+    ) {
+        this.experienceYear = experienceYear
+        this.introduce = introduce
+        this.speciality = speciality
+        this.jobSearchStatus = jobSearchStatus
+    }
+
 }

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/exception/BusinessRegistrationException.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/exception/BusinessRegistrationException.kt
@@ -11,7 +11,8 @@ sealed class BusinessRegistrationException(
         BusinessRegistrationException(codeNumber = 1, message = message)
 
     companion object {
-        const val CODE_PREFIX = "CLIENT"
+
+        const val CODE_PREFIX = "BUSINESS-REGISTRATION"
     }
 
 }

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/exception/GeoCodeException.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/exception/GeoCodeException.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.infrastructure.client.geocode.exception
+
+import com.swm.idle.support.common.exception.CustomException
+
+sealed class GeoCodeException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class ResultNotFound(message: String = "입력한 주소로 GeoCode 검색 결과가 존재하지 않습니다.") :
+        GeoCodeException(codeNumber = 1, message = message)
+
+    companion object {
+
+        const val CODE_PREFIX = "GEOCODE"
+    }
+
+}
+

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/service/GeoCodeService.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/geocode/service/GeoCodeService.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.infrastructure.client.geocode.service
 
 import com.swm.idle.infrastructure.client.geocode.dto.GeoCodeSearchResultResponse
+import com.swm.idle.infrastructure.client.geocode.exception.GeoCodeException
 import com.swm.idle.infrastructure.client.geocode.properties.GeoCodeProperties
 import com.swm.idle.infrastructure.client.geocode.util.GeoCodeClient
 import org.springframework.stereotype.Service
@@ -17,11 +18,16 @@ class GeoCodeService(
 
     fun search(address: String): GeoCodeSearchResultResponse {
         val uri = generateSearchUri(address)
-        return geoCodeClient.send(
-            uri,
-            geoCodeProperties.clientId,
-            geoCodeProperties.clientSecret,
-        )
+        try {
+            return geoCodeClient.send(
+                uri,
+                geoCodeProperties.clientId,
+                geoCodeProperties.clientSecret,
+            )
+        } catch (e: Exception) {
+            throw GeoCodeException.ResultNotFound()
+        }
+
     }
 
     private fun generateSearchUri(address: String): URI {

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
@@ -26,8 +26,6 @@ class CarerAuthController(
             phoneNumber = PhoneNumber(request.phoneNumber),
             roadNameAddress = request.roadNameAddress,
             lotNumberAddress = request.lotNumberAddress,
-            longitude = request.longitude,
-            latitude = request.latitude,
         )
     }
 

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/controller/CarerController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/controller/CarerController.kt
@@ -25,8 +25,6 @@ class CarerController(
             experienceYear = request.experienceYear,
             roadNameAddress = request.roadNameAddress,
             lotNumberAddress = request.lotNumberAddress,
-            longitude = request.longitude,
-            latitude = request.latitude,
             introduce = request.introduce,
             speciality = request.speciality,
             jobSearchStatus = request.jobSearchStatus,

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/center/controller/CenterController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/center/controller/CenterController.kt
@@ -20,8 +20,6 @@ class CenterController(
             roadNameAddress = request.roadNameAddress,
             lotNumberAddress = request.roadNameAddress,
             detailedAddress = request.detailedAddress,
-            longitude = request.longitude,
-            latitude = request.latitude,
             introduce = request.introduce,
         )
     }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/carer/CarerJoinRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/carer/CarerJoinRequest.kt
@@ -20,8 +20,4 @@ data class CarerJoinRequest(
     val roadNameAddress: String,
     @Schema(description = "지번 주소")
     val lotNumberAddress: String,
-    @Schema(description = "경도")
-    val longitude: String,
-    @Schema(description = "위도")
-    val latitude: String,
 )

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/carer/UpdateMyCarerProfileRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/carer/UpdateMyCarerProfileRequest.kt
@@ -11,17 +11,13 @@ data class UpdateMyCarerProfileRequest(
     @Schema(description = "연차")
     val experienceYear: Int?,
     @Schema(description = "도로명 주소")
-    val roadNameAddress: String,
+    val roadNameAddress: String?,
     @Schema(description = "지번 주소")
-    val lotNumberAddress: String,
-    @Schema(description = "경도")
-    val longitude: String,
-    @Schema(description = "위도")
-    val latitude: String,
+    val lotNumberAddress: String?,
     @Schema(description = "소개글")
     val introduce: String?,
     @Schema(description = "특기")
     val speciality: String?,
     @Schema(description = "현재 구인 상태")
-    val jobSearchStatus: JobSearchStatus,
+    val jobSearchStatus: JobSearchStatus?,
 )

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/CreateCenterProfileRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/CreateCenterProfileRequest.kt
@@ -22,12 +22,6 @@ data class CreateCenterProfileRequest(
     @Schema(description = "상세 주소")
     val detailedAddress: String,
 
-    @Schema(description = "경도", example = "127.027621")
-    val longitude: String,
-
-    @Schema(description = "위도", example = "37.497942")
-    val latitude: String,
-
     @Schema(description = "소개")
     val introduce: String? = null,
 )


### PR DESCRIPTION
## 1. 📄 Summary
기존 Client에서 geocode API를 호출하여 위도 및 경도 값을 획득하는 방식에서, 서버에서 직접 geocode API를 호출하여 획득하는 구조로 변경하였습니다. 적용 대상인 몇몇 API에 대해 모두 변경을 완료하였으며 이에 따라 요청 body spec에 변동사항이 존재합니다.

### 적용 대상 API
* 센터 프로필 등록 API 
* 요양 보호사 회원가입 API  
* 요양 보호사 프로필 수정 API