### PR TITLE
[IDLE-93] 센터 별 마감된(이전) 공고 전체 조회 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingService.kt
@@ -207,6 +207,10 @@ class JobPostingService(
         return jobPostingJpaRepository.findAllInProgress(centerId)
     }
 
+    fun findAllCompleted(centerId: UUID): List<JobPosting> {
+        return jobPostingJpaRepository.findAllCompleted(centerId)
+    }
+
     fun calculateDistance(
         jobPosting: JobPosting,
         carerLocation: Point,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CenterJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CenterJobPostingFacadeService.kt
@@ -225,7 +225,7 @@ class CenterJobPostingFacadeService(
         }
     }
 
-    fun findAllById(): List<JobPosting> {
+    fun findAllInProgressById(): List<JobPosting> {
         val center = getUserAuthentication().userId.let { centerManagerId ->
             centerManagerService.getById(centerManagerId).let {
                 centerService.findByBusinessRegistrationNumber(
@@ -235,6 +235,18 @@ class CenterJobPostingFacadeService(
         }
 
         return jobPostingService.findAllInProgress(center.id)
+    }
+
+    fun findAllCompletedById(): List<JobPosting> {
+        val center = getUserAuthentication().userId.let { centerManagerId ->
+            centerManagerService.getById(centerManagerId).let {
+                centerService.findByBusinessRegistrationNumber(
+                    BusinessRegistrationNumber(it.centerBusinessRegistrationNumber)
+                ) ?: throw CenterException.NotFoundException()
+            }
+        }
+
+        return jobPostingService.findAllCompleted(center.id)
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingJpaRepository.kt
@@ -39,4 +39,18 @@ interface JobPostingJpaRepository : JpaRepository<JobPosting, UUID> {
         @Param("centerId") centerId: UUID,
     ): List<JobPosting>
 
+    @Query(
+        """
+            SELECT *
+            FROM job_posting as jp
+            WHERE jp.job_posting_status = 'COMPLETED'
+            AND jp.entity_status = 'ACTIVE'
+            AND jp.center_id = :centerId
+        """,
+        nativeQuery = true
+    )
+    fun findAllCompleted(
+        @Param("centerId") centerId: UUID,
+    ): List<JobPosting>
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CenterJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CenterJobPostingApi.kt
@@ -1,7 +1,7 @@
 package com.swm.idle.presentation.jobposting.api
 
 import com.swm.idle.presentation.common.security.annotation.Secured
-import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingInProgressResponse
+import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingListResponse
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.center.CreateJobPostingRequest
 import com.swm.idle.support.transfer.jobposting.center.UpdateJobPostingRequest
@@ -62,9 +62,15 @@ interface CenterJobPostingApi {
     fun getJobPosting(@PathVariable(value = "job-posting-id") jobPostingId: UUID): CenterJobPostingResponse
 
     @Secured
-    @Operation(summary = "센터 진행중인 공고 전체 조회 API")
+    @Operation(summary = "센터별 진행 중인 공고 전체 조회 API")
     @GetMapping("/status/in-progress")
     @ResponseStatus(HttpStatus.OK)
-    fun getJobPostingInProgress(): CenterJobPostingInProgressResponse
+    fun getJobPostingInProgress(): CenterJobPostingListResponse
+
+    @Secured
+    @Operation(summary = "센터별 마감된(이전) 공고 전체 조회 API")
+    @GetMapping("/status/completed")
+    @ResponseStatus(HttpStatus.OK)
+    fun getJobPostingCompleted(): CenterJobPostingListResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
@@ -2,7 +2,7 @@ package com.swm.idle.presentation.jobposting.controller
 
 import com.swm.idle.application.jobposting.service.facade.CenterJobPostingFacadeService
 import com.swm.idle.presentation.jobposting.api.CenterJobPostingApi
-import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingInProgressResponse
+import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingListResponse
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.center.CreateJobPostingRequest
 import com.swm.idle.support.transfer.jobposting.center.UpdateJobPostingRequest
@@ -40,9 +40,15 @@ class CenterJobPostingController(
         return centerJobPostingFacadeService.getById(jobPostingId)
     }
 
-    override fun getJobPostingInProgress(): CenterJobPostingInProgressResponse {
-        return CenterJobPostingInProgressResponse.from(
-            centerJobPostingFacadeService.findAllById()
+    override fun getJobPostingInProgress(): CenterJobPostingListResponse {
+        return CenterJobPostingListResponse.from(
+            centerJobPostingFacadeService.findAllInProgressById()
+        )
+    }
+
+    override fun getJobPostingCompleted(): CenterJobPostingListResponse {
+        return CenterJobPostingListResponse.from(
+            centerJobPostingFacadeService.findAllCompletedById()
         )
     }
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/CenterJobPostingListResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/CenterJobPostingListResponse.kt
@@ -9,14 +9,14 @@ import java.time.LocalDate
 import java.util.*
 
 @Schema(
-    name = "CenterJobPostingInProgressResponse",
+    name = "CenterJobPostingListResponse",
     description = "센터 공고 상세 조회 API",
 )
-data class CenterJobPostingInProgressResponse(
-    val jobPostings: List<CenterJobPostingInProgressDto>,
+data class CenterJobPostingListResponse(
+    val jobPostings: List<CenterJobPostingDto>,
 ) {
 
-    data class CenterJobPostingInProgressDto(
+    data class CenterJobPostingDto(
         @Schema(description = "공고 ID")
         val id: UUID,
 
@@ -52,8 +52,8 @@ data class CenterJobPostingInProgressResponse(
 
             fun from(
                 jobPosting: JobPosting,
-            ): CenterJobPostingInProgressDto {
-                return CenterJobPostingInProgressDto(
+            ): CenterJobPostingDto {
+                return CenterJobPostingDto(
                     id = jobPosting.id,
                     roadNameAddress = jobPosting.roadNameAddress,
                     lotNumberAddress = jobPosting.lotNumberAddress,
@@ -72,9 +72,9 @@ data class CenterJobPostingInProgressResponse(
 
     companion object {
 
-        fun from(jobPostings: List<JobPosting>): CenterJobPostingInProgressResponse {
-            return CenterJobPostingInProgressResponse(
-                jobPostings.map(CenterJobPostingInProgressDto::from)
+        fun from(jobPostings: List<JobPosting>): CenterJobPostingListResponse {
+            return CenterJobPostingListResponse(
+                jobPostings.map(CenterJobPostingDto::from)
             )
         }
     }


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 별 마감된(이전) 공고 전체 조회 API를 구현하였습니다.

## 2. ✏️ Documentation

### [센터 마감된 공고 전체 조회 API] GET /api/v1/job-postings/status/completed
- request
    - method & path: `GET /api/v1/job-postings/status/completed`
- response
    - 정상 처리된 경우
        - status code: `200 OK`
        - body
            
            ```json
            {
              "jobPostings" : [
                {
                  "id": "019154ba-4723-761d-9351-b72499ab1eb1",
                  "roadNameAddress": "서울시 강남구 테헤란로 311",
                  "lotNumberAddress": "서울시 강남구 역삼동 1234",
                  "clientName": "string",
                  "gender": "MAN",
                  "age": "int",
                  "careLevel": "int",
                  "applyDeadlineType": "LIMITED",
                  "applyDeadline": "2024-08-09", // **nullable**
            	    "createdAt": "2024-07-10"
                },
                
                {
                  "id": "019154ba-4723-761d-9351-b72499ab1eb1",
                  "roadNameAddress": "서울시 강남구 테헤란로 311",
                  "lotNumberAddress": "서울시 강남구 역삼동 1234",
                  "clientName": "string",
                  "gender": "MAN",
                  "age": "int",
                  "careLevel": "int",
                  "applyDeadlineType": "LIMITED",
                  "applyDeadline": "2024-08-09", // **nullable**
            	    "createdAt": "2024-07-10"
                }, // 여러 개
              ]
            }
            ```