### PR TITLE
[IDLE-000] 공고 마감 기한 nullable하게 변경

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
@@ -49,10 +49,12 @@ class JobPostingService(
                 isWalkingAssistance = jobPostingInfo.isWalkingAssistance,
                 extraRequirement = jobPostingInfo.extraRequirement,
                 isExperiencePreferred = jobPostingInfo.isExperiencePreferred,
-                applyDeadline = LocalDate.parse(
-                    jobPostingInfo.applyDeadline,
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd")
-                ),
+                applyDeadline = jobPostingInfo.applyDeadline?.let {
+                    LocalDate.parse(
+                        it,
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd")
+                    )
+                },
                 applyDeadlineType = jobPostingInfo.applyDeadlineType,
             ).also {
                 it.active()

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/vo/JobPostingInfo.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/vo/JobPostingInfo.kt
@@ -28,7 +28,7 @@ data class JobPostingInfo(
     val isWalkingAssistance: Boolean,
     val extraRequirement: String?,
     val isExperiencePreferred: Boolean,
-    val applyDeadline: String,
+    val applyDeadline: String?,
     val applyDeadlineType: ApplyDeadlineType,
 ) {
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
@@ -39,7 +39,7 @@ class JobPosting(
     isWalkingAssistance: Boolean,
     extraRequirement: String?,
     isExperiencePreferred: Boolean,
-    applyDeadline: LocalDate,
+    applyDeadline: LocalDate?,
     applyDeadlineType: ApplyDeadlineType,
 ) : BaseEntity() {
 
@@ -130,8 +130,8 @@ class JobPosting(
     var isExperiencePreferred: Boolean = isExperiencePreferred
         private set
 
-    @Column(nullable = false)
-    var applyDeadline: LocalDate = applyDeadline
+    @Column(nullable = true)
+    var applyDeadline: LocalDate? = applyDeadline
         private set
 
     @Enumerated(EnumType.STRING)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/CreateJobPostingRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/CreateJobPostingRequest.kt
@@ -66,7 +66,7 @@ data class CreateJobPostingRequest(
     @Schema(description = "접수 방법", example = "[CALLING, MESSAGE]")
     val applyMethod: List<ApplyMethodType>,
     @Schema(description = "접수 마감 일자")
-    val applyDeadline: String,
+    val applyDeadline: String? = null,
     @Schema(description = "접수 마감일 상태")
     val applyDeadlineType: ApplyDeadlineType,
 )


### PR DESCRIPTION
## 1. 📄 Summary
* 공고 마감 기한 정책에서 '채용시까지' 로 설정된 경우 마감 기한 필드를 null으로 관리하기로 결정됨에 따라, 마감 기한 필드를 nullable하게 변경하였습니다.