### PR TITLE
[IDLE-320] 센터별 진행 중인 공고 전체 조회 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
@@ -203,6 +203,10 @@ class JobPostingService(
         )
     }
 
+    fun findAllInProgress(centerId: UUID): List<JobPosting> {
+        return jobPostingJpaRepository.findAllInProgress(centerId)
+    }
+
     fun calculateDistance(
         jobPosting: JobPosting,
         carerLocation: Point,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CenterJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CenterJobPostingFacadeService.kt
@@ -8,6 +8,7 @@ import com.swm.idle.application.jobposting.service.domain.JobPostingWeekdayServi
 import com.swm.idle.application.jobposting.service.vo.JobPostingInfo
 import com.swm.idle.application.user.center.service.domain.CenterManagerService
 import com.swm.idle.application.user.center.service.domain.CenterService
+import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.user.center.exception.CenterException
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.domain.user.common.vo.BirthYear
@@ -222,6 +223,18 @@ class CenterJobPostingFacadeService(
                 applyDeadline = it.applyDeadline,
             )
         }
+    }
+
+    fun findAllById(): List<JobPosting> {
+        val center = getUserAuthentication().userId.let { centerManagerId ->
+            centerManagerService.getById(centerManagerId).let {
+                centerService.findByBusinessRegistrationNumber(
+                    BusinessRegistrationNumber(it.centerBusinessRegistrationNumber)
+                ) ?: throw CenterException.NotFoundException()
+            }
+        }
+
+        return jobPostingService.findAllInProgress(center.id)
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingJpaRepository.kt
@@ -25,4 +25,18 @@ interface JobPostingJpaRepository : JpaRepository<JobPosting, UUID> {
         @Param("clientLocation") clientLocation: Point,
     ): Double
 
+    @Query(
+        """
+            SELECT *
+            FROM job_posting as jp
+            WHERE jp.job_posting_status = 'IN_PROGRESS'
+            AND jp.entity_status = 'ACTIVE'
+            AND jp.center_id = :centerId
+        """,
+        nativeQuery = true
+    )
+    fun findAllInProgress(
+        @Param("centerId") centerId: UUID,
+    ): List<JobPosting>
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CenterJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CenterJobPostingApi.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.presentation.jobposting.api
 
 import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingInProgressResponse
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.center.CreateJobPostingRequest
 import com.swm.idle.support.transfer.jobposting.center.UpdateJobPostingRequest
@@ -59,5 +60,11 @@ interface CenterJobPostingApi {
     @GetMapping("/{job-posting-id}/center")
     @ResponseStatus(HttpStatus.OK)
     fun getJobPosting(@PathVariable(value = "job-posting-id") jobPostingId: UUID): CenterJobPostingResponse
+
+    @Secured
+    @Operation(summary = "센터 진행중인 공고 전체 조회 API")
+    @GetMapping("/status/in-progress")
+    @ResponseStatus(HttpStatus.OK)
+    fun getJobPostingInProgress(): CenterJobPostingInProgressResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
@@ -2,6 +2,7 @@ package com.swm.idle.presentation.jobposting.controller
 
 import com.swm.idle.application.jobposting.service.facade.CenterJobPostingFacadeService
 import com.swm.idle.presentation.jobposting.api.CenterJobPostingApi
+import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingInProgressResponse
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.center.CreateJobPostingRequest
 import com.swm.idle.support.transfer.jobposting.center.UpdateJobPostingRequest
@@ -37,6 +38,12 @@ class CenterJobPostingController(
 
     override fun getJobPosting(jobPostingId: UUID): CenterJobPostingResponse {
         return centerJobPostingFacadeService.getById(jobPostingId)
+    }
+
+    override fun getJobPostingInProgress(): CenterJobPostingInProgressResponse {
+        return CenterJobPostingInProgressResponse.from(
+            centerJobPostingFacadeService.findAllById()
+        )
     }
 
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/CenterJobPostingInProgressResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/CenterJobPostingInProgressResponse.kt
@@ -1,0 +1,82 @@
+package com.swm.idle.support.transfer.jobposting.center
+
+import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
+import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
+import com.swm.idle.domain.user.common.enum.GenderType
+import com.swm.idle.domain.user.common.vo.BirthYear
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.util.*
+
+@Schema(
+    name = "CenterJobPostingInProgressResponse",
+    description = "센터 공고 상세 조회 API",
+)
+data class CenterJobPostingInProgressResponse(
+    val jobPostings: List<CenterJobPostingInProgressDto>,
+) {
+
+    data class CenterJobPostingInProgressDto(
+        @Schema(description = "공고 ID")
+        val id: UUID,
+
+        @Schema(description = "도로명 주소")
+        val roadNameAddress: String,
+
+        @Schema(description = "지번 주소")
+        val lotNumberAddress: String,
+
+        @Schema(description = "고객 성명")
+        val clientName: String,
+
+        @Schema(description = "성별")
+        val gender: GenderType,
+
+        @Schema(description = "나이")
+        val age: Int,
+
+        @Schema(description = "요양 등급")
+        val careLevel: Int,
+
+        @Schema(description = "지원 마감 유형", example = "LIMITED")
+        val applyDeadlineType: ApplyDeadlineType,
+
+        @Schema(description = "지원 마감일", example = "2024-07-30")
+        val applyDeadline: LocalDate?,
+
+        @Schema(description = "공고 등록 시각", example = "2024-07-29")
+        val createdAt: LocalDate,
+    ) {
+
+        companion object {
+
+            fun from(
+                jobPosting: JobPosting,
+            ): CenterJobPostingInProgressDto {
+                return CenterJobPostingInProgressDto(
+                    id = jobPosting.id,
+                    roadNameAddress = jobPosting.roadNameAddress,
+                    lotNumberAddress = jobPosting.lotNumberAddress,
+                    clientName = jobPosting.clientName,
+                    gender = jobPosting.gender,
+                    age = BirthYear.calculateAge(jobPosting.birthYear),
+                    careLevel = jobPosting.careLevel,
+                    applyDeadlineType = jobPosting.applyDeadlineType,
+                    applyDeadline = jobPosting.applyDeadline,
+                    createdAt = jobPosting.createdAt!!.toLocalDate()
+                )
+            }
+
+        }
+    }
+
+    companion object {
+
+        fun from(jobPostings: List<JobPosting>): CenterJobPostingInProgressResponse {
+            return CenterJobPostingInProgressResponse(
+                jobPostings.map(CenterJobPostingInProgressDto::from)
+            )
+        }
+    }
+
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 별 진행 중인 공고 전체 조회 API를 구현했습니다.
* 진행 중인 공고의 개수는 크지 않을 것으로 예상되므로, 별도의 페이지네이션은 구현하지 않았습니다.

## 2. ✏️ Documentation
- [센터 진행중인 공고 전체 조회 API] GET /api/v1/job-postings/status/in-progress
    - request
        - method & path: `GET /api/v1/job-postings/status/in-progress`
    - response
        - 정상 처리된 경우
            - status code: `200 OK`
            - body
                
                ```json
                {
                  "jobPostings" : [
                    {
                      "id": "019154ba-4723-761d-9351-b72499ab1eb1",
                      "roadNameAddress": "서울시 강남구 테헤란로 311",
                      "lotNumberAddress": "서울시 강남구 역삼동 1234",
                      "clientName": "string",
                      "gender": "MAN",
                      "age": "int",
                      "careLevel": "int",
                      "applyDeadlineType": "LIMITED",
                      "applyDeadline": "2024-08-09", // nullable
                      "createdAt": "2024-07-10"
                    },
                    
                    {
                      "id": "019154ba-4723-761d-9351-b72499ab1eb1",
                      "roadNameAddress": "서울시 강남구 테헤란로 311",
                      "lotNumberAddress": "서울시 강남구 역삼동 1234",
                      "clientName": "string",
                      "gender": "MAN",
                      "age": "int",
                      "careLevel": "int",
                      "applyDeadlineType": "LIMITED",
                      "applyDeadline": "2024-08-09", // nullable
                      "createdAt": "2024-07-10"
                    }, // 여러 개
                  ]
                }
                ```