### PR TITLE
[IDLE-342] 구인 공고의 마감 기한을 전처리하기 위한 로직 추가

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -58,7 +58,7 @@ class JobPostingService(
                         it,
                         DateTimeFormatter.ofPattern("yyyy-MM-dd")
                     )
-                },
+                } ?: LocalDate.now().plusMonths(1),
                 applyDeadlineType = jobPostingInfo.applyDeadlineType,
                 location = PointConverter.convertToPoint(
                     jobPostingInfo.latitude.toDouble(),

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
@@ -3,6 +3,7 @@ package com.swm.idle.batch.common.dto
 import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
 import com.swm.idle.support.common.uuid.UuidCreator
 import org.locationtech.jts.geom.Point
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -23,6 +24,15 @@ data class CrawledJobPostingDto(
     val directUrl: String,
 ) {
 
+    fun parseApplyDeadline(applyDeadline: String): LocalDate {
+        return if (applyDeadline.contains("채용시까지")) {
+            LocalDate.now().plusMonths(1)
+        } else {
+            val dateString = applyDeadline.substringBefore("마감시간").trim()
+            LocalDate.parse(dateString, DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+        }
+    }
+
     fun toDomain(location: Point): CrawledJobPosting {
         return CrawledJobPosting(
             id = UuidCreator.create(),
@@ -36,7 +46,7 @@ data class CrawledJobPostingDto(
             payInfo = payInfo,
             workTime = workTime,
             workSchedule = workSchedule,
-            applyDeadline = applyDeadline,
+            applyDeadline = parseApplyDeadline(applyDeadline),
             recruitmentProcess = recruitmentProcess,
             applyMethod = applyMethod,
             requiredDocument = requiredDocument,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.locationtech.jts.geom.Point
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -18,7 +19,7 @@ class CrawledJobPosting(
     payInfo: String,
     workTime: String,
     workSchedule: String,
-    applyDeadline: String,
+    applyDeadline: LocalDate,
     recruitmentProcess: String,
     applyMethod: String,
     requiredDocument: String,
@@ -58,8 +59,7 @@ class CrawledJobPosting(
     var workSchedule: String = workSchedule
         private set
 
-    @Column(columnDefinition = "varchar(255)")
-    var applyDeadline: String = applyDeadline
+    var applyDeadline: LocalDate = applyDeadline
         private set
 
     @Column(columnDefinition = "varchar(255)")

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
@@ -59,7 +59,7 @@ data class CrawlingJobPostingScrollResponse(
                     workingTime = crawlingJobPostingPreviewDto.crawledJobPosting.workTime,
                     workingSchedule = crawlingJobPostingPreviewDto.crawledJobPosting.workSchedule,
                     payInfo = crawlingJobPostingPreviewDto.crawledJobPosting.payInfo,
-                    applyDeadline = crawlingJobPostingPreviewDto.crawledJobPosting.applyDeadline,
+                    applyDeadline = crawlingJobPostingPreviewDto.crawledJobPosting.applyDeadline.toString(),
                     distance = crawlingJobPostingPreviewDto.distance,
                     isFavorite = crawlingJobPostingPreviewDto.isFavorite,
                 )

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
@@ -86,7 +86,7 @@ data class CrawlingJobPostingResponse(
                 payInfo = crawlingJobPosting.payInfo,
                 workingTime = crawlingJobPosting.workTime,
                 workingSchedule = crawlingJobPosting.workSchedule,
-                applyDeadline = crawlingJobPosting.applyDeadline,
+                applyDeadline = crawlingJobPosting.applyDeadline.toString(),
                 recruitmentProcess = crawlingJobPosting.recruitmentProcess,
                 applyMethod = crawlingJobPosting.applyMethod,
                 requiredDocumentation = crawlingJobPosting.requiredDocument,


### PR DESCRIPTION
## 1. 📄 Summary
* 구인 공고의 마감 기한을 전처리하기 위한 로직을 추가하였습니다.

* 기존 공고 : 별도의 마감기한이 설정되지 않은 경우, 등록일로부터 1달
* 크롤링 된 공고 
1. 채용시까지로 표기된 경우 -> 크롤링 일자로부터 1달
2. 정확한 날짜가 기재되어 있는 경우 -> 기존 날짜 유지