### PR TITLE
[IDLE-334] 요양 보호사 지원 공고 전체 조회 API 내 즐겨찾기 여부 응답 명세 추가

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/CrawledJobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/CrawledJobPostingService.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.application.jobposting.service.domain
+package com.swm.idle.application.jobposting.domain
 
 import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
 import com.swm.idle.domain.jobposting.repository.jpa.CrawledJobPostingJpaRepository

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingApplyMethodService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingApplyMethodService.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.application.jobposting.service.domain
+package com.swm.idle.application.jobposting.domain
 
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingApplyMethod

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.application.jobposting.service.domain
+package com.swm.idle.application.jobposting.domain
 
 import com.swm.idle.domain.common.dto.FavoriteJobPostingWithWeekdaysDto
 import com.swm.idle.domain.common.exception.PersistenceException

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingLifeAssistanceService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingLifeAssistanceService.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.application.jobposting.service.domain
+package com.swm.idle.application.jobposting.domain
 
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingLifeAssistance

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -1,7 +1,7 @@
-package com.swm.idle.application.jobposting.service.domain
+package com.swm.idle.application.jobposting.domain
 
 import com.swm.idle.application.common.converter.PointConverter
-import com.swm.idle.application.jobposting.service.vo.JobPostingInfo
+import com.swm.idle.application.jobposting.vo.JobPostingInfo
 import com.swm.idle.domain.common.dto.JobPostingWithWeekdaysAndApplyDto
 import com.swm.idle.domain.common.dto.JobPostingWithWeekdaysDto
 import com.swm.idle.domain.common.exception.PersistenceException

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingWeekdayService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingWeekdayService.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.application.jobposting.service.domain
+package com.swm.idle.application.jobposting.domain
 
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingWeekday

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
@@ -1,11 +1,11 @@
-package com.swm.idle.application.jobposting.service.facade
+package com.swm.idle.application.jobposting.facade
 
 import com.swm.idle.application.common.converter.PointConverter
 import com.swm.idle.application.common.security.getUserAuthentication
-import com.swm.idle.application.jobposting.service.domain.JobPostingApplyMethodService
-import com.swm.idle.application.jobposting.service.domain.JobPostingLifeAssistanceService
-import com.swm.idle.application.jobposting.service.domain.JobPostingService
-import com.swm.idle.application.jobposting.service.domain.JobPostingWeekdayService
+import com.swm.idle.application.jobposting.domain.JobPostingApplyMethodService
+import com.swm.idle.application.jobposting.domain.JobPostingLifeAssistanceService
+import com.swm.idle.application.jobposting.domain.JobPostingService
+import com.swm.idle.application.jobposting.domain.JobPostingWeekdayService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.common.dto.JobPostingWithWeekdaysAndApplyDto

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
@@ -1,13 +1,13 @@
-package com.swm.idle.application.jobposting.service.facade
+package com.swm.idle.application.jobposting.facade
 
 import com.swm.idle.application.applys.domain.ApplicantService
 import com.swm.idle.application.applys.domain.CarerApplyService
 import com.swm.idle.application.common.security.getUserAuthentication
-import com.swm.idle.application.jobposting.service.domain.JobPostingApplyMethodService
-import com.swm.idle.application.jobposting.service.domain.JobPostingLifeAssistanceService
-import com.swm.idle.application.jobposting.service.domain.JobPostingService
-import com.swm.idle.application.jobposting.service.domain.JobPostingWeekdayService
-import com.swm.idle.application.jobposting.service.vo.JobPostingInfo
+import com.swm.idle.application.jobposting.domain.JobPostingApplyMethodService
+import com.swm.idle.application.jobposting.domain.JobPostingLifeAssistanceService
+import com.swm.idle.application.jobposting.domain.JobPostingService
+import com.swm.idle.application.jobposting.domain.JobPostingWeekdayService
+import com.swm.idle.application.jobposting.vo.JobPostingInfo
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterManagerService
 import com.swm.idle.application.user.center.service.domain.CenterService

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
@@ -1,9 +1,9 @@
-package com.swm.idle.application.jobposting.service.facade
+package com.swm.idle.application.jobposting.facade
 
 import com.swm.idle.application.common.converter.PointConverter
 import com.swm.idle.application.common.security.getUserAuthentication
-import com.swm.idle.application.jobposting.service.domain.JobPostingFavoriteService
-import com.swm.idle.application.jobposting.service.domain.JobPostingService
+import com.swm.idle.application.jobposting.domain.JobPostingFavoriteService
+import com.swm.idle.application.jobposting.domain.JobPostingService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.domain.common.dto.FavoriteJobPostingWithWeekdaysDto
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/vo/JobPostingInfo.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/vo/JobPostingInfo.kt
@@ -1,4 +1,4 @@
-package com.swm.idle.application.jobposting.service.vo
+package com.swm.idle.application.jobposting.vo
 
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.vo.MentalStatus

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJobPostingTasklet.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJobPostingTasklet.kt
@@ -1,6 +1,6 @@
 package com.swm.idle.batch.job
 
-import com.swm.idle.application.jobposting.service.domain.CrawledJobPostingService
+import com.swm.idle.application.jobposting.domain.CrawledJobPostingService
 import com.swm.idle.batch.common.dto.CrawledJobPostingDto
 import com.swm.idle.batch.util.WorknetCrawler
 import org.springframework.batch.core.StepContribution

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysAndApplyDto.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingWithWeekdaysAndApplyDto.kt
@@ -9,12 +9,14 @@ data class JobPostingWithWeekdaysAndApplyDto(
     val jobPostingWeekdays: List<JobPostingWeekday>,
     var distance: Int = 0,
     val applyTime: LocalDateTime,
+    val isFavorite: Boolean = false,
 ) {
 
     constructor(
         jobPosting: JobPosting,
         jobPostingWeekdays: List<JobPostingWeekday>,
         applyTime: LocalDateTime,
-    ) : this(jobPosting, jobPostingWeekdays, 0, applyTime)
+        isFavorite: Boolean,
+    ) : this(jobPosting, jobPostingWeekdays, 0, applyTime, isFavorite)
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
@@ -14,6 +14,7 @@ import com.swm.idle.domain.jobposting.entity.jpa.QJobPostingWeekday.jobPostingWe
 import org.springframework.stereotype.Repository
 import java.util.*
 
+
 @Repository
 class JobPostingQueryRepository(
     private val jpaQueryFactory: JPAQueryFactory,
@@ -40,12 +41,14 @@ class JobPostingQueryRepository(
         }
 
         return jpaQueryFactory
-            .select(jobPosting, jobPostingWeekday, applys)
+            .select(jobPosting, jobPostingWeekday, applys, jobPostingFavorite)
             .from(jobPosting)
             .leftJoin(jobPostingWeekday).fetchJoin()
             .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
             .leftJoin(applys).fetchJoin()
             .on(jobPosting.id.eq(applys.jobPostingId))
+            .leftJoin(jobPostingFavorite).fetchJoin()
+            .on(jobPosting.id.eq(jobPostingFavorite.jobPostingId))
             .where(jobPosting.id.`in`(jobPostingIds))
             .transform(
                 groupBy(jobPosting.id)
@@ -55,6 +58,8 @@ class JobPostingQueryRepository(
                             jobPosting,
                             list(jobPostingWeekday),
                             applys.createdAt,
+                            jobPostingFavorite.id.isNotNull
+                                .and(jobPostingFavorite.entityStatus.eq(EntityStatus.ACTIVE))
                         )
                     )
             )

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
@@ -62,4 +62,5 @@ interface CarerJobPostingApi {
     fun getMyFavoriteJobPostings(
         request: CursorScrollRequest,
     ): GetMyFavoriteJobPostingScrollResponse
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
@@ -2,8 +2,8 @@ package com.swm.idle.presentation.jobposting.controller
 
 import com.swm.idle.application.common.converter.PointConverter
 import com.swm.idle.application.common.security.getUserAuthentication
-import com.swm.idle.application.jobposting.service.facade.CarerJobPostingFacadeService
-import com.swm.idle.application.jobposting.service.facade.JobPostingFavoriteFacadeService
+import com.swm.idle.application.jobposting.facade.CarerJobPostingFacadeService
+import com.swm.idle.application.jobposting.facade.JobPostingFavoriteFacadeService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.presentation.jobposting.api.CarerJobPostingApi
 import com.swm.idle.support.transfer.jobposting.carer.CarerAppliedJobPostingScrollResponse

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
@@ -1,6 +1,6 @@
 package com.swm.idle.presentation.jobposting.controller
 
-import com.swm.idle.application.jobposting.service.facade.CenterJobPostingFacadeService
+import com.swm.idle.application.jobposting.facade.CenterJobPostingFacadeService
 import com.swm.idle.presentation.jobposting.api.CenterJobPostingApi
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingListResponse
 import com.swm.idle.support.transfer.jobposting.center.CenterJobPostingResponse

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerAppliedJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerAppliedJobPostingScrollResponse.kt
@@ -77,6 +77,11 @@ data class CarerAppliedJobPostingScrollResponse(
 
         @Schema(description = "지원 시각")
         val applyTime: LocalDateTime,
+
+        @get:JsonProperty("isFavorite")
+        @param:JsonProperty("isFavorite")
+        @Schema(description = "즐겨찾기 설정 여부")
+        val isFavorite: Boolean,
     ) {
 
         companion object {
@@ -101,6 +106,7 @@ data class CarerAppliedJobPostingScrollResponse(
                     applyDeadlineType = jobPostingWithWeekdaysAndApplyDto.jobPosting.applyDeadlineType,
                     distance = jobPostingWithWeekdaysAndApplyDto.distance,
                     applyTime = jobPostingWithWeekdaysAndApplyDto.applyTime,
+                    isFavorite = jobPostingWithWeekdaysAndApplyDto.isFavorite
                 )
             }
 


### PR DESCRIPTION
## 1. 📄 Summary
* 공고 즐겨찾기 로직을 추가함에 따라 요양 보호사 지원 공고 전체 조회 API 내 즐겨찾기 여부를 판단할 수 있는 로직을 추가합니다.

<img width="382" alt="스크린샷 2024-08-26 오후 7 18 11" src="https://github.com/user-attachments/assets/eda04414-5b7a-491c-9002-e3f0ee10b80d">
