### PR TITLE
[IDLE-295] PATCH API에서 non-null 필드에 null 삽입 시, 업데이트 방지 로직 추가

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
@@ -63,7 +63,7 @@ class CarerService(
         latitude: String,
         introduce: String?,
         speciality: String?,
-        jobSearchStatus: JobSearchStatus,
+        jobSearchStatus: JobSearchStatus?,
     ) {
         carer.update(
             experienceYear = experienceYear,
@@ -82,7 +82,7 @@ class CarerService(
         experienceYear: Int?,
         introduce: String?,
         speciality: String?,
-        jobSearchStatus: JobSearchStatus,
+        jobSearchStatus: JobSearchStatus?,
     ) {
         carer.updateWithoutAddress(
             experienceYear = experienceYear,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterService.kt
@@ -51,7 +51,7 @@ class CenterService(
 
     fun update(
         center: Center,
-        officeNumber: String,
+        officeNumber: String?,
         introduce: String?,
     ) {
         center.update(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
@@ -52,7 +52,7 @@ class CenterFacadeService(
     }
 
     @Transactional
-    fun update(officeNumber: String, introduce: String?) {
+    fun update(officeNumber: String?, introduce: String?) {
         val centerManager = getUserAuthentication().userId.let {
             centerManagerService.getById(it)
         }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
@@ -93,7 +93,7 @@ class Carer(
         latitude: BigDecimal,
         introduce: String?,
         speciality: String?,
-        jobSearchStatus: JobSearchStatus,
+        jobSearchStatus: JobSearchStatus?,
     ) {
         this.experienceYear = experienceYear
         this.roadNameAddress = roadNameAddress
@@ -102,19 +102,19 @@ class Carer(
         this.latitude = latitude
         this.introduce = introduce
         this.speciality = speciality
-        this.jobSearchStatus = jobSearchStatus
+        this.jobSearchStatus = jobSearchStatus ?: this.jobSearchStatus
     }
 
     fun updateWithoutAddress(
         experienceYear: Int?,
         introduce: String?,
         speciality: String?,
-        jobSearchStatus: JobSearchStatus,
+        jobSearchStatus: JobSearchStatus?,
     ) {
         this.experienceYear = experienceYear
         this.introduce = introduce
         this.speciality = speciality
-        this.jobSearchStatus = jobSearchStatus
+        this.jobSearchStatus = jobSearchStatus ?: this.jobSearchStatus
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/Center.kt
@@ -75,8 +75,8 @@ class Center(
         this.profileImageUrl = profileImageUrl
     }
 
-    fun update(officeNumber: String, introduce: String?) {
-        this.officeNumber = officeNumber
+    fun update(officeNumber: String?, introduce: String?) {
+        this.officeNumber = officeNumber ?: this.officeNumber
         this.introduce = introduce
     }
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/UpdateCenterProfileRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/UpdateCenterProfileRequest.kt
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class UpdateCenterProfileRequest(
     @Schema(description = "담당자 연락처")
-    val officeNumber: String,
+    val officeNumber: String?,
 
     @Schema(description = "소개")
     val introduce: String? = null,


### PR DESCRIPTION
## 1. 📄 Summary
PATCH 방식을 사용하는 수정 API에서, 특정 필드가 non-null로 유지되어야 할 때
변동사항이 없어 필드를 보내지 않는 경우 null이 삽입되거나, 혹은 request dto에서 `MethodArgumentNotValidException`이 발생할 수 있습니다. 

따라서 PATCH 메서드에 맞게 request dto를 모두 nullable하게 허용하되, 
실제 entity 내 update 메서드에서는 변경사항이 없다면 기존 값을 유지하도록 조치하였습니다!
