### PR TITLE
[IDLE-243] 공고 채용 종료 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
@@ -175,4 +175,8 @@ class JobPostingService(
         jobPosting.delete()
     }
 
+    fun updateToComplete(jobPosting: JobPosting) {
+        jobPosting.updateToComplete()
+    }
+
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/JobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/JobPostingFacadeService.kt
@@ -167,4 +167,11 @@ class JobPostingFacadeService(
         }
     }
 
+    @Transactional
+    fun updateToComplete(jobPostingId: UUID) {
+        jobPostingService.getById(jobPostingId).let {
+            jobPostingService.updateToComplete(it)
+        }
+    }
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
@@ -2,6 +2,7 @@ package com.swm.idle.domain.jobposting.entity.jpa
 
 import com.swm.idle.domain.common.entity.BaseEntity
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
+import com.swm.idle.domain.jobposting.vo.JobPostingStatus
 import com.swm.idle.domain.jobposting.vo.MentalStatus
 import com.swm.idle.domain.jobposting.vo.PayType
 import com.swm.idle.domain.user.common.enum.GenderType
@@ -138,6 +139,11 @@ class JobPosting(
     var applyDeadlineType: ApplyDeadlineType = applyDeadlineType
         private set
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var jobPostingStatus: JobPostingStatus = JobPostingStatus.IN_PROGRESS
+        private set
+
     fun update(
         startTime: String?,
         endTime: String?,
@@ -224,6 +230,10 @@ class JobPosting(
         this.isExperiencePreferred = isExperiencePreferred ?: this.isExperiencePreferred
         this.applyDeadline = applyDeadline ?: this.applyDeadline
         this.applyDeadlineType = applyDeadlineType ?: this.applyDeadlineType
+    }
+
+    fun updateToComplete() {
+        this.jobPostingStatus = JobPostingStatus.COMPLETED
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/vo/JobPostingStatus.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/vo/JobPostingStatus.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.domain.jobposting.vo
+
+enum class JobPostingStatus {
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/JobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/JobPostingApi.kt
@@ -44,4 +44,12 @@ interface JobPostingApi {
         @PathVariable(value = "job-posting-id") jobPostingId: UUID,
     )
 
+    @Secured
+    @Operation(summary = "구인 공고 채용 종료 API")
+    @PatchMapping("/{job-posting-id}/end")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun completeJobPosting(
+        @PathVariable(value = "job-posting-id") jobPostingId: UUID,
+    )
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/JobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/JobPostingController.kt
@@ -30,4 +30,8 @@ class JobPostingController(
         jobPostingFacadeService.delete(jobPostingId)
     }
 
+    override fun completeJobPosting(jobPostingId: UUID) {
+        jobPostingFacadeService.updateToComplete(jobPostingId)
+    }
+
 }


### PR DESCRIPTION
## 1. 📄 Summary
* 공고 채용 종료 API를 구현하였습니다.

## 2. ✏️ Documentation
- [공고 채용 종료 API] PATCH /api/v1/job-postings/{job-posting-id}/end
    - request
        - method & path: `PATCH /api/v1/job-postings/{job-posting-id}/end`
    - response
        - 정상 처리된 경우
            - status code: `204 No Content`

## 3. 🤔 고민했던 점
공고 채용 종료 상태를 변경하기 위해 Spring Data Jpa 사용 시, 변경 감지가 동작하지 않는 문제가 있었습니다.

[기존 코드]

Facade Service
```kotlin
    fun updateToComplete(jobPostingId: UUID) {
        jobPostingService.getById(jobPostingId).let {
            jobPostingService.updateToComplete(it)
        }
    }
```

Service
```kotlin
    @Transactional
    fun updateToComplete(jobPosting: JobPosting) {
        jobPosting.updateToComplete()
    }
```

기본적으로 변경 감지(Dirty Checking)은 트랜잭션 커밋 시점에 적용되므로, @Transactional 등을 이용해 명시적으로 트랜잭션 범위 내에서 실행되도록 해야 합니다. 하지만, update문을 @Transactional을 이용해 트랜잭션 범위를 잡아 주었는데도 실제 DB에는 반영되지 않았습니다.

[변경된 코드]

Facade Service
```kotlin
    @Transactional
    fun updateToComplete(jobPostingId: UUID) {
        jobPostingService.getById(jobPostingId).let {
            jobPostingService.updateToComplete(it)
        }
    }
```

Service
```kotlin
    fun updateToComplete(jobPosting: JobPosting) {
        jobPosting.updateToComplete()
    }
```

위의 FacadeService의 updateToComplete() 전체를 @Transactional을 이용해 같은 트랜잭션 범위로 설정하니 비로소 동작하게 되었습니다. 

그 이유는, 우선 JobPosting 조회를 위해 읽기 전용 트랜잭션이 실행되며 JobPosting을 DB에서 조회합니다. 
이후 update를 하기 위한 시점에서, 앞선 트랜잭션은 이미 종료되었으며 현재 조회한 JobPosting은 JPA 내부에서 준영속(Detached) 상태로 변한 값입니다. 

해당 값을 이용해 변경 감지를 시도하여도, 이미 영속성 컨텍스트에서 분리되어 있는 상태이므로 변경 감지(Dirty Checking)이 동작하지 않습니다.