### PR TITLE
[IDLE-305] 요양보호사 공고 전체 조회 API 및 커서 방식 페이지네이션 방식 적용

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,7 +93,6 @@ jakarta-persistence-api = { group = "jakarta.persistence", name = "jakarta.persi
 
 locationtech = { group = "org.locationtech.jts", name = "jts-core", version.ref = "jts-core"}
 [plugins]
-
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-cloud" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-boot-dependency-management" }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/common/converter/PointConverter.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/common/converter/PointConverter.kt
@@ -14,7 +14,10 @@ object PointConverter {
         SPATIAL_REFERENCE_IDENTIFIER_NUMBER
     )
 
-    fun convertToPoint(latitude: Double, longitude: Double): Point {
+    fun convertToPoint(
+        latitude: Double,
+        longitude: Double,
+    ): Point {
         return geometryFactory.createPoint(Coordinate(longitude, latitude))
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/QueryDslConfig.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/QueryDslConfig.kt
@@ -1,5 +1,6 @@
 package com.swm.idle.domain.common.config
 
+import com.querydsl.jpa.JPQLTemplates
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
@@ -13,6 +14,7 @@ class QueryDslConfig {
     private lateinit var entityManager: EntityManager
 
     @Bean
-    fun jpaQueryFactory() =
-        JPAQueryFactory(entityManager)
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager)
+    }
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysDto.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysDto.kt
@@ -1,0 +1,9 @@
+package com.swm.idle.domain.common.dto
+
+import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
+import com.swm.idle.domain.jobposting.entity.jpa.JobPostingWeekday
+
+data class JobPostingWithWeekdaysDto(
+    val jobPosting: JobPosting,
+    val jobPostingWeekdays: List<JobPostingWeekday>,
+)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -1,10 +1,12 @@
 package com.swm.idle.domain.jobposting.repository.querydsl
 
+import com.querydsl.core.group.GroupBy.groupBy
+import com.querydsl.core.group.GroupBy.list
+import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
-import com.querydsl.core.types.dsl.ComparablePath
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
+import com.swm.idle.domain.common.dto.JobPostingWithWeekdaysDto
 import com.swm.idle.domain.jobposting.entity.jpa.QJobPosting.jobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.QJobPostingWeekday.jobPostingWeekday
 import org.locationtech.jts.geom.Point
@@ -16,41 +18,82 @@ class JobPostingSpatialQueryRepository(
     private val jpaQueryFactory: JPAQueryFactory,
 ) {
 
-    fun findByInRange(
-        jobPostingId: UUID,
+    //    fun findAllWithWeekdaysInRange(
+//        location: Point,
+//        next: UUID?,
+//        limit: Long,
+//    ): List<JobPostingWithWeekdaysDto> {
+//        return jpaQueryFactory
+//            .select(jobPosting, jobPostingWeekday)
+//            .from(jobPosting)
+//            .leftJoin(jobPostingWeekday).fetchJoin()
+//            .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
+//            .where(
+//                isExistInRange(location)
+//                    .and(next?.let { jobPosting.id.loe(it) })
+//            )
+//            .limit(limit)
+//            .transform(
+//                groupBy(jobPosting.id)
+//                    .list(
+//                        Projections.constructor(
+//                            JobPostingWithWeekdaysDto::class.java,
+//                            jobPosting,
+//                            list(
+//                                jobPostingWeekday
+//                            )
+//                        )
+//                    )
+//            )
+//
+//    }
+    fun findAllWithWeekdaysInRange(
         location: Point,
-        pageSize: Long,
-    ): List<JobPosting> {
-
-        return jpaQueryFactory
-            .selectFrom(jobPosting)
-            .innerJoin(jobPostingWeekday).on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
-            .fetchJoin()
+        next: UUID?,
+        limit: Long,
+    ): List<JobPostingWithWeekdaysDto> {
+        // Step 1: 제한된 개수의 JobPosting ID를 가져옴
+        val jobPostingIds = jpaQueryFactory
+            .select(jobPosting.id)
+            .from(jobPosting)
             .where(
-                isExistInRange(location)?.and(lowerThanJobPostingId(jobPosting.id))
+                isExistInRange(location)
+                    .and(next?.let { jobPosting.id.goe(it) })
             )
-            .orderBy(jobPosting.id.desc())
-            .limit(pageSize)
-            .fetch();
-    }
+            .limit(limit)
+            .fetch()
 
-    private fun isExistInRange(location: Point): BooleanExpression? {
-        if (location == null) {
-            return null;
+        if (jobPostingIds.isEmpty()) {
+            return emptyList()
         }
 
+        // Step 2: 가져온 JobPosting ID에 해당하는 JobPosting과 그에 연결된 Weekdays를 가져옴
+        return jpaQueryFactory
+            .select(jobPosting, jobPostingWeekday)
+            .from(jobPosting)
+            .leftJoin(jobPostingWeekday).fetchJoin()
+            .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
+            .where(jobPosting.id.`in`(jobPostingIds))
+            .transform(
+                groupBy(jobPosting.id)
+                    .list(
+                        Projections.constructor(
+                            JobPostingWithWeekdaysDto::class.java,
+                            jobPosting,
+                            list(jobPostingWeekday)
+                        )
+                    )
+            )
+    }
+
+
+    private fun isExistInRange(
+        location: Point,
+    ): BooleanExpression {
         return Expressions.booleanTemplate(
-            "ST_Contains(ST_BUFFER({0}, 3000, {1})",
+            "ST_Contains(ST_BUFFER({0}, 3000), {1})",
             location,
-            jobPosting.location
+            jobPosting.location,
         )
-    }
-
-    private fun lowerThanJobPostingId(jobPostingId: ComparablePath<UUID>): BooleanExpression? {
-        if (jobPostingId == null) {
-            return null;
-        }
-
-        return jobPosting.id.lt(jobPostingId)
     }
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -18,35 +18,6 @@ class JobPostingSpatialQueryRepository(
     private val jpaQueryFactory: JPAQueryFactory,
 ) {
 
-    //    fun findAllWithWeekdaysInRange(
-//        location: Point,
-//        next: UUID?,
-//        limit: Long,
-//    ): List<JobPostingWithWeekdaysDto> {
-//        return jpaQueryFactory
-//            .select(jobPosting, jobPostingWeekday)
-//            .from(jobPosting)
-//            .leftJoin(jobPostingWeekday).fetchJoin()
-//            .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
-//            .where(
-//                isExistInRange(location)
-//                    .and(next?.let { jobPosting.id.loe(it) })
-//            )
-//            .limit(limit)
-//            .transform(
-//                groupBy(jobPosting.id)
-//                    .list(
-//                        Projections.constructor(
-//                            JobPostingWithWeekdaysDto::class.java,
-//                            jobPosting,
-//                            list(
-//                                jobPostingWeekday
-//                            )
-//                        )
-//                    )
-//            )
-//
-//    }
     fun findAllWithWeekdaysInRange(
         location: Point,
         next: UUID?,
@@ -83,7 +54,6 @@ class JobPostingSpatialQueryRepository(
                     )
             )
     }
-
 
     private fun isExistInRange(
         location: Point,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -52,7 +52,6 @@ class JobPostingSpatialQueryRepository(
         next: UUID?,
         limit: Long,
     ): List<JobPostingWithWeekdaysDto> {
-        // Step 1: 제한된 개수의 JobPosting ID를 가져옴
         val jobPostingIds = jpaQueryFactory
             .select(jobPosting.id)
             .from(jobPosting)
@@ -67,7 +66,6 @@ class JobPostingSpatialQueryRepository(
             return emptyList()
         }
 
-        // Step 2: 가져온 JobPosting ID에 해당하는 JobPosting과 그에 연결된 Weekdays를 가져옴
         return jpaQueryFactory
             .select(jobPosting, jobPostingWeekday)
             .from(jobPosting)

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -20,7 +20,7 @@ spring:
       on-profile: local
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: true
     properties:
         hibernate.format_sql: true

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
@@ -2,6 +2,8 @@ package com.swm.idle.presentation.jobposting.api
 
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
+import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollRequest
+import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingsScrollResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -20,5 +22,13 @@ interface CarerJobPostingApi {
     @GetMapping("/{job-posting-id}/carer")
     @ResponseStatus(HttpStatus.OK)
     fun getJobPosting(@PathVariable(value = "job-posting-id") jobPostingId: UUID): CarerJobPostingResponse
+
+    @Secured
+    @Operation(summary = "요양 보호사 구인 공고 전체 조회 API(3km 내 검색, 최근 등록 순 정렬)")
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    fun getJobPostingList(
+        request: CarerJobPostingScrollRequest,
+    ): CarerJobPostingsScrollResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
@@ -1,18 +1,38 @@
 package com.swm.idle.presentation.jobposting.controller
 
+import com.swm.idle.application.common.converter.PointConverter
+import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.jobposting.service.facade.CarerJobPostingFacadeService
+import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.presentation.jobposting.api.CarerJobPostingApi
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
+import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollRequest
+import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingsScrollResponse
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
 @RestController
 class CarerJobPostingController(
     private val carerJobPostingFacadeService: CarerJobPostingFacadeService,
+    private val carerService: CarerService,
 ) : CarerJobPostingApi {
 
     override fun getJobPosting(jobPostingId: UUID): CarerJobPostingResponse {
         return carerJobPostingFacadeService.getJobPosting(jobPostingId)
+    }
+
+    override fun getJobPostingList(request: CarerJobPostingScrollRequest): CarerJobPostingsScrollResponse {
+        val carer = carerService.getById(getUserAuthentication().userId)
+
+        val location = PointConverter.convertToPoint(
+            latitude = carer.latitude.toDouble(),
+            longitude = carer.longitude.toDouble(),
+        )
+
+        return carerJobPostingFacadeService.getJobPostingsInRange(
+            request = request,
+            location = location
+        )
     }
 
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/common/ScrollRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/common/ScrollRequest.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.support.transfer.common
+
+abstract class ScrollRequest<N>(
+    open val next: N,
+    open val limit: Long,
+)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/common/ScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/common/ScrollResponse.kt
@@ -1,0 +1,7 @@
+package com.swm.idle.support.transfer.common
+
+abstract class ScrollResponse<T, N>(
+    open val items: List<T>,
+    open val next: N,
+    open val total: Int,
+)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingScrollRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingScrollRequest.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 @ParameterObject
 data class CarerJobPostingScrollRequest(
-    @Parameter(required = false, example = "이전 요청의 마지막 item ID. 최초 요청시에는 null")
+    @Parameter(required = false, example = "다음 요청 시에 최초로 조회되는 ID. 최초 요청시에는 null")
     override val next: UUID? = null,
     @Parameter(required = false, example = "조회 item 수 : default 10")
     override val limit: Long = 10,

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingScrollRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingScrollRequest.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.support.transfer.jobposting.carer
+
+import com.swm.idle.support.transfer.common.ScrollRequest
+import io.swagger.v3.oas.annotations.Parameter
+import org.springdoc.core.annotations.ParameterObject
+import java.util.*
+
+@ParameterObject
+data class CarerJobPostingScrollRequest(
+    @Parameter(required = false, example = "이전 요청의 마지막 item ID. 최초 요청시에는 null")
+    override val next: UUID? = null,
+    @Parameter(required = false, example = "조회 item 수 : default 10")
+    override val limit: Long = 10,
+) : ScrollRequest<UUID?>(
+    next = next,
+    limit = limit,
+)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingsScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingsScrollResponse.kt
@@ -1,0 +1,117 @@
+package com.swm.idle.support.transfer.jobposting.carer
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.swm.idle.domain.common.dto.JobPostingWithWeekdaysDto
+import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
+import com.swm.idle.domain.jobposting.vo.PayType
+import com.swm.idle.domain.jobposting.vo.Weekdays
+import com.swm.idle.domain.user.common.enum.GenderType
+import com.swm.idle.domain.user.common.vo.BirthYear
+import com.swm.idle.support.transfer.common.ScrollResponse
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.util.*
+
+@Schema(
+    name = "JobPostingsResponse",
+    description = "요양 보호사 공고 반경범위 검색 결과 응답",
+)
+data class CarerJobPostingsScrollResponse(
+    override val items: List<JobPostingDto>,
+    override val next: UUID?,
+    override val total: Int,
+) : ScrollResponse<CarerJobPostingsScrollResponse.JobPostingDto, UUID?>(
+    items = items,
+    next = next,
+    total = total,
+) {
+
+    data class JobPostingDto(
+        @Schema(description = "공고 ID")
+        val id: UUID,
+
+        @Schema(description = "근무 요일", example = "[\"MONDAY\", \"TUESDAY\"]")
+        val weekdays: List<Weekdays>,
+
+        @Schema(description = "근무 시작 시간", example = "09:00")
+        val startTime: String,
+
+        @Schema(description = "근무 종료 시간", example = "18:00")
+        val endTime: String,
+
+        @Schema(description = "급여 유형", example = "HOURLY")
+        val payType: PayType,
+
+        @Schema(description = "급여 금액", example = "10000")
+        val payAmount: Int,
+
+        @Schema(description = "도로명 주소")
+        val roadNameAddress: String,
+
+        @Schema(description = "지번 주소")
+        val lotNumberAddress: String,
+
+        @Schema(description = "고객 성별", example = "MAN")
+        val gender: GenderType,
+
+        @Schema(description = "나이", example = "65")
+        val age: Int,
+
+        @Schema(description = "장기 요양 등급", example = "3")
+        val careLevel: Int,
+
+        @get:JsonProperty("isExperiencePreferred")
+        @param:JsonProperty("isExperiencePreferred")
+        @Schema(description = "경력자 우대 여부", example = "true")
+        val isExperiencePreferred: Boolean,
+
+        @Schema(description = "지원 마감 유형", example = "LIMITED")
+        val applyDeadlineType: ApplyDeadlineType,
+
+        @Schema(description = "지원 마감일", example = "2024-07-30")
+        val applyDeadline: LocalDate?,
+    ) {
+
+        companion object {
+
+            fun from(
+                jobPostingWithWeekdaysDto: JobPostingWithWeekdaysDto,
+            ): JobPostingDto {
+                return JobPostingDto(
+                    id = jobPostingWithWeekdaysDto.jobPosting.id,
+                    weekdays = jobPostingWithWeekdaysDto.jobPostingWeekdays.map { it.weekday },
+                    startTime = jobPostingWithWeekdaysDto.jobPosting.startTime,
+                    endTime = jobPostingWithWeekdaysDto.jobPosting.endTime,
+                    payType = jobPostingWithWeekdaysDto.jobPosting.payType,
+                    payAmount = jobPostingWithWeekdaysDto.jobPosting.payAmount,
+                    roadNameAddress = jobPostingWithWeekdaysDto.jobPosting.roadNameAddress,
+                    lotNumberAddress = jobPostingWithWeekdaysDto.jobPosting.lotNumberAddress,
+                    gender = jobPostingWithWeekdaysDto.jobPosting.gender,
+                    age = BirthYear.calculateAge(jobPostingWithWeekdaysDto.jobPosting.birthYear),
+                    careLevel = jobPostingWithWeekdaysDto.jobPosting.careLevel,
+                    isExperiencePreferred = jobPostingWithWeekdaysDto.jobPosting.isExperiencePreferred,
+                    applyDeadline = jobPostingWithWeekdaysDto.jobPosting.applyDeadline,
+                    applyDeadlineType = jobPostingWithWeekdaysDto.jobPosting.applyDeadlineType,
+                )
+            }
+
+        }
+    }
+
+    companion object {
+
+        fun from(
+            items: List<JobPostingWithWeekdaysDto>,
+            next: UUID?,
+            total: Int,
+        ): CarerJobPostingsScrollResponse {
+            return CarerJobPostingsScrollResponse(
+                items = items.map(JobPostingDto::from),
+                next = next,
+                total = total,
+            )
+        }
+    }
+
+}
+


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사 공고 전체 조회 API를 구현하였습니다.
* 기존 offset 방식 페이지네이션에서 커서 방식 페이지네이션으로 전환하였습니다.
* 현재 기본값으로 채택되어 있는 정책은 요양 보호사의 현 위치 기준 반경범위 **3km** 내의 모든 공고를 필터링하여 탐색합니다.

## 2. ✏️ Documentation
- [요양 보호사 공고 전체 조회 API] GET /api/v1/job-postings
    - request
        - method & path: `GET /api/v1/job-postings`
        - **query parameters**
            - next(UUID, String)
                - **해당 요청에 조회할 공고의 ID, 즉 커서 방식 페이지네이션의 커서 역할**
                - 초기 요청시에는 null
            - limit(number)
                - 한 페이지에서 조회할 데이터의 수를 지정할 수 있습니다.
                - null인 경우, 기본값은 **10**입니다.
        
        - example path(limit를 임의로 3개로 지정한 경우)
        **`http://localhost:8080/api/v1/job-postings?next=019154ba-4723-761d-9351-b72499ab1eb1&limit=3`**
    - response
        - 정상 처리된 경우
            - status code: `200 OK`
            - body
                
                ```json
                {
                  "items": [
                    {
                      "isExperiencePreferred": false,
                      "id": "019154ba-4723-761d-9351-b72499ab1eb1",
                      "weekdays": [
                        "TUESDAY",
                        "MONDAY"
                      ],
                      "startTime": "09:00",
                      "endTime": "12:00",
                      "payType": "HOURLY",
                      "payAmount": 12500,
                      "roadNameAddress": "서울시 강남구 테헤란로 311",
                      "lotNumberAddress": "서울시 강남구 역삼동 1234",
                      "gender": "MAN",
                      "age": 26,
                      "careLevel": 5,
                      "applyDeadlineType": "LIMITED",
                      "applyDeadline": "2024-08-09" // nullable
                    }
                  ],
                  "next": "019154ba-48a8-7b65-b5ee-df530d5a0a34", 
                  "total": 1
                }
                ```
                
                - items : 현재 조회된 공고의 데이터들
                - next : **다음 페이지에서 최초로 조회되는 공고 ID, 연속적으로 페이지 조회 시에는 해당 값을 request 시 query parameter 인자로 전달.**
                - total : 현재 페이지에서 조회되는 item의 수

## 3. 🤔 고민했던 점

현재 프로젝트에서는 성능 및 관리의 이점을 위해 FK를 별도로 사용하지 않고 있는데요, 

1. QueryDSL을 사용함에 따라 FK가 없는 경우에 조인이 되지 않는 문제가 있었습니다.

이는 아래와 같이 join 시 명시적으로 on 조건절을 이용함으로써 해결할 수 있었습니다.

```kotlin
join(엔티티).on(키.eq(키))
```

2. 일대다 컬렉션 조회에서 limit 쿼리가 1 쪽이 아닌, 다 쪽의 원소 개수만큼 limit되는 현상

[기존 코드]
```kotlin
    fun findAllWithWeekdaysInRange(
        location: Point,
        next: UUID?,
        limit: Long,
    ): List<JobPostingWithWeekdaysDto> {
        return jpaQueryFactory
            .select(jobPosting, jobPostingWeekday)
            .from(jobPosting)
            .leftJoin(jobPostingWeekday).fetchJoin()
            .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
            .where(
                isExistInRange(location)
                    .and(next?.let { jobPosting.id.loe(it) })
            )
            .limit(limit)
            .transform(
                groupBy(jobPosting.id)
                    .list(
                        Projections.constructor(
                            JobPostingWithWeekdaysDto::class.java,
                            jobPosting,
                            list(
                                jobPostingWeekday
                            )
                        )
                    )
            )
```

QueryDSL을 이용해 페이지 수만큼 공고와 공고 내 요일 정보를 조회하는 코드입니다.
현재 공고(JobPosting)과 공고 내 요일 정보(JobPostingWeekday)는 1:N 관계를 갖습니다. 하지만 해당 쿼리를 실제 수행해 보았을 때, 
DB에 데이터가 충분함에도 불구하고 limit 값보다 훨씬 적은 수의 데이터가 조회되는 문제를 경험했습니다.

여러 값을 통해 디버깅을 진행해 보니, limit 쿼리의 기준이 JobPosting이 아닌, JobPostingWeekday에 개수만큼 필터링 되고 있음을 알게 되었습니다.

따라서 서브쿼리를 통해, 선제적으로 jobPosting에 대해서만 페이징 검색을 통해 limit 쿼리를 직접 적용합니다.
이후, 본 쿼리문에서 앞서 limit로 가져온 id값에 대해 JobPostingWeekday를 list형태로 조회하여 DTO에 매핑하는 방식으로 변경하여 해결할 수 있었습니다.

```kotlin
        val jobPostingIds = jpaQueryFactory
            .select(jobPosting.id)
            .from(jobPosting)
            .where(
                isExistInRange(location)
                    .and(next?.let { jobPosting.id.goe(it) })
            )
            .limit(limit)
            .fetch()

        if (jobPostingIds.isEmpty()) {
            return emptyList()
        }

        return jpaQueryFactory
            .select(jobPosting, jobPostingWeekday)
            .from(jobPosting)
            .leftJoin(jobPostingWeekday).fetchJoin()
            .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
            .where(jobPosting.id.`in`(jobPostingIds))
            .transform(
                groupBy(jobPosting.id)
                    .list(
                        Projections.constructor(
                            JobPostingWithWeekdaysDto::class.java,
                            jobPosting,
                            list(jobPostingWeekday)
                        )
                    )
            )
```

QueryDSL이 JPQL이나 Native Query 대비 다소 직관적이지 못해서, 디버깅 시간이 조금 더 소요되는 것 같습니다. 
현재 프로젝트에서도 페이징 같이 동적 쿼리가 필요한 순간이 아니라면, JPA 및 native query를 계속해서 사용할 것 같네요!
