### PR TITLE
[IDLE-000] 구인 공고 수정 시, 마감일자 기본값 추가

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/QueryDslConfig.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/QueryDslConfig.kt
@@ -17,4 +17,5 @@ class QueryDslConfig {
     fun jpaQueryFactory(): JPAQueryFactory {
         return JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager)
     }
+
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/UpdateJobPostingRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/UpdateJobPostingRequest.kt
@@ -66,7 +66,7 @@ data class UpdateJobPostingRequest(
     @Schema(description = "접수 방법", example = "[CALLING, MESSAGE]")
     val applyMethod: List<ApplyMethodType>?,
     @Schema(description = "접수 마감 일자")
-    val applyDeadline: String?,
+    val applyDeadline: String? = null,
     @Schema(description = "접수 마감일 상태")
     val applyDeadlineType: ApplyDeadlineType?,
 )


### PR DESCRIPTION
## 1. 📄 Summary
* 구인 공고 수정 시, 마감일자가 전달되지 않는 경우 명시적으로 null을 지정하도록 변경했습니다.