### PR TITLE
[IDLE-328] 공고 지원자 수 조회 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/applys/domain/ApplicantService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applys/domain/ApplicantService.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.application.applys.domain
+
+import com.swm.idle.domain.applys.repository.CarerApplyJpaRepository
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class ApplicantService(
+    private val carerApplyJpaRepository: CarerApplyJpaRepository,
+) {
+
+    fun countByJobPostingId(jobPostingId: UUID): Int {
+        return carerApplyJpaRepository.countByJobPostingId(jobPostingId)
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CenterJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/CenterJobPostingFacadeService.kt
@@ -1,5 +1,6 @@
 package com.swm.idle.application.jobposting.service.facade
 
+import com.swm.idle.application.applys.domain.ApplicantService
 import com.swm.idle.application.applys.domain.CarerApplyService
 import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.jobposting.service.domain.JobPostingApplyMethodService
@@ -18,6 +19,7 @@ import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.infrastructure.client.geocode.service.GeoCodeService
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.center.CreateJobPostingRequest
+import com.swm.idle.support.transfer.jobposting.center.JobPostingApplicantCountResponse
 import com.swm.idle.support.transfer.jobposting.center.JobPostingApplicantsResponse
 import com.swm.idle.support.transfer.jobposting.center.UpdateJobPostingRequest
 import kotlinx.coroutines.coroutineScope
@@ -38,6 +40,7 @@ class CenterJobPostingFacadeService(
     private val centerService: CenterService,
     private val carerService: CarerService,
     private val carerApplyService: CarerApplyService,
+    private val applicantService: ApplicantService,
 ) {
 
     @Transactional
@@ -247,6 +250,10 @@ class CenterJobPostingFacadeService(
             jobPosting = jobPosting,
             applicants = applicants,
         )
+    }
+
+    fun getApplicantCount(jobPostingId: UUID): JobPostingApplicantCountResponse {
+        return JobPostingApplicantCountResponse(applicantService.countByJobPostingId(jobPostingId))
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/repository/CarerApplyJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/repository/CarerApplyJpaRepository.kt
@@ -15,4 +15,6 @@ interface CarerApplyJpaRepository : JpaRepository<Applys, UUID> {
 
     fun findAllByJobPostingId(jobPostingId: UUID): List<Applys>
 
+    fun countByJobPostingId(jobPostingId: UUID): Int
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CenterJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CenterJobPostingApi.kt
@@ -4,6 +4,7 @@ import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingListResponse
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.center.CreateJobPostingRequest
+import com.swm.idle.support.transfer.jobposting.center.JobPostingApplicantCountResponse
 import com.swm.idle.support.transfer.jobposting.center.JobPostingApplicantsResponse
 import com.swm.idle.support.transfer.jobposting.center.UpdateJobPostingRequest
 import io.swagger.v3.oas.annotations.Operation
@@ -80,4 +81,9 @@ interface CenterJobPostingApi {
     @ResponseStatus(HttpStatus.OK)
     fun getJobPostingApplicants(@PathVariable(value = "job-posting-id") jobPostingId: UUID): JobPostingApplicantsResponse
 
+    @Secured
+    @Operation(summary = "공고 지원자 수 조회 API")
+    @GetMapping("/{job-posting-id}/applicant-count")
+    @ResponseStatus(HttpStatus.OK)
+    fun getJobPostingApplicantCount(@PathVariable(value = "job-posting-id") jobPostingId: UUID): JobPostingApplicantCountResponse
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
@@ -5,6 +5,7 @@ import com.swm.idle.presentation.jobposting.api.CenterJobPostingApi
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingListResponse
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.center.CreateJobPostingRequest
+import com.swm.idle.support.transfer.jobposting.center.JobPostingApplicantCountResponse
 import com.swm.idle.support.transfer.jobposting.center.JobPostingApplicantsResponse
 import com.swm.idle.support.transfer.jobposting.center.UpdateJobPostingRequest
 import org.springframework.web.bind.annotation.RestController
@@ -55,6 +56,10 @@ class CenterJobPostingController(
 
     override fun getJobPostingApplicants(jobPostingId: UUID): JobPostingApplicantsResponse {
         return centerJobPostingFacadeService.getJobPostingApplicants(jobPostingId)
+    }
+
+    override fun getJobPostingApplicantCount(jobPostingId: UUID): JobPostingApplicantCountResponse {
+        return centerJobPostingFacadeService.getApplicantCount(jobPostingId)
     }
 
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/JobPostingApplicantCountResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/JobPostingApplicantCountResponse.kt
@@ -1,0 +1,11 @@
+package com.swm.idle.support.transfer.jobposting.center
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "JobPostingApplicantCountResponse",
+    description = "공고 지원자 수 조회 응답",
+)
+data class JobPostingApplicantCountResponse(
+    val applicantCount: Int = 0,
+)


### PR DESCRIPTION
## 1. 📄 Summary
* 공고 지원자 수를 집계하는 API를 구현했습니다.
* apply 도메인에 대한 리팩토링이 필요할 것 같습니다. 지원 특성상 공고 도메인에서 파생되는 개념이므로, 기존 공고쪽 Api와 함께 어떻게 관리하면 좋을 지를 고민해야 할 것 같습니다!