### PR TITLE
[IDLE-327] 요양 보호사별 지원한 공고 전체 조회 API 명세 수정

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysAndApplyDto.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysAndApplyDto.kt
@@ -8,13 +8,13 @@ data class JobPostingWithWeekdaysAndApplyDto(
     val jobPosting: JobPosting,
     val jobPostingWeekdays: List<JobPostingWeekday>,
     var distance: Int = 0,
-    val applyTime: LocalDateTime?,
+    val applyTime: LocalDateTime,
 ) {
 
     constructor(
         jobPosting: JobPosting,
         jobPostingWeekdays: List<JobPostingWeekday>,
-        applyTime: LocalDateTime?,
+        applyTime: LocalDateTime,
     ) : this(jobPosting, jobPostingWeekdays, 0, applyTime)
 
 }

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -31,5 +31,5 @@ spring:
       on-profile: dev
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     show-sql: false

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
@@ -34,7 +34,7 @@ interface CarerJobPostingApi {
 
     @Secured
     @Operation(summary = "요양 보호사별 지원한 공고 전체 조회 API")
-    @GetMapping("/carer/applied")
+    @GetMapping("/carer/my/applied")
     @ResponseStatus(HttpStatus.OK)
     fun getAppliedJobPostings(
         request: CarerJobPostingScrollRequest,

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerAppliedJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerAppliedJobPostingScrollResponse.kt
@@ -76,7 +76,7 @@ data class CarerAppliedJobPostingScrollResponse(
         val distance: Int,
 
         @Schema(description = "지원 시각")
-        val applyTime: LocalDateTime?,
+        val applyTime: LocalDateTime,
     ) {
 
         companion object {


### PR DESCRIPTION
## 1. 📄 Summary
* 지원 이력에서 nullable 속성을 제거했습니다.
* API path를 수정했습니다.