### PR TITLE
[IDLE-96] 구인 공고 삭제 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ subprojects {
 
         implementation(rootProject.libs.kotlin.reflect)
         implementation(rootProject.libs.kotlin.coroutines.core)
+        implementation(rootProject.libs.kotlin.coroutines.reactor)
         implementation(rootProject.libs.uuid.creator)
         implementation(rootProject.libs.jbcrypt)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ selenium = "4.23.0"
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
+kotlin-coroutines-reactor = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactor", version.ref = "kotlin-coroutines" }
 
 spring-boot-devtools = { group = "org.springframework.boot", name = "spring-boot-devtools", version.ref = "spring-boot" }
 spring-boot-docker-compose = { group = "org.springframework.boot", name = "spring-boot-docker-compose", version.ref = "spring-boot" }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingApplyMethodService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingApplyMethodService.kt
@@ -4,7 +4,6 @@ import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingApplyMethod
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingApplyMethodJpaRepository
 import com.swm.idle.domain.jobposting.vo.ApplyMethodType
-import com.swm.idle.support.common.uuid.UuidCreator
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -19,7 +18,6 @@ class JobPostingApplyMethodService(
     ) {
         applyMethods.map { applyMethod ->
             JobPostingApplyMethod(
-                id = UuidCreator.create(),
                 jobPostingId = jobPostingId,
                 applyMethod = applyMethod
             )
@@ -31,7 +29,7 @@ class JobPostingApplyMethodService(
         applyMethods: List<ApplyMethodType>,
     ) {
         val existingApplyMethods =
-            jobPostingApplyMethodJpaRepository.findByJobPostingId(jobPosting.id)
+            jobPostingApplyMethodJpaRepository.findAllByJobPostingId(jobPosting.id)
 
         val existingApplyMethodSet =
             existingApplyMethods?.map { it.applyMethod }?.toSet() ?: emptySet()
@@ -40,7 +38,6 @@ class JobPostingApplyMethodService(
         val toAddApplyMethods =
             newApplyMethodSet.subtract(existingApplyMethodSet).map { applyMethod ->
                 JobPostingApplyMethod(
-                    id = UuidCreator.create(),
                     jobPostingId = jobPosting.id,
                     applyMethod = applyMethod
                 )
@@ -55,6 +52,16 @@ class JobPostingApplyMethodService(
 
         if (toAddApplyMethods.isEmpty().not()) {
             jobPostingApplyMethodJpaRepository.saveAll(toAddApplyMethods.toList())
+        }
+    }
+
+    fun findByJobPostingId(jobPostingId: UUID): List<JobPostingApplyMethod>? {
+        return jobPostingApplyMethodJpaRepository.findAllByJobPostingId(jobPostingId)
+    }
+
+    fun deleteAll(jobPostingApplyMethods: List<JobPostingApplyMethod>) {
+        for (jobPostingMethod in jobPostingApplyMethods) {
+            jobPostingMethod.delete()
         }
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingLifeAssistanceService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingLifeAssistanceService.kt
@@ -4,7 +4,6 @@ import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingLifeAssistance
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingLifeAssistanceJpaRepository
 import com.swm.idle.domain.jobposting.vo.LifeAssistanceType
-import com.swm.idle.support.common.uuid.UuidCreator
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -19,7 +18,6 @@ class JobPostingLifeAssistanceService(
     ) {
         lifeAssistance.map { lifeAssistanceType ->
             JobPostingLifeAssistance(
-                id = UuidCreator.create(),
                 jobPostingId = jobPostingId,
                 lifeAssistance = lifeAssistanceType,
             )
@@ -33,18 +31,17 @@ class JobPostingLifeAssistanceService(
         lifeAssistance: List<LifeAssistanceType>,
     ) {
         val existingLifeAssistances =
-            jobPostingLifeAssistanceJpaRepository.findByJobPostingId(jobPosting.id)
+            jobPostingLifeAssistanceJpaRepository.findAllByJobPostingId(jobPosting.id)
 
         val existingLifeAssistanceSet =
             existingLifeAssistances?.map { it.lifeAssistance }?.toSet() ?: emptySet()
         val newLifeAssistanceSet = lifeAssistance.toSet()
 
         val toAddLifeAssistances =
-            newLifeAssistanceSet.subtract(existingLifeAssistanceSet).map { lifeAssistance ->
+            newLifeAssistanceSet.subtract(existingLifeAssistanceSet).map { lifeAssistanceType ->
                 JobPostingLifeAssistance(
-                    id = UuidCreator.create(),
                     jobPostingId = jobPosting.id,
-                    lifeAssistance = lifeAssistance
+                    lifeAssistance = lifeAssistanceType
                 )
             }
 
@@ -57,6 +54,16 @@ class JobPostingLifeAssistanceService(
 
         if (toAddLifeAssistances.isEmpty().not()) {
             jobPostingLifeAssistanceJpaRepository.saveAll(toAddLifeAssistances.toList())
+        }
+    }
+
+    fun findByJobPostingId(jobPostingId: UUID): List<JobPostingLifeAssistance>? {
+        return jobPostingLifeAssistanceJpaRepository.findAllByJobPostingId(jobPostingId)
+    }
+
+    fun deleteAll(jobPostingLifeAssistances: List<JobPostingLifeAssistance>) {
+        for (jobPostingLifeAssistance in jobPostingLifeAssistances) {
+            jobPostingLifeAssistance.delete()
         }
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
@@ -9,7 +9,6 @@ import com.swm.idle.domain.jobposting.vo.MentalStatus
 import com.swm.idle.domain.jobposting.vo.PayType
 import com.swm.idle.domain.user.common.enum.GenderType
 import com.swm.idle.domain.user.common.vo.BirthYear
-import com.swm.idle.support.common.uuid.UuidCreator
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -29,7 +28,6 @@ class JobPostingService(
     ): JobPosting {
         return jobPostingJpaRepository.save(
             JobPosting(
-                id = UuidCreator.create(),
                 centerId = centerId,
                 startTime = jobPostingInfo.startTime,
                 endTime = jobPostingInfo.endTime,
@@ -56,7 +54,9 @@ class JobPostingService(
                     DateTimeFormatter.ofPattern("yyyy-MM-dd")
                 ),
                 applyDeadlineType = jobPostingInfo.applyDeadlineType,
-            )
+            ).also {
+                it.active()
+            }
         )
     }
 
@@ -64,7 +64,6 @@ class JobPostingService(
         return jobPostingJpaRepository.findByIdOrNull(jobPostingId)
             ?: throw PersistenceException.ResourceNotFound("구인 공고(id=$jobPostingId)를 찾을 수 없습니다")
     }
-
 
     @Transactional
     fun updateWithoutAddress(
@@ -170,6 +169,10 @@ class JobPostingService(
             },
             applyDeadlineType = applyDeadlineType,
         )
+    }
+
+    fun delete(jobPosting: JobPosting) {
+        jobPosting.delete()
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingWeekdayService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingWeekdayService.kt
@@ -4,7 +4,6 @@ import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingWeekday
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingWeekdayJpaRepository
 import com.swm.idle.domain.jobposting.vo.Weekdays
-import com.swm.idle.support.common.uuid.UuidCreator
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -19,7 +18,6 @@ class JobPostingWeekdayService(
     ) {
         weekdays.map { weekday ->
             JobPostingWeekday(
-                id = UuidCreator.create(),
                 jobPostingId = jobPostingId,
                 weekday = weekday
             )
@@ -31,14 +29,13 @@ class JobPostingWeekdayService(
         weekdays: List<Weekdays>,
     ) {
         val existingWeekdays =
-            jobPostingWeekdayJpaRepository.findByJobPostingId(jobPosting.id)
+            jobPostingWeekdayJpaRepository.findAllByJobPostingId(jobPosting.id)
 
         val existingWeekdaySet = existingWeekdays?.map { it.weekday }?.toSet() ?: emptySet()
         val newWeekdaysSet = weekdays.toSet()
 
         val toAddWeekdays = newWeekdaysSet.subtract(existingWeekdaySet).map { weekday ->
             JobPostingWeekday(
-                id = UuidCreator.create(),
                 jobPostingId = jobPosting.id,
                 weekday = weekday
             )
@@ -53,7 +50,16 @@ class JobPostingWeekdayService(
         if (toAddWeekdays.isEmpty().not()) {
             jobPostingWeekdayJpaRepository.saveAll(toAddWeekdays.toList())
         }
+    }
 
+    fun findByJobPostingId(jobPostingId: UUID): List<JobPostingWeekday>? {
+        return jobPostingWeekdayJpaRepository.findAllByJobPostingId(jobPostingId)
+    }
+
+    fun deleteAll(jobPostingWeekdays: List<JobPostingWeekday>) {
+        for (jobPostingWeekday in jobPostingWeekdays) {
+            jobPostingWeekday.delete()
+        }
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerFacadeService.kt
@@ -69,7 +69,7 @@ class CarerFacadeService(
                 latitude = geoCodeSearchResult.addresses[0].y,
                 introduce = introduce,
                 speciality = speciality,
-                jobSearchStatus = carer.jobSearchStatus,
+                jobSearchStatus = jobSearchStatus,
             )
         } else {
             carerService.updateWithoutAddress(
@@ -77,7 +77,7 @@ class CarerFacadeService(
                 experienceYear = experienceYear,
                 introduce = introduce,
                 speciality = speciality,
-                jobSearchStatus = carer.jobSearchStatus,
+                jobSearchStatus = jobSearchStatus,
             )
         }
     }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/UserFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/UserFacadeService.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.application.user.common.service.facade
 
 import com.swm.idle.application.common.security.getUserAuthentication
+import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterManagerService
 import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.user.center.exception.CenterException
@@ -20,6 +21,7 @@ class UserFacadeService(
     private val s3ImageService: S3ImageService,
     private val centerManagerService: CenterManagerService,
     private val centerService: CenterService,
+    private val carerService: CarerService,
 ) {
 
     fun getProfileImageUploadUrl(
@@ -63,9 +65,30 @@ class UserFacadeService(
                 imageId = imageId,
                 imageFileExtension = imageFileExtension,
             )
+        } else {
+            updateCarerImageURL(
+                userType = userType,
+                imageId = imageId,
+                imageFileExtension = imageFileExtension,
+            )
         }
+    }
 
-        // TODO("요양 보호사 프로필 업로드 로직 구현")
+    fun updateCarerImageURL(
+        userType: UserType,
+        imageId: UUID,
+        imageFileExtension: ImageFileExtension,
+    ) {
+        getUserAuthentication().userId
+            .let { carerService.getById(it) }
+            .also {
+                val profileImageUrl = s3ImageService.findByIdAndExtension(
+                    userType = userType,
+                    imageId = imageId,
+                    imageFileExtension = imageFileExtension,
+                )
+                it.updateProfileImageUrl(profileImageUrl.toString())
+            }
     }
 
     fun updateCenterImageURL(

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/entity/BaseEntity.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/entity/BaseEntity.kt
@@ -1,0 +1,42 @@
+package com.swm.idle.domain.common.entity
+
+import com.swm.idle.domain.common.enum.EntityStatus
+import com.swm.idle.support.common.uuid.UuidCreator
+import jakarta.persistence.Column
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+import java.util.*
+
+@MappedSuperclass
+abstract class BaseEntity {
+
+    @Id
+    val id: UUID = UuidCreator.create()
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(255)")
+    private var entityStatus: EntityStatus = EntityStatus.ACTIVE
+
+    @CreationTimestamp
+    @Column(columnDefinition = "timestamp", updatable = false)
+    var createdAt: LocalDateTime? = null
+
+    @UpdateTimestamp
+    @Column(columnDefinition = "timestamp")
+    var updatedAt: LocalDateTime? = null
+        protected set
+
+    fun active() {
+        this.entityStatus = EntityStatus.ACTIVE
+    }
+
+    fun delete() {
+        this.entityStatus = EntityStatus.DELETED
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/enum/EntityStatus.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/enum/EntityStatus.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.domain.common.enum
+
+enum class EntityStatus {
+    ACTIVE,
+    DELETED,
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
@@ -1,5 +1,6 @@
 package com.swm.idle.domain.jobposting.entity.jpa
 
+import com.swm.idle.domain.common.entity.BaseEntity
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.vo.MentalStatus
 import com.swm.idle.domain.jobposting.vo.PayType
@@ -8,7 +9,6 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -17,7 +17,6 @@ import java.util.*
 @Entity
 @Table(name = "job_posting")
 class JobPosting(
-    id: UUID,
     centerId: UUID,
     startTime: String,
     endTime: String,
@@ -41,12 +40,7 @@ class JobPosting(
     isExperiencePreferred: Boolean,
     applyDeadline: LocalDate,
     applyDeadlineType: ApplyDeadlineType,
-) {
-
-    @Id
-    @Column(nullable = false)
-    var id: UUID = id
-        private set
+) : BaseEntity() {
 
     @Column(nullable = false)
     var centerId: UUID = centerId

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingApplyMethod.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingApplyMethod.kt
@@ -1,26 +1,20 @@
 package com.swm.idle.domain.jobposting.entity.jpa
 
+import com.swm.idle.domain.common.entity.BaseEntity
 import com.swm.idle.domain.jobposting.vo.ApplyMethodType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.util.*
 
 @Entity
 @Table(name = "job_posting_apply_method")
 class JobPostingApplyMethod(
-    id: UUID,
     jobPostingId: UUID,
     applyMethod: ApplyMethodType,
-) {
-
-    @Id
-    @Column(nullable = false)
-    var id: UUID = id
-        private set
+) : BaseEntity() {
 
     @Column(nullable = false)
     var jobPostingId: UUID = jobPostingId

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingLifeAssistance.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingLifeAssistance.kt
@@ -1,26 +1,20 @@
 package com.swm.idle.domain.jobposting.entity.jpa
 
+import com.swm.idle.domain.common.entity.BaseEntity
 import com.swm.idle.domain.jobposting.vo.LifeAssistanceType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.util.*
 
 @Entity
 @Table(name = "job_posting_life_assistance")
 class JobPostingLifeAssistance(
-    id: UUID,
     jobPostingId: UUID,
     lifeAssistance: LifeAssistanceType,
-) {
-
-    @Id
-    @Column(nullable = false)
-    var id: UUID = id
-        private set
+) : BaseEntity() {
 
     @Column(nullable = false)
     var jobPostingId: UUID = jobPostingId

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingWeekday.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingWeekday.kt
@@ -1,26 +1,20 @@
 package com.swm.idle.domain.jobposting.entity.jpa
 
+import com.swm.idle.domain.common.entity.BaseEntity
 import com.swm.idle.domain.jobposting.vo.Weekdays
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.util.*
 
 @Entity
 @Table(name = "job_posting_weekday")
 class JobPostingWeekday(
-    id: UUID,
     jobPostingId: UUID,
     weekday: Weekdays,
-) {
-
-    @Id
-    @Column(nullable = false)
-    var id: UUID = id
-        private set
+) : BaseEntity() {
 
     @Column(nullable = false)
     var jobPostingId: UUID = jobPostingId

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingApplyMethodJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingApplyMethodJpaRepository.kt
@@ -2,12 +2,23 @@ package com.swm.idle.domain.jobposting.repository.jpa
 
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingApplyMethod
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
 interface JobPostingApplyMethodJpaRepository : JpaRepository<JobPostingApplyMethod, UUID> {
 
-    fun findByJobPostingId(id: UUID): List<JobPostingApplyMethod>?
+    @Query(
+        value =
+        """
+            SELECT *
+            FROM job_posting_apply_method as jpam
+            WHERE jpam.entity_status = 'ACTIVE'
+            AND jpam.job_posting_id = :jobPostingId
+        """,
+        nativeQuery = true
+    )
+    fun findAllByJobPostingId(jobPostingId: UUID): List<JobPostingApplyMethod>?
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingLifeAssistanceJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingLifeAssistanceJpaRepository.kt
@@ -2,12 +2,23 @@ package com.swm.idle.domain.jobposting.repository.jpa
 
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingLifeAssistance
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
 interface JobPostingLifeAssistanceJpaRepository : JpaRepository<JobPostingLifeAssistance, UUID> {
 
-    fun findByJobPostingId(id: UUID): List<JobPostingLifeAssistance>?
+    @Query(
+        value =
+        """
+            SELECT * 
+            FROM job_posting_life_assistance as jpla
+            WHERE jpla.entity_status = 'ACTIVE'
+            AND jpla.job_posting_id = :jobPostingId
+        """,
+        nativeQuery = true
+    )
+    fun findAllByJobPostingId(jobPostingId: UUID): List<JobPostingLifeAssistance>?
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingWeekdayJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingWeekdayJpaRepository.kt
@@ -2,12 +2,23 @@ package com.swm.idle.domain.jobposting.repository.jpa
 
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingWeekday
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
 interface JobPostingWeekdayJpaRepository : JpaRepository<JobPostingWeekday, UUID> {
 
-    fun findByJobPostingId(id: UUID): List<JobPostingWeekday>?
+    @Query(
+        value =
+        """
+            SELECT *
+            FROM job_posting_weekday as jw
+            WHERE jw.entity_status = 'ACTIVE'
+            AND jw.job_posting_id = :jobPostingId
+        """,
+        nativeQuery = true
+    )
+    fun findAllByJobPostingId(jobPostingId: UUID): List<JobPostingWeekday>?
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
@@ -117,4 +117,8 @@ class Carer(
         this.jobSearchStatus = jobSearchStatus ?: this.jobSearchStatus
     }
 
+    fun updateProfileImageUrl(profileImageUrl: String) {
+        this.profileImageUrl = profileImageUrl
+    }
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/JobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/JobPostingApi.kt
@@ -6,6 +6,7 @@ import com.swm.idle.support.transfer.jobposting.UpdateJobPostingRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -22,7 +23,7 @@ interface JobPostingApi {
     @Operation(summary = "구인 공고 등록 API")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun createJobPosting(
+    suspend fun createJobPosting(
         @RequestBody request: CreateJobPostingRequest,
     )
 
@@ -31,8 +32,16 @@ interface JobPostingApi {
     @PatchMapping("/{job-posting-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun updateJobPosting(
-        @PathVariable("job-posting-id") jobPostingId: UUID,
+        @PathVariable(value = "job-posting-id") jobPostingId: UUID,
         @RequestBody request: UpdateJobPostingRequest,
+    )
+
+    @Secured
+    @Operation(summary = "구인 공고 삭제 API")
+    @DeleteMapping("/{job-posting-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteJobPosting(
+        @PathVariable(value = "job-posting-id") jobPostingId: UUID,
     )
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/JobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/JobPostingController.kt
@@ -12,7 +12,7 @@ class JobPostingController(
     private val jobPostingFacadeService: JobPostingFacadeService,
 ) : JobPostingApi {
 
-    override fun createJobPosting(request: CreateJobPostingRequest) {
+    override suspend fun createJobPosting(request: CreateJobPostingRequest) {
         jobPostingFacadeService.create(request = request)
     }
 
@@ -24,6 +24,10 @@ class JobPostingController(
             jobPostingId = jobPostingId,
             request = request
         )
+    }
+
+    override fun deleteJobPosting(jobPostingId: UUID) {
+        jobPostingFacadeService.delete(jobPostingId)
     }
 
 }


### PR DESCRIPTION
## 1. 📄 Summary
* 구인 공고 삭제 API 를 구현했습니다. 
* BaseEntity를 정의하고, 해당 클래스 내에서 soft-delete를 적용하였습니다.
* 요양 보호사 프로필 업로드 로직을 함께 추가하였습니다.