### PR TITLE
[IDLE-290] 요양 보호사 - 고객 간 distance 계산 로직 추가

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
@@ -201,7 +201,16 @@ class JobPostingService(
             next = next,
             limit = limit,
         )
+    }
 
+    fun calculateDistance(
+        jobPosting: JobPosting,
+        carerLocation: Point,
+    ): Int {
+        return jobPostingJpaRepository.calculateDistance(
+            jobPosting.location,
+            carerLocation
+        ).toInt()
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CarerJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CarerJobPostingFacadeService.kt
@@ -9,7 +9,6 @@ import com.swm.idle.application.jobposting.service.domain.JobPostingWeekdayServi
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.common.dto.JobPostingWithWeekdaysDto
-import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollRequest
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingsScrollResponse
@@ -50,35 +49,12 @@ class CarerJobPostingFacadeService(
 
 
         val center = centerService.getById(jobPosting.centerId)
-        return CarerJobPostingResponse(
-            id = jobPosting.id,
-            weekdays = weekdays!!,
-            startTime = jobPosting.startTime,
-            endTime = jobPosting.endTime,
-            payType = jobPosting.payType,
-            payAmount = jobPosting.payAmount,
-            roadNameAddress = jobPosting.roadNameAddress,
-            lotNumberAddress = jobPosting.lotNumberAddress,
-            longitude = jobPosting.location.x.toString(),
-            latitude = jobPosting.location.y.toString(),
-            gender = jobPosting.gender,
-            age = BirthYear.calculateAge(jobPosting.birthYear),
-            weight = jobPosting.weight,
-            careLevel = jobPosting.careLevel,
-            mentalStatus = jobPosting.mentalStatus,
-            disease = jobPosting.disease,
-            isMealAssistance = jobPosting.isMealAssistance,
-            isBowelAssistance = jobPosting.isBowelAssistance,
-            isWalkingAssistance = jobPosting.isWalkingAssistance,
-            lifeAssistance = lifeAssistances,
-            extraRequirement = jobPosting.extraRequirement,
-            isExperiencePreferred = jobPosting.isExperiencePreferred,
-            applyMethod = applyMethods!!,
-            applyDeadlineType = jobPosting.applyDeadlineType,
-            applyDeadline = jobPosting.applyDeadline,
-            centerId = center.id,
-            centerName = center.centerName,
-            centerRoadNameAddress = center.roadNameAddress,
+        return CarerJobPostingResponse.of(
+            jobPosting = jobPosting,
+            weekdays = weekdays,
+            lifeAssistances = lifeAssistances,
+            applyMethods = applyMethods,
+            center = center,
             distance = distance,
         )
     }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysDto.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysDto.kt
@@ -6,4 +6,10 @@ import com.swm.idle.domain.jobposting.entity.jpa.JobPostingWeekday
 data class JobPostingWithWeekdaysDto(
     val jobPosting: JobPosting,
     val jobPostingWeekdays: List<JobPostingWeekday>,
-)
+    var distance: Int = 0,
+) {
+
+    constructor(jobPosting: JobPosting, jobPostingWeekdays: List<JobPostingWeekday>) :
+            this(jobPosting, jobPostingWeekdays, 0)
+}
+

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingJpaRepository.kt
@@ -1,10 +1,28 @@
 package com.swm.idle.domain.jobposting.repository.jpa
 
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
+import io.lettuce.core.dynamic.annotation.Param
+import org.locationtech.jts.geom.Point
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
 interface JobPostingJpaRepository : JpaRepository<JobPosting, UUID> {
+
+    @Query(
+        """
+            SELECT ST_Distance(
+                :carerLocation,
+                :clientLocation
+            )
+        """,
+        nativeQuery = true
+    )
+    fun calculateDistance(
+        @Param("carerLocation") carerLocation: Point,
+        @Param("clientLocation") clientLocation: Point,
+    ): Double
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -49,7 +49,7 @@ class JobPostingSpatialQueryRepository(
                         Projections.constructor(
                             JobPostingWithWeekdaysDto::class.java,
                             jobPosting,
-                            list(jobPostingWeekday)
+                            list(jobPostingWeekday),
                         )
                     )
             )

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/vo/BirthYear.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/vo/BirthYear.kt
@@ -6,7 +6,9 @@ import java.time.LocalDateTime
 value class BirthYear(val value: Int) {
 
     init {
-        require(value in MINIMUM_BIRTH_YEAR..MAXIMUM_BIRTH_YEAR)
+        require(value in MINIMUM_BIRTH_YEAR..MAXIMUM_BIRTH_YEAR) {
+            "출생연도는 $MINIMUM_BIRTH_YEAR ~ $MAXIMUM_BIRTH_YEAR 년 사이의 연도만 입력할 수 있습니다."
+        }
     }
 
     companion object {

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
@@ -1,13 +1,16 @@
 package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.vo.ApplyMethodType
 import com.swm.idle.domain.jobposting.vo.LifeAssistanceType
 import com.swm.idle.domain.jobposting.vo.MentalStatus
 import com.swm.idle.domain.jobposting.vo.PayType
 import com.swm.idle.domain.jobposting.vo.Weekdays
+import com.swm.idle.domain.user.center.entity.jpa.Center
 import com.swm.idle.domain.user.common.enum.GenderType
+import com.swm.idle.domain.user.common.vo.BirthYear
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.util.*
@@ -111,4 +114,51 @@ data class CarerJobPostingResponse(
 
     @Schema(description = "직선 거리", example = "760(단위 : 미터)")
     val distance: Int,
-)
+) {
+
+    companion object {
+
+        fun of(
+            jobPosting: JobPosting,
+            weekdays: List<Weekdays>?,
+            lifeAssistances: List<LifeAssistanceType>?,
+            applyMethods: List<ApplyMethodType>?,
+            center: Center,
+            distance: Int,
+        ): CarerJobPostingResponse {
+            return CarerJobPostingResponse(
+                id = jobPosting.id,
+                weekdays = weekdays!!,
+                startTime = jobPosting.startTime,
+                endTime = jobPosting.endTime,
+                payType = jobPosting.payType,
+                payAmount = jobPosting.payAmount,
+                roadNameAddress = jobPosting.roadNameAddress,
+                lotNumberAddress = jobPosting.lotNumberAddress,
+                longitude = jobPosting.location.x.toString(),
+                latitude = jobPosting.location.y.toString(),
+                gender = jobPosting.gender,
+                age = BirthYear.calculateAge(jobPosting.birthYear),
+                weight = jobPosting.weight,
+                careLevel = jobPosting.careLevel,
+                mentalStatus = jobPosting.mentalStatus,
+                disease = jobPosting.disease,
+                isMealAssistance = jobPosting.isMealAssistance,
+                isBowelAssistance = jobPosting.isBowelAssistance,
+                isWalkingAssistance = jobPosting.isWalkingAssistance,
+                lifeAssistance = lifeAssistances,
+                extraRequirement = jobPosting.extraRequirement,
+                isExperiencePreferred = jobPosting.isExperiencePreferred,
+                applyMethod = applyMethods!!,
+                applyDeadlineType = jobPosting.applyDeadlineType,
+                applyDeadline = jobPosting.applyDeadline,
+                centerId = center.id,
+                centerName = center.centerName,
+                centerRoadNameAddress = center.roadNameAddress,
+                distance = distance,
+            )
+        }
+
+    }
+
+}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
@@ -108,4 +108,7 @@ data class CarerJobPostingResponse(
 
     @Schema(description = "센터 도로명 주소")
     val centerRoadNameAddress: String,
+
+    @Schema(description = "직선 거리", example = "760(단위 : 미터)")
+    val distance: Int,
 )

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingsScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingsScrollResponse.kt
@@ -70,6 +70,9 @@ data class CarerJobPostingsScrollResponse(
 
         @Schema(description = "지원 마감일", example = "2024-07-30")
         val applyDeadline: LocalDate?,
+
+        @Schema(description = "직선 거리", example = "760(단위 : 미터)")
+        val distance: Int,
     ) {
 
         companion object {
@@ -92,6 +95,7 @@ data class CarerJobPostingsScrollResponse(
                     isExperiencePreferred = jobPostingWithWeekdaysDto.jobPosting.isExperiencePreferred,
                     applyDeadline = jobPostingWithWeekdaysDto.jobPosting.applyDeadline,
                     applyDeadlineType = jobPostingWithWeekdaysDto.jobPosting.applyDeadlineType,
+                    distance = jobPostingWithWeekdaysDto.distance,
                 )
             }
 


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사 및 고객 간 직선 거리를 계산하는 로직을 작성하였습니다.
* 이에 따라, distance 컬럼이 요양 보호사 공고 전체 조회 API, 요양 보호사 공고 상세 조회 API에 모두 반영되었습니다.

## 2. 🤔 고민했던 점
Hibernate-Spatial dependency에서 제공하는 `ST_Distance` function을 이용해 두 Geometry Point간 거리를 계산할 수 있습니다.
이는 DB에 저장된 모든 공간 데이터 칼럼과 Input으로 주어지는 공간 데이터 칼럼을 Full로 연산해야 하므로, MySQL에서는 기본적으로 R-Index를 지원하지 않아 앞서 구현한 범위 검색 대비 성능이 저하될 수 있다는 문제가 있습니다.

추후 고도화 단계를 거치며 해당 이슈를 꾸준히 모니터링하고, 필요 시 대책을 강구해야 합니다.
이 문제는 아래 discussion에서 처리하도록 하겠습니다.
[Discussion](https://github.com/3IDLES/idle-server/discussions/44#discussioncomment-10354094)