### PR TITLE
[IDLE-000] CD 불필요한 스크립트 제거

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -70,7 +70,6 @@ jobs:
           key: ${{ secrets.DEV_INSTANCE_KEY }}
           script: |
             echo "${{ secrets.DOCKER_PASSWORD }}" | sudo docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            sudo docker-compose -f ~/app/docker/compose-dev.yaml down --rmi all
             sudo docker-compose -f ~/app/docker/compose-dev.yaml pull
             sudo docker-compose -f ~/app/docker/compose-dev.yaml up -d --force-recreate
 


### PR DESCRIPTION
## 1. 📄 Summary
* docker compose에서 실행중인 컨테이너 중지를 위해 docker compose down 명령어를 사용하였지만, 해당 명령어에서는 단순히 컨테이너 뿐만 아니라 network, volume까지 모두 삭제되는 문제가 있었습니다.
* docker compose up -d --force-recreate를 통해 volume 삭제 없이 컨테이너를 삭제하고 다시 빌드하는 역할을 수행할 수 있습니다.