### PR TITLE
[IDLE-149] 공고 지원하기 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/applyment/domain/CarerApplyService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applyment/domain/CarerApplyService.kt
@@ -1,0 +1,40 @@
+package com.swm.idle.application.applyment.domain
+
+import com.swm.idle.domain.apply.entity.jpa.Apply
+import com.swm.idle.domain.apply.repository.CarerApplyJpaRepository
+import com.swm.idle.domain.jobposting.vo.ApplyMethodType
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class CarerApplyService(
+    private val carerApplyJpaRepository: CarerApplyJpaRepository,
+) {
+
+    fun existsByJobPostingIdAndCarerIdAndApplyMethodType(
+        jobPostingId: UUID,
+        carerId: UUID,
+        applyMethodType: ApplyMethodType,
+    ): Boolean {
+        return carerApplyJpaRepository.existsByJobPostingIdAndCarerIdAndApplyMethodType(
+            jobPostingId = jobPostingId,
+            carerId = carerId,
+            applyMethodType = applyMethodType,
+        )
+    }
+
+    fun create(
+        jobPostingId: UUID,
+        carerId: UUID,
+        applyMethodType: ApplyMethodType,
+    ) {
+        carerApplyJpaRepository.save(
+            Apply(
+                jobPostingId = jobPostingId,
+                carerId = carerId,
+                applyMethodType = applyMethodType,
+            )
+        )
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/applyment/facade/CarerApplyFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applyment/facade/CarerApplyFacadeService.kt
@@ -1,0 +1,41 @@
+package com.swm.idle.application.applyment.facade
+
+import com.swm.idle.application.applyment.domain.CarerApplyService
+import com.swm.idle.application.common.security.getUserAuthentication
+import com.swm.idle.domain.apply.exception.ApplyException
+import com.swm.idle.domain.jobposting.vo.ApplyMethodType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+@Transactional(readOnly = true)
+class CarerApplyFacadeService(
+    private val carerApplyService: CarerApplyService,
+) {
+
+    @Transactional
+    fun createApply(
+        jobPostingId: UUID,
+        applyMethodType: ApplyMethodType,
+    ) {
+        val carerId = getUserAuthentication().userId
+
+        if (carerApplyService.existsByJobPostingIdAndCarerIdAndApplyMethodType(
+                jobPostingId = jobPostingId,
+                carerId = carerId,
+                applyMethodType = applyMethodType,
+            )
+        ) {
+            throw ApplyException.AlreadyApplied()
+        }
+
+        carerApplyService.create(
+            jobPostingId = jobPostingId,
+            carerId = carerId,
+            applyMethodType = applyMethodType,
+        )
+
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/apply/entity/jpa/Apply.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/apply/entity/jpa/Apply.kt
@@ -1,0 +1,33 @@
+package com.swm.idle.domain.apply.entity.jpa
+
+import com.swm.idle.domain.common.entity.BaseEntity
+import com.swm.idle.domain.jobposting.vo.ApplyMethodType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "apply")
+class Apply(
+    jobPostingId: UUID,
+    carerId: UUID,
+    applyMethodType: ApplyMethodType,
+) : BaseEntity() {
+
+    @Column(nullable = false)
+    var jobPostingId: UUID = jobPostingId
+        private set
+
+    @Column(nullable = false)
+    var carerId: UUID = carerId
+        private set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var applyMethodType: ApplyMethodType = applyMethodType
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/apply/exception/ApplyException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/apply/exception/ApplyException.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.domain.apply.exception
+
+import com.swm.idle.support.common.exception.CustomException
+
+sealed class ApplyException(
+    codeNumber: Int,
+    message: String,
+) : CustomException(CODE_PREFIX, codeNumber, message) {
+
+    class AlreadyApplied(message: String = "") :
+        ApplyException(codeNumber = 1, message = message)
+
+    companion object {
+
+        const val CODE_PREFIX = "APPLYMENT"
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/apply/repository/CarerApplyJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/apply/repository/CarerApplyJpaRepository.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.domain.apply.repository
+
+import com.swm.idle.domain.apply.entity.jpa.Apply
+import com.swm.idle.domain.jobposting.vo.ApplyMethodType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface CarerApplyJpaRepository : JpaRepository<Apply, UUID> {
+
+    fun existsByJobPostingIdAndCarerIdAndApplyMethodType(
+        jobPostingId: UUID,
+        carerId: UUID,
+        applyMethodType: ApplyMethodType,
+    ): Boolean
+
+}

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -20,7 +20,7 @@ spring:
       on-profile: local
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: true
     properties:
         hibernate.format_sql: true

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/applyment/api/CarerApplyApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/applyment/api/CarerApplyApi.kt
@@ -1,0 +1,25 @@
+package com.swm.idle.presentation.applyment.api
+
+import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.applyment.CreateApplyRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@Tag(name = "Applyment - Carer", description = "요양 보호사 공고 지원 API")
+@RequestMapping("/api/v1/applyments", produces = ["application/json;charset=utf-8"])
+interface CarerApplyApi {
+
+    @Secured
+    @Operation(summary = "요양 보호사 공고 지원하기 API")
+    @PostMapping("/history")
+    @ResponseStatus(HttpStatus.OK)
+    fun createApply(
+        @RequestBody request: CreateApplyRequest,
+    )
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/applyment/controller/CarerApplyController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/applyment/controller/CarerApplyController.kt
@@ -1,0 +1,22 @@
+package com.swm.idle.presentation.applyment.controller
+
+import com.swm.idle.application.applyment.facade.CarerApplyFacadeService
+import com.swm.idle.presentation.applyment.api.CarerApplyApi
+import com.swm.idle.support.transfer.applyment.CreateApplyRequest
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CarerApplyController(
+    private val carerApplyFacadeService: CarerApplyFacadeService,
+) : CarerApplyApi {
+
+    override fun createApply(
+        request: CreateApplyRequest,
+    ) {
+        carerApplyFacadeService.createApply(
+            jobPostingId = request.jobPostingId,
+            applyMethodType = request.applyMethodType,
+        )
+    }
+
+}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/applyment/CreateApplyRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/applyment/CreateApplyRequest.kt
@@ -1,0 +1,14 @@
+package com.swm.idle.support.transfer.applyment
+
+import com.swm.idle.domain.jobposting.vo.ApplyMethodType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
+
+@Schema(
+    name = "CreateApplyRequest",
+    description = "공고 지원 요청"
+)
+data class CreateApplyRequest(
+    val jobPostingId: UUID,
+    val applyMethodType: ApplyMethodType,
+)


### PR DESCRIPTION
## 1. 📄 Summary
* 공고 지원 API를 구현했습니다.

## 2. ✏️ Documentation
### API

- 지원 API
    - [공고 지원 API] POST /api/v1/applyments/history
        - request
            - method & path: `POST /api/v1/applyments/history`
            - body
                
                ```json
                {
                  "jobPostingId": "string(uuid)",
                  "applyMethodType": "string"
                }
                ```
                
                - **apply_method 공고 지원 방법**
                    - CALLING(전화 지원)
                    - MESSAGE(문자 지원)
                    - APP(어플 지원)
        
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
            - 같은 공고에 같은 지원 방식으로 중복 지원하는 경우
                - status code: `400 Bad Request`