### PR TITLE
[IDLE-325] 각 유저별로 나뉘어 있던 Refresh Token API 하나로 통합

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerAuthFacadeService.kt
@@ -15,7 +15,6 @@ import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.infrastructure.client.geocode.service.GeoCodeService
 import com.swm.idle.support.security.exception.SecurityException
-import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.stereotype.Service
 
@@ -100,16 +99,6 @@ class CarerAuthFacadeService(
             role = UserType.CARER,
             reason = reason,
         )
-    }
-
-    fun refreshLoginToken(refreshToken: String): RefreshLoginTokenResponse {
-        return refreshTokenService.create(refreshToken)
-            .let {
-                RefreshLoginTokenResponse(
-                    accessToken = it.accessToken,
-                    refreshToken = it.refreshToken,
-                )
-            }
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/AuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/common/service/facade/AuthFacadeService.kt
@@ -1,10 +1,12 @@
 package com.swm.idle.application.user.common.service.facade
 
+import com.swm.idle.application.user.common.service.domain.RefreshTokenService
 import com.swm.idle.application.user.common.service.domain.UserPhoneVerificationService
 import com.swm.idle.application.user.vo.UserPhoneVerificationNumber
 import com.swm.idle.domain.user.common.exception.UserException
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.infrastructure.sms.auth.service.SmsService
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 class AuthFacadeService(
     private val smsService: SmsService,
     private val userPhoneVerificationService: UserPhoneVerificationService,
+    private val refreshTokenService: RefreshTokenService,
 ) {
 
     @Transactional
@@ -45,6 +48,17 @@ class AuthFacadeService(
                 throw UserException.InvalidVerificationNumber()
             }
         } ?: throw UserException.VerificationNumberNotFound()
+    }
+
+    @Transactional
+    fun refreshLoginToken(refreshToken: String): RefreshLoginTokenResponse {
+        return refreshTokenService.create(refreshToken)
+            .let {
+                RefreshLoginTokenResponse(
+                    accessToken = it.accessToken,
+                    refreshToken = it.refreshToken,
+                )
+            }
     }
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/api/CarerAuthApi.kt
@@ -4,8 +4,6 @@ import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
 import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
 import com.swm.idle.support.transfer.auth.carer.CarerWithdrawRequest
-import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
-import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -46,12 +44,5 @@ interface CarerAuthApi {
     fun withdraw(
         @RequestBody request: CarerWithdrawRequest,
     )
-
-    @Operation(summary = "요양 보호사 Refresh Login Token API")
-    @PostMapping("/refresh")
-    @ResponseStatus(HttpStatus.OK)
-    fun refreshLoginToken(
-        @RequestBody request: RefreshTokenRequest,
-    ): RefreshLoginTokenResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/carer/controller/CarerAuthController.kt
@@ -8,8 +8,6 @@ import com.swm.idle.presentation.auth.carer.api.CarerAuthApi
 import com.swm.idle.support.transfer.auth.carer.CarerJoinRequest
 import com.swm.idle.support.transfer.auth.carer.CarerLoginRequest
 import com.swm.idle.support.transfer.auth.carer.CarerWithdrawRequest
-import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
-import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import org.springframework.web.bind.annotation.RestController
 
@@ -42,10 +40,6 @@ class CarerAuthController(
 
     override fun withdraw(request: CarerWithdrawRequest) {
         carerAuthFacadeService.withdraw(request.reason)
-    }
-
-    override fun refreshLoginToken(request: RefreshTokenRequest): RefreshLoginTokenResponse {
-        return carerAuthFacadeService.refreshLoginToken(request.refreshToken)
     }
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
@@ -4,8 +4,6 @@ import com.swm.idle.presentation.common.exception.ErrorResponse
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.auth.center.CenterLoginRequest
 import com.swm.idle.support.transfer.auth.center.JoinRequest
-import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
-import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
@@ -52,13 +50,6 @@ interface CenterAuthApi {
     @PostMapping("/logout")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun logout()
-
-    @Operation(summary = "센터 Refresh Login Token API")
-    @PostMapping("/refresh")
-    @ResponseStatus(HttpStatus.OK)
-    fun refreshLoginToken(
-        @RequestBody request: RefreshTokenRequest,
-    ): RefreshLoginTokenResponse
 
     @Secured
     @Operation(summary = "센터 회원 탈퇴 API")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
@@ -8,8 +8,6 @@ import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.center.api.CenterAuthApi
 import com.swm.idle.support.transfer.auth.center.CenterLoginRequest
 import com.swm.idle.support.transfer.auth.center.JoinRequest
-import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
-import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
@@ -49,10 +47,6 @@ class CenterAuthController(
 
     override fun logout() {
         centerAuthFacadeService.logout()
-    }
-
-    override fun refreshLoginToken(request: RefreshTokenRequest): RefreshLoginTokenResponse {
-        return centerAuthFacadeService.refreshLoginToken(request.refreshToken)
     }
 
     override fun withdraw(request: WithdrawRequest) {

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/api/AuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/api/AuthApi.kt
@@ -1,6 +1,8 @@
 package com.swm.idle.presentation.auth.common.api
 
 import com.swm.idle.presentation.common.exception.ErrorResponse
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
+import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.common.ConfirmSmsVerificationRequest
 import com.swm.idle.support.transfer.auth.common.SendSmsVerificationRequest
 import io.swagger.v3.oas.annotations.Operation
@@ -72,5 +74,12 @@ interface AuthApi {
     fun confirmVerificationMessage(
         @RequestBody request: ConfirmSmsVerificationRequest,
     )
+
+    @Operation(summary = "Refresh Login Token API")
+    @PostMapping("/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    fun refreshLoginToken(
+        @RequestBody request: RefreshTokenRequest,
+    ): RefreshLoginTokenResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/controller/AuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/common/controller/AuthController.kt
@@ -4,6 +4,8 @@ import com.swm.idle.application.user.common.service.facade.AuthFacadeService
 import com.swm.idle.application.user.vo.UserPhoneVerificationNumber
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.common.api.AuthApi
+import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
+import com.swm.idle.support.transfer.auth.center.RefreshTokenRequest
 import com.swm.idle.support.transfer.auth.common.ConfirmSmsVerificationRequest
 import com.swm.idle.support.transfer.auth.common.SendSmsVerificationRequest
 import org.springframework.web.bind.annotation.RestController
@@ -24,6 +26,10 @@ class AuthController(
             phoneNumber = PhoneNumber(request.phoneNumber),
             verificationNumber = UserPhoneVerificationNumber(request.verificationNumber)
         )
+    }
+
+    override fun refreshLoginToken(request: RefreshTokenRequest): RefreshLoginTokenResponse {
+        return authFacadeService.refreshLoginToken(request.refreshToken)
     }
 
 }


### PR DESCRIPTION
## 1. 📄 Summary
* 기존 유저별로 분리되어 있던 refresh token 갱신 API를 유저 공용으로 사용 가능하도록 하나의 API로 통합하였습니다!
