### PR TITLE
[IDLE-000] 요양 보호사 공고 전체 조회 시, 진행 중인 공고만 조회하도록 로직 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ subprojects {
         implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
         implementation("com.querydsl:querydsl-apt:5.1.0:jakarta")
         implementation(rootProject.libs.locationtech)
+        implementation(rootProject.libs.jakarta.persistence.api)
 
         kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
         kapt(rootProject.libs.spring.boot.configuration.processor)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/entity/BaseEntity.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/entity/BaseEntity.kt
@@ -1,6 +1,6 @@
 package com.swm.idle.domain.common.entity
 
-import com.swm.idle.domain.common.enum.EntityStatus
+import com.swm.idle.domain.common.enums.EntityStatus
 import com.swm.idle.support.common.uuid.UuidCreator
 import jakarta.persistence.Column
 import jakarta.persistence.EnumType
@@ -20,7 +20,7 @@ abstract class BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(255)")
-    private var entityStatus: EntityStatus = EntityStatus.ACTIVE
+    var entityStatus: EntityStatus = EntityStatus.ACTIVE
 
     @CreationTimestamp
     @Column(columnDefinition = "timestamp", updatable = false)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/enums/EntityStatus.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/enums/EntityStatus.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.domain.common.enum
+package com.swm.idle.domain.common.enums
 
 enum class EntityStatus {
     ACTIVE,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -7,8 +7,10 @@ import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.swm.idle.domain.common.dto.JobPostingWithWeekdaysDto
+import com.swm.idle.domain.common.enums.EntityStatus
 import com.swm.idle.domain.jobposting.entity.jpa.QJobPosting.jobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.QJobPostingWeekday.jobPostingWeekday
+import com.swm.idle.domain.jobposting.vo.JobPostingStatus
 import org.locationtech.jts.geom.Point
 import org.springframework.stereotype.Repository
 import java.util.*
@@ -29,6 +31,8 @@ class JobPostingSpatialQueryRepository(
             .where(
                 isExistInRange(location)
                     .and(next?.let { jobPosting.id.goe(it) })
+                    .and(jobPosting.jobPostingStatus.eq(JobPostingStatus.IN_PROGRESS))
+                    .and(jobPosting.entityStatus.eq(EntityStatus.ACTIVE))
             )
             .limit(limit)
             .fetch()


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사 공고 전체 조회 시, 진행 중인 공고만 조회하도록 로직을 변경하였습니다.

## 2. 💡 알게된 점, 궁금한 점
* QueryDSL을 이용하며 Q Class 내부 필드 중 enum값의 필드가 생성되지 않는 문제가 있었고, 해당 enum값을 관리하는 
디렉토리 명이 예약어인 `enum`으로 되어 있어 오류가 발생한다는 것을 새로 알게 되었습니다! 

따라서 해당 파일이 속한 디렉토리명을 `enums` 로 변경하여 해결할 수 있었습니다.