### PR TITLE
[IDLE-342] 요양 보호사 측 모든 구인 공고 조회 API에서 공고 타입을 추가한다.

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -58,7 +58,7 @@ class JobPostingService(
                         it,
                         DateTimeFormatter.ofPattern("yyyy-MM-dd")
                     )
-                },
+                } ?: LocalDate.now().plusMonths(1),
                 applyDeadlineType = jobPostingInfo.applyDeadlineType,
                 location = PointConverter.convertToPoint(
                     jobPostingInfo.latitude.toDouble(),

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
@@ -3,6 +3,7 @@ package com.swm.idle.batch.common.dto
 import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
 import com.swm.idle.support.common.uuid.UuidCreator
 import org.locationtech.jts.geom.Point
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -23,6 +24,15 @@ data class CrawledJobPostingDto(
     val directUrl: String,
 ) {
 
+    fun parseApplyDeadline(applyDeadline: String): LocalDate {
+        return if (applyDeadline.contains("채용시까지")) {
+            LocalDate.now().plusMonths(1)
+        } else {
+            val dateString = applyDeadline.substringBefore("마감시간").trim()
+            LocalDate.parse(dateString, DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+        }
+    }
+
     fun toDomain(location: Point): CrawledJobPosting {
         return CrawledJobPosting(
             id = UuidCreator.create(),
@@ -36,7 +46,7 @@ data class CrawledJobPostingDto(
             payInfo = payInfo,
             workTime = workTime,
             workSchedule = workSchedule,
-            applyDeadline = applyDeadline,
+            applyDeadline = parseApplyDeadline(applyDeadline),
             recruitmentProcess = recruitmentProcess,
             applyMethod = applyMethod,
             requiredDocument = requiredDocument,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.locationtech.jts.geom.Point
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -18,7 +19,7 @@ class CrawledJobPosting(
     payInfo: String,
     workTime: String,
     workSchedule: String,
-    applyDeadline: String,
+    applyDeadline: LocalDate,
     recruitmentProcess: String,
     applyMethod: String,
     requiredDocument: String,
@@ -58,8 +59,7 @@ class CrawledJobPosting(
     var workSchedule: String = workSchedule
         private set
 
-    @Column(columnDefinition = "varchar(255)")
-    var applyDeadline: String = applyDeadline
+    var applyDeadline: LocalDate = applyDeadline
         private set
 
     @Column(columnDefinition = "varchar(255)")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CrawlingJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CrawlingJobPostingApi.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import java.util.*
 
 @Tag(name = "Crawling Job Posting", description = "크롤링 공고 API")
-@RequestMapping("/api/v1/crwaling-job-postings", produces = ["application/json;charset=utf-8"])
+@RequestMapping("/api/v1/crawling-job-postings", produces = ["application/json;charset=utf-8"])
 interface CrawlingJobPostingApi {
 
     @Secured

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerAppliedJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerAppliedJobPostingScrollResponse.kt
@@ -2,6 +2,7 @@ package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.vo.PayType
 import com.swm.idle.domain.jobposting.vo.Weekdays
@@ -82,6 +83,9 @@ data class CarerAppliedJobPostingScrollResponse(
         @param:JsonProperty("isFavorite")
         @Schema(description = "즐겨찾기 설정 여부")
         val isFavorite: Boolean,
+
+        @Schema(description = "공고 타입")
+        val jobPostingType: JobPostingType = JobPostingType.CAREMEET,
     ) {
 
         companion object {

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
@@ -2,6 +2,7 @@ package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.vo.ApplyMethodType
 import com.swm.idle.domain.jobposting.vo.LifeAssistanceType
@@ -123,6 +124,9 @@ data class CarerJobPostingResponse(
     @param:JsonProperty("isFavorite")
     @Schema(description = "즐겨찾기 설정 여부")
     val isFavorite: Boolean,
+
+    @Schema(description = "공고 타입")
+    val jobPostingType: JobPostingType = JobPostingType.CAREMEET,
 ) {
 
     companion object {

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingScrollResponse.kt
@@ -2,6 +2,7 @@ package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.vo.PayType
 import com.swm.idle.domain.jobposting.vo.Weekdays
@@ -82,6 +83,9 @@ data class CarerJobPostingScrollResponse(
         @param:JsonProperty("isFavorite")
         @Schema(description = "즐겨찾기 설정 여부")
         val isFavorite: Boolean,
+
+        @Schema(description = "공고 타입")
+        val jobPostingType: JobPostingType = JobPostingType.CAREMEET,
     ) {
 
         companion object {

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
@@ -2,6 +2,7 @@ package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.common.dto.CrawlingJobPostingPreviewDto
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.support.transfer.common.ScrollResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
@@ -46,6 +47,9 @@ data class CrawlingJobPostingScrollResponse(
         @param:JsonProperty("isFavorite")
         @Schema(description = "즐겨찾기 설정 여부")
         val isFavorite: Boolean,
+
+        @Schema(description = "공고 타입")
+        val jobPostingType: JobPostingType = JobPostingType.WORKNET,
     ) {
 
         companion object {
@@ -59,7 +63,7 @@ data class CrawlingJobPostingScrollResponse(
                     workingTime = crawlingJobPostingPreviewDto.crawledJobPosting.workTime,
                     workingSchedule = crawlingJobPostingPreviewDto.crawledJobPosting.workSchedule,
                     payInfo = crawlingJobPostingPreviewDto.crawledJobPosting.payInfo,
-                    applyDeadline = crawlingJobPostingPreviewDto.crawledJobPosting.applyDeadline,
+                    applyDeadline = crawlingJobPostingPreviewDto.crawledJobPosting.applyDeadline.toString(),
                     distance = crawlingJobPostingPreviewDto.distance,
                     isFavorite = crawlingJobPostingPreviewDto.isFavorite,
                 )

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
@@ -48,7 +48,7 @@ data class CrawlingJobPostingScrollResponse(
         @Schema(description = "즐겨찾기 설정 여부")
         val isFavorite: Boolean,
 
-        @Schema(description = "공고 타입")
+        @Schema(description = "공고 타입", example = "WORKNET")
         val jobPostingType: JobPostingType = JobPostingType.WORKNET,
     ) {
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/GetMyFavoriteJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/GetMyFavoriteJobPostingScrollResponse.kt
@@ -2,6 +2,7 @@ package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.vo.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.vo.PayType
 import com.swm.idle.domain.jobposting.vo.Weekdays
@@ -82,6 +83,9 @@ data class GetMyFavoriteJobPostingScrollResponse(
         @param:JsonProperty("isFavorite")
         @Schema(description = "즐겨찾기 설정 여부")
         val isFavorite: Boolean,
+
+        @Schema(description = "공고 타입")
+        val jobPostingType: JobPostingType = JobPostingType.CAREMEET,
     ) {
 
         companion object {

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
@@ -64,7 +64,7 @@ data class CrawlingJobPostingResponse(
     @Schema(description = "즐겨찾기 설정 여부")
     val isFavorite: Boolean,
 
-    @Schema(description = "공고 타입")
+    @Schema(description = "공고 타입", example = "WORKNET")
     val jobPostingType: JobPostingType = JobPostingType.WORKNET,
 ) {
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
@@ -59,13 +59,13 @@ data class CrawlingJobPostingResponse(
     @Schema(description = "외부 공고 url")
     val jobPostingUrl: String,
 
-    @Schema(description = "공고 타입(워크넷, 케어밋)")
-    val jobPostingType: JobPostingType,
-
     @get:JsonProperty("isFavorite")
     @param:JsonProperty("isFavorite")
     @Schema(description = "즐겨찾기 설정 여부")
     val isFavorite: Boolean,
+
+    @Schema(description = "공고 타입")
+    val jobPostingType: JobPostingType = JobPostingType.WORKNET,
 ) {
 
     companion object {
@@ -86,7 +86,7 @@ data class CrawlingJobPostingResponse(
                 payInfo = crawlingJobPosting.payInfo,
                 workingTime = crawlingJobPosting.workTime,
                 workingSchedule = crawlingJobPosting.workSchedule,
-                applyDeadline = crawlingJobPosting.applyDeadline,
+                applyDeadline = crawlingJobPosting.applyDeadline.toString(),
                 recruitmentProcess = crawlingJobPosting.recruitmentProcess,
                 applyMethod = crawlingJobPosting.applyMethod,
                 requiredDocumentation = crawlingJobPosting.requiredDocument,


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사 기준으로, 사용 가능한 모든 구인 공고 조회 API에서 공고 타입(WORKNET, CAREMEET)을 추가하였습니다.

[적용된 API 리스트]
* 요양 보호사 구인 공고 전체 조회 API (완료)
* 요양 보호사 구인 공고 상세 조회 API (완료)
* 요양 보호사 즐겨찾기 공고 전체 조회 API(완료)
* 요양 보호사별 지원 공고 전체 조회 API(완료)
* 크롤링 공고 전체 조회 API(완료)
* 크롤링 공고 상세 조회 API(완료)