### PR TITLE
[IDLE-159] 요양 보호사 공고 즐겨찾기 추가 및 삭제 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingFavoriteService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/domain/JobPostingFavoriteService.kt
@@ -1,0 +1,46 @@
+package com.swm.idle.application.jobposting.service.domain
+
+import com.swm.idle.domain.common.exception.PersistenceException
+import com.swm.idle.domain.jobposting.entity.jpa.JobPostingFavorite
+import com.swm.idle.domain.jobposting.repository.jpa.JobPostingFavoriteJpaRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+class JobPostingFavoriteService(
+    private val jobPostingFavoriteJpaRepository: JobPostingFavoriteJpaRepository,
+) {
+
+    @Transactional
+    fun create(
+        jobPostingId: UUID,
+        carerId: UUID,
+    ) {
+        val jobPostingFavorite = jobPostingFavoriteJpaRepository.findByJobPostingIdAndCarerId(
+            jobPostingId = jobPostingId,
+            carerId = carerId
+        ) ?: jobPostingFavoriteJpaRepository.save(
+            JobPostingFavorite(
+                carerId = carerId,
+                jobPostingId = jobPostingId,
+            )
+        )
+
+        jobPostingFavorite.active()
+    }
+
+    @Transactional
+    fun delete(
+        jobPostingId: UUID,
+        carerId: UUID,
+    ) {
+        val jobPostingFavorite = jobPostingFavoriteJpaRepository.findByJobPostingIdAndCarerId(
+            jobPostingId = jobPostingId,
+            carerId = carerId
+        ) ?: throw PersistenceException.ResourceNotFound("해당 공고 즐겨찾기 내역이 존재하지 않습니다.")
+
+        jobPostingFavorite.delete()
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/JobPostingFavoriteFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/service/facade/JobPostingFavoriteFacadeService.kt
@@ -1,0 +1,32 @@
+package com.swm.idle.application.jobposting.service.facade
+
+import com.swm.idle.application.jobposting.service.domain.JobPostingFavoriteService
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+data class JobPostingFavoriteFacadeService(
+    private val jobPostingFavoriteService: JobPostingFavoriteService,
+) {
+
+    fun createJobPostingFavorite(
+        jobPostingId: UUID,
+        carerId: UUID,
+    ) {
+        jobPostingFavoriteService.create(
+            jobPostingId = jobPostingId,
+            carerId = carerId,
+        )
+    }
+
+    fun deleteJobPostingFavorite(
+        jobPostingId: UUID,
+        carerId: UUID,
+    ) {
+        jobPostingFavoriteService.delete(
+            jobPostingId = jobPostingId,
+            carerId = carerId,
+        )
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingFavorite.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingFavorite.kt
@@ -1,0 +1,24 @@
+package com.swm.idle.domain.jobposting.entity.jpa
+
+import com.swm.idle.domain.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "job_posting_favorite")
+class JobPostingFavorite(
+    carerId: UUID,
+    jobPostingId: UUID,
+) : BaseEntity() {
+
+    @Column(nullable = false)
+    var carerId: UUID = carerId
+        private set
+
+    @Column(nullable = false)
+    var jobPostingId: UUID = jobPostingId
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingFavoriteJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingFavoriteJpaRepository.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.domain.jobposting.repository.jpa
+
+import com.swm.idle.domain.jobposting.entity.jpa.JobPostingFavorite
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface JobPostingFavoriteJpaRepository : JpaRepository<JobPostingFavorite, UUID> {
+
+    fun save(jobPostingFavorite: JobPostingFavorite): JobPostingFavorite
+
+    fun findByJobPostingIdAndCarerId(
+        jobPostingId: UUID,
+        carerId: UUID,
+    ): JobPostingFavorite?
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
@@ -8,8 +8,10 @@ import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollRespo
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import java.util.*
@@ -39,5 +41,17 @@ interface CarerJobPostingApi {
     fun getAppliedJobPostings(
         request: CarerJobPostingScrollRequest,
     ): CarerAppliedJobPostingScrollResponse
+
+    @Secured
+    @Operation(summary = "요양 보호사 공고 즐겨찾기 추가 API")
+    @PostMapping("/{job-posting-id}/favorites")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun createJobPostingFavorite(@PathVariable(value = "job-posting-id") jobPostingId: UUID)
+
+    @Secured
+    @Operation(summary = "요양 보호사 공고 즐겨찾기 삭제 API")
+    @DeleteMapping("/{job-posting-id}/remove-favorites")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteJobPostingFavorite(@PathVariable(value = "job-posting-id") jobPostingId: UUID)
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
@@ -3,6 +3,7 @@ package com.swm.idle.presentation.jobposting.controller
 import com.swm.idle.application.common.converter.PointConverter
 import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.jobposting.service.facade.CarerJobPostingFacadeService
+import com.swm.idle.application.jobposting.service.facade.JobPostingFavoriteFacadeService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.presentation.jobposting.api.CarerJobPostingApi
 import com.swm.idle.support.transfer.jobposting.carer.CarerAppliedJobPostingScrollResponse
@@ -16,6 +17,7 @@ import java.util.*
 class CarerJobPostingController(
     private val carerJobPostingFacadeService: CarerJobPostingFacadeService,
     private val carerService: CarerService,
+    private val jobPostingFavoriteFacadeService: JobPostingFavoriteFacadeService,
 ) : CarerJobPostingApi {
 
     override fun getJobPosting(jobPostingId: UUID): CarerJobPostingResponse {
@@ -44,6 +46,20 @@ class CarerJobPostingController(
         return carerJobPostingFacadeService.getAppliedJobPostings(
             request = request,
             carerId = carer.id
+        )
+    }
+
+    override fun createJobPostingFavorite(jobPostingId: UUID) {
+        jobPostingFavoriteFacadeService.createJobPostingFavorite(
+            carerId = getUserAuthentication().userId,
+            jobPostingId = jobPostingId,
+        )
+    }
+
+    override fun deleteJobPostingFavorite(jobPostingId: UUID) {
+        jobPostingFavoriteFacadeService.deleteJobPostingFavorite(
+            carerId = getUserAuthentication().userId,
+            jobPostingId = jobPostingId,
         )
     }
 


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사의 공고 즐겨찾기 추가 API, 삭제 API를 구현하였습니다.

## 2. Documentation

## Background

요양 보호사는 특정 공고에 대해 찜(즐겨찾기)를 이용해 원하는 공고를 별도로 저장해 둘 수 있어야 합니다.

구인 시, 비슷한 양식의 수많은 공고를 접하게 되므로 찜(즐겨찾기) 기능이 꼭 필요합니다.

<img width="257" alt="스크린샷 2024-08-22 오후 7 14 16" src="https://github.com/user-attachments/assets/038f9a50-946f-4ad3-893d-3e010f919f5e">

<img width="276" alt="스크린샷 2024-08-22 오후 7 13 49" src="https://github.com/user-attachments/assets/b1662991-07e0-4bc7-81d0-9ef74f365ab1">

## Goals & Non-Goals

### Goals

- 요양 보호사는 공고 전체 조회 및 상세 조회하는 화면에서 공고를 찜할 수 있어야 한다.
- 즐겨찾기 버튼이 활성화된 상태에서 유저가 한번 더 클릭 시, 즐겨찾기가 해제되어야 한다.

- soft-delete를 기반으로 동작한다.
    - 즐겨찾기 활성화 시, 해당 유저의 즐겨찾기 내역을 조회 후 재 활성화하거나, 새롭게 추가해야 한다.
    - 즐겨찾기 비 활성화 시, 해당 즐겨찾기 내역을 조회 후, 비활성화한다.
        - 만약 비활성화하려는 즐겨찾기 내역이 존재하지 않는 경우 에러가 발생한다.

## **Methodology & Design(Proposal)**

### ERD

https://www.erdcloud.com/d/koMLaN8C95aA25y7k

<img width="510" alt="image" src="https://github.com/user-attachments/assets/a4c26450-8350-4b65-9c71-7817420fd487">

### API

- 공고 즐겨찾기(찜) API
    - [**공고 즐겨찾기 추가 API**] POST /api/v1/job-postings/{job-posting-id}/favorites
        - request
            - method & path: `POST /api/v1/job-postings/{job-posting-id}/favorites`
        
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
    
    - [**공고 즐겨찾기 삭제 API**] DELETE /api/v1/job-postings/{job-posting-id}/favorites
        - request
            - method & path: `DELETE /api/v1/job-postings/{job-posting-id}/favorites`
        
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
            - 삭제하려는 즐겨찾기 공고가 존재하지 않는 경우
                - status code: `400 Bad Request`

## Schedule

- [x]  설계 및 문서 작성
- [x]  공고 즐겨찾기 추가 API
- [x]  공고 즐겨찾기 삭제 API
- [ ]  즐겨찾기 공고 전체 조회 API
- [ ]  일반 공고 전체 조회, 상세 조회 시 즐겨찾기 활성화 여부 필드 추가
- [ ]  dev 배포
- [ ]  Client API 연동 및 상호 QA
