### PR TITLE
[IDLE-338] 즐겨찾기 등록 API에서 공고 타입을 입력받도록 변경

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
@@ -3,6 +3,7 @@ package com.swm.idle.application.jobposting.domain
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
 import com.swm.idle.domain.common.exception.PersistenceException
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingFavorite
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingFavoriteJpaRepository
 import com.swm.idle.domain.jobposting.repository.querydsl.JobPostingQueryRepository
 import org.springframework.stereotype.Service
@@ -20,6 +21,7 @@ class JobPostingFavoriteService(
     fun create(
         jobPostingId: UUID,
         carerId: UUID,
+        jobPostingType: JobPostingType,
     ) {
         val jobPostingFavorite = jobPostingFavoriteJpaRepository.findByJobPostingIdAndCarerId(
             jobPostingId = jobPostingId,
@@ -28,6 +30,7 @@ class JobPostingFavoriteService(
             JobPostingFavorite(
                 carerId = carerId,
                 jobPostingId = jobPostingId,
+                jobPostingType = jobPostingType,
             )
         )
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
@@ -6,6 +6,7 @@ import com.swm.idle.application.jobposting.domain.JobPostingFavoriteService
 import com.swm.idle.application.jobposting.domain.JobPostingService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.carer.GetMyFavoriteJobPostingScrollResponse
 import org.springframework.stereotype.Service
@@ -21,10 +22,12 @@ data class JobPostingFavoriteFacadeService(
     fun createJobPostingFavorite(
         jobPostingId: UUID,
         carerId: UUID,
+        jobPostingType: JobPostingType,
     ) {
         jobPostingFavoriteService.create(
             jobPostingId = jobPostingId,
             carerId = carerId,
+            jobPostingType = jobPostingType,
         )
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingFavorite.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingFavorite.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.domain.jobposting.entity.jpa
 
 import com.swm.idle.domain.common.entity.BaseEntity
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
@@ -11,6 +12,7 @@ import java.util.*
 class JobPostingFavorite(
     carerId: UUID,
     jobPostingId: UUID,
+    jobPostingType: JobPostingType,
 ) : BaseEntity() {
 
     @Column(nullable = false)
@@ -19,6 +21,10 @@ class JobPostingFavorite(
 
     @Column(nullable = false)
     var jobPostingId: UUID = jobPostingId
+        private set
+
+    @Column(nullable = false)
+    var jobPostingType: JobPostingType = jobPostingType
         private set
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/enums/JobPostingType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/enums/JobPostingType.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.domain.jobposting.enums
+
+enum class JobPostingType {
+    CAREMEET,
+    WORKNET
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
@@ -4,6 +4,7 @@ import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.jobposting.carer.CarerAppliedJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollResponse
+import com.swm.idle.support.transfer.jobposting.carer.CreateJobPostingFavoriteRequest
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.carer.GetMyFavoriteJobPostingScrollResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import java.util.*
@@ -47,7 +49,10 @@ interface CarerJobPostingApi {
     @Operation(summary = "요양 보호사 공고 즐겨찾기 추가 API")
     @PostMapping("/{job-posting-id}/favorites")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun createJobPostingFavorite(@PathVariable(value = "job-posting-id") jobPostingId: UUID)
+    fun createJobPostingFavorite(
+        @PathVariable(value = "job-posting-id") jobPostingId: UUID,
+        @RequestBody createJobPostingFavoriteRequest: CreateJobPostingFavoriteRequest,
+    )
 
     @Secured
     @Operation(summary = "요양 보호사 공고 즐겨찾기 삭제 API")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
@@ -9,6 +9,7 @@ import com.swm.idle.presentation.jobposting.api.CarerJobPostingApi
 import com.swm.idle.support.transfer.jobposting.carer.CarerAppliedJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollResponse
+import com.swm.idle.support.transfer.jobposting.carer.CreateJobPostingFavoriteRequest
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.carer.GetMyFavoriteJobPostingScrollResponse
 import org.springframework.web.bind.annotation.RestController
@@ -50,10 +51,14 @@ class CarerJobPostingController(
         )
     }
 
-    override fun createJobPostingFavorite(jobPostingId: UUID) {
+    override fun createJobPostingFavorite(
+        jobPostingId: UUID,
+        request: CreateJobPostingFavoriteRequest,
+    ) {
         jobPostingFavoriteFacadeService.createJobPostingFavorite(
             carerId = getUserAuthentication().userId,
             jobPostingId = jobPostingId,
+            jobPostingType = request.jobPostingType,
         )
     }
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CreateJobPostingFavoriteRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CreateJobPostingFavoriteRequest.kt
@@ -1,0 +1,13 @@
+package com.swm.idle.support.transfer.jobposting.carer
+
+import com.swm.idle.domain.jobposting.enums.JobPostingType
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "CreateJobPostingFavoriteRequest",
+    description = "공고 즐겨찾기 등록 요청"
+)
+data class CreateJobPostingFavoriteRequest(
+    @Schema(description = "공고 타입")
+    val jobPostingType: JobPostingType,
+)


### PR DESCRIPTION
## 1. 📄 Summary
* 즐겨찾기 등록 API에서 공고 타입을 입력받도록 변경했습니다.
* 공고 즐겨찾기 entity에서 공고 타입 필드를 추가했습니다.

## 2. ✏️ Documentation
### API

- 공고 즐겨찾기(찜) API
    - [**공고 즐겨찾기 추가 API**] POST /api/v1/job-postings/{job-posting-id}/favorites
        - request
            - method & path: `POST /api/v1/job-postings/{job-posting-id}/favorites`
            - body
                
              ```json
              {
                 "jobPostingType": "CAREMEET"
              }
              ```
              
                - jobPostingType : 공고 타입
                    - CAREMEET : 케어밋 서비스에서 등록된 공고
                    - WORKNET : 워크넷에서 크롤링된 공고
        
        - response
            - 정상 처리된 경우
                - status code: `204 No Content`
   