### PR TITLE
[IDLE-341] 즐겨찾기한 크롤링 공고 전체 조회 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ subprojects {
         implementation("com.querydsl:querydsl-apt:5.1.0:jakarta")
         implementation(rootProject.libs.locationtech)
         implementation(rootProject.libs.jakarta.persistence.api)
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
         kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
         kapt(rootProject.libs.spring.boot.configuration.processor)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,8 @@ jakarta-annotation-api = "3.0.0"
 
 jts-core = "1.19.0"
 
+jackson-module-kotlin = "2.17.0"
+
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
@@ -92,6 +94,7 @@ jakarta-annotation-api = { group = "jakarta.annotation", name = "jakarta.annotat
 jakarta-persistence-api = { group = "jakarta.persistence", name = "jakarta.persistence-api", version.ref = "jakarta-persistence-api"}
 
 locationtech = { group = "org.locationtech.jts", name = "jts-core", version.ref = "jts-core"}
+jackson-module-kotlin = { group = "com.fasterxml.jackson.moudle", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin"}
 [plugins]
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-cloud" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/CrawlingJobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/CrawlingJobPostingService.kt
@@ -50,4 +50,8 @@ class CrawlingJobPostingService(
         ).toInt()
     }
 
+    fun findMyFavoritesByCarerId(carerId: UUID): List<CrawledJobPosting>? {
+        return crawlingJobPostingJpaRepository.findAllFavoritesByCarerId(carerId)
+    }
+
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
@@ -4,7 +4,6 @@ import com.swm.idle.domain.common.exception.PersistenceException
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingFavorite
 import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingFavoriteJpaRepository
-import com.swm.idle.domain.jobposting.repository.querydsl.JobPostingQueryRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -13,7 +12,6 @@ import java.util.*
 @Transactional(readOnly = true)
 class JobPostingFavoriteService(
     private val jobPostingFavoriteJpaRepository: JobPostingFavoriteJpaRepository,
-    private val jobPostingQueryRepository: JobPostingQueryRepository,
 ) {
 
     @Transactional

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
@@ -1,6 +1,5 @@
 package com.swm.idle.application.jobposting.domain
 
-import com.swm.idle.domain.common.dto.JobPostingPreviewDto
 import com.swm.idle.domain.common.exception.PersistenceException
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingFavorite
 import com.swm.idle.domain.jobposting.enums.JobPostingType
@@ -48,18 +47,6 @@ class JobPostingFavoriteService(
         ) ?: throw PersistenceException.ResourceNotFound("해당 공고 즐겨찾기 내역이 존재하지 않습니다.")
 
         jobPostingFavorite.delete()
-    }
-
-    fun findMyFavoriteJobPostingsByCarerId(
-        carerId: UUID,
-        next: UUID?,
-        limit: Long,
-    ): List<JobPostingPreviewDto> {
-        return jobPostingQueryRepository.findAllInFavorites(
-            carerId = carerId,
-            next = next,
-            limit = limit
-        )
     }
 
     fun findByJobPostingIdAndCarerId(jobPostingId: UUID, carerId: UUID): JobPostingFavorite? {

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -135,6 +135,7 @@ class JobPostingService(
         roadNameAddress: String,
         lotNumberAddress: String,
         latitude: String,
+
         longitude: String,
         clientName: String?,
         gender: GenderType?,
@@ -232,6 +233,10 @@ class JobPostingService(
             jobPosting.location,
             carerLocation
         ).toInt()
+    }
+
+    fun findAllFavorites(carerId: UUID): List<JobPostingPreviewDto>? {
+        return jobPostingQueryRepository.findAllInFavorites(carerId)
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
@@ -11,10 +11,12 @@ import com.swm.idle.application.jobposting.domain.JobPostingWeekdayService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
+import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import com.swm.idle.support.transfer.jobposting.carer.CarerAppliedJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
+import com.swm.idle.support.transfer.jobposting.carer.JobPostingFavoriteResponse
 import org.locationtech.jts.geom.Point
 import org.springframework.stereotype.Service
 import java.util.*
@@ -183,6 +185,31 @@ class CarerJobPostingFacadeService(
                 limit.toInt()
             )
         return items to newNext
+    }
+
+    fun getMyFavoriteJobPostings(
+        carer: Carer,
+        location: Point,
+    ): JobPostingFavoriteResponse {
+        val jobPostingPreviewDtos: List<JobPostingPreviewDto>? =
+            jobPostingService.findAllFavorites(carer.id)
+
+        jobPostingPreviewDtos?.map { jobPostingPreviewDto ->
+            val distance = jobPostingService.calculateDistance(
+                jobPostingPreviewDto.jobPosting,
+                PointConverter.convertToPoint(
+                    latitude = carer.latitude.toDouble(),
+                    longitude = carer.longitude.toDouble(),
+                )
+            )
+
+            JobPostingFavoriteResponse.MyFavoriteJobPostingDto.of(
+                jobPostingPreviewDto = jobPostingPreviewDto,
+                distance = distance,
+            )
+        }.let {
+            return JobPostingFavoriteResponse.from(it!!)
+        }
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
@@ -6,7 +6,9 @@ import com.swm.idle.application.jobposting.domain.CrawlingJobPostingService
 import com.swm.idle.application.jobposting.domain.JobPostingFavoriteService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.domain.common.dto.CrawlingJobPostingPreviewDto
+import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import com.swm.idle.infrastructure.client.geocode.service.GeoCodeService
+import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingFavoriteResponse
 import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.common.CrawlingJobPostingResponse
@@ -54,6 +56,30 @@ class CrawlingJobPostingFacadeService(
             next = next,
             total = items.size,
         )
+    }
+
+    fun getFavoriteCrawlingJobPostings(
+        carer: Carer,
+        location: Point,
+    ): CrawlingJobPostingFavoriteResponse {
+        val crawlingJobPostings = crawlingJobPostingService.findMyFavoritesByCarerId(carer.id)
+
+        crawlingJobPostings?.map { crawledJobPosting ->
+            val distance = crawlingJobPostingService.calculateDistance(
+                crawledJobPosting,
+                PointConverter.convertToPoint(
+                    latitude = carer.latitude.toDouble(),
+                    longitude = carer.longitude.toDouble(),
+                )
+            )
+
+            CrawlingJobPostingFavoriteResponse.CrawlingJobPostingFavoriteDto.from(
+                crawledJobPosting = crawledJobPosting,
+                distance = distance,
+            )
+        }.let {
+            return CrawlingJobPostingFavoriteResponse.from(it!!)
+        }
     }
 
     private fun scrollByCarerLocationInRange(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
@@ -1,14 +1,9 @@
 package com.swm.idle.application.jobposting.facade
 
-import com.swm.idle.application.common.converter.PointConverter
-import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.jobposting.domain.JobPostingFavoriteService
 import com.swm.idle.application.jobposting.domain.JobPostingService
 import com.swm.idle.application.user.carer.domain.CarerService
-import com.swm.idle.domain.common.dto.JobPostingPreviewDto
 import com.swm.idle.domain.jobposting.enums.JobPostingType
-import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
-import com.swm.idle.support.transfer.jobposting.carer.GetMyFavoriteJobPostingScrollResponse
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -39,62 +34,6 @@ data class JobPostingFavoriteFacadeService(
             jobPostingId = jobPostingId,
             carerId = carerId,
         )
-    }
-
-    fun getMyFavoriteJobPostings(
-        request: CursorScrollRequest,
-        carerId: UUID,
-    ): GetMyFavoriteJobPostingScrollResponse {
-        val (items, next) = scrollByCarerFavorites(
-            carerId = carerId,
-            next = request.next,
-            limit = request.limit
-        )
-
-        return GetMyFavoriteJobPostingScrollResponse.from(
-            items = items,
-            next = next,
-            total = items.size,
-        )
-    }
-
-    fun scrollByCarerFavorites(
-        carerId: UUID,
-        next: UUID?,
-        limit: Long,
-    ): Pair<List<JobPostingPreviewDto>, UUID?> {
-
-        val FavoriteJobPostingWithWeekdaysDtos =
-            jobPostingFavoriteService.findMyFavoriteJobPostingsByCarerId(
-                next = next,
-                limit = limit + 1,
-                carerId = carerId,
-            )
-
-        val carerLocation = getUserAuthentication().userId.let {
-            carerService.getById(it)
-        }.let {
-            PointConverter.convertToPoint(
-                latitude = it.latitude.toDouble(),
-                longitude = it.longitude.toDouble(),
-            )
-        }
-
-        for (favoriteJobPostingWithWeekdaysDto in FavoriteJobPostingWithWeekdaysDtos) {
-            jobPostingService.calculateDistance(
-                favoriteJobPostingWithWeekdaysDto.jobPosting,
-                carerLocation
-            ).also { favoriteJobPostingWithWeekdaysDto.distance = it }
-        }
-
-        val newNext =
-            if (FavoriteJobPostingWithWeekdaysDtos.size > limit) FavoriteJobPostingWithWeekdaysDtos.last().jobPosting.id else null
-        val items =
-            if (newNext == null) FavoriteJobPostingWithWeekdaysDtos else FavoriteJobPostingWithWeekdaysDtos.subList(
-                0,
-                limit.toInt()
-            )
-        return items to newNext
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingFavorite.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPostingFavorite.kt
@@ -4,6 +4,8 @@ import com.swm.idle.domain.common.entity.BaseEntity
 import com.swm.idle.domain.jobposting.enums.JobPostingType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import java.util.*
 
@@ -23,6 +25,7 @@ class JobPostingFavorite(
     var jobPostingId: UUID = jobPostingId
         private set
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var jobPostingType: JobPostingType = jobPostingType
         private set

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/enums/JobPostingType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/enums/JobPostingType.kt
@@ -1,6 +1,6 @@
 package com.swm.idle.domain.jobposting.enums
 
 enum class JobPostingType {
+    WORKNET,
     CAREMEET,
-    WORKNET
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/CrawlingJobPostingJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/CrawlingJobPostingJpaRepository.kt
@@ -27,4 +27,18 @@ interface CrawlingJobPostingJpaRepository : JpaRepository<CrawledJobPosting, UUI
         @Param("clientLocation") clientLocation: Point,
     ): Double
 
+    @Query(
+        """
+            SELECT cjp.*
+            FROM crawled_job_posting cjp
+            INNER JOIN job_posting_favorite jpf 
+            ON jpf.job_posting_id = cjp.id
+            WHERE cjp.entity_status = 'ACTIVE'
+            AND jpf.entity_status = 'ACTIVE'
+            ORDER BY cjp.id DESC;
+        """,
+        nativeQuery = true
+    )
+    fun findAllFavoritesByCarerId(carerId: UUID): List<CrawledJobPosting>?
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CarerJobPostingApi.kt
@@ -6,7 +6,7 @@ import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CreateJobPostingFavoriteRequest
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
-import com.swm.idle.support.transfer.jobposting.carer.GetMyFavoriteJobPostingScrollResponse
+import com.swm.idle.support.transfer.jobposting.carer.JobPostingFavoriteResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -64,8 +64,6 @@ interface CarerJobPostingApi {
     @Operation(summary = "요양 보호사 즐겨찾기 공고 목록 전체 조회 API")
     @GetMapping("/my/favorites")
     @ResponseStatus(HttpStatus.OK)
-    fun getMyFavoriteJobPostings(
-        request: CursorScrollRequest,
-    ): GetMyFavoriteJobPostingScrollResponse
+    fun getMyFavoriteJobPostings(): JobPostingFavoriteResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CrawlingJobPostingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/api/CrawlingJobPostingApi.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.presentation.jobposting.api
 
 import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingFavoriteResponse
 import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.common.CrawlingJobPostingResponse
@@ -28,5 +29,11 @@ interface CrawlingJobPostingApi {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     fun getCrawlingJobPostings(request: CursorScrollRequest): CrawlingJobPostingScrollResponse
+
+    @Secured
+    @Operation(summary = "즐겨찾기한 크롤링 공고 전체 조회 API")
+    @GetMapping("/my/favorites")
+    @ResponseStatus(HttpStatus.OK)
+    fun getFavoriteCrawlingJobPostings(): CrawlingJobPostingFavoriteResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CarerJobPostingController.kt
@@ -11,7 +11,7 @@ import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CreateJobPostingFavoriteRequest
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
-import com.swm.idle.support.transfer.jobposting.carer.GetMyFavoriteJobPostingScrollResponse
+import com.swm.idle.support.transfer.jobposting.carer.JobPostingFavoriteResponse
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
@@ -69,14 +69,17 @@ class CarerJobPostingController(
         )
     }
 
-    override fun getMyFavoriteJobPostings(
-        request: CursorScrollRequest,
-    ): GetMyFavoriteJobPostingScrollResponse {
+    override fun getMyFavoriteJobPostings(): JobPostingFavoriteResponse {
         val carer = carerService.getById(getUserAuthentication().userId)
 
-        return jobPostingFavoriteFacadeService.getMyFavoriteJobPostings(
-            request = request,
-            carerId = carer.id,
+        val location = PointConverter.convertToPoint(
+            latitude = carer.latitude.toDouble(),
+            longitude = carer.longitude.toDouble(),
+        )
+
+        return carerJobPostingFacadeService.getMyFavoriteJobPostings(
+            carer = carer,
+            location = location,
         )
     }
 

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CrawlingJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CrawlingJobPostingController.kt
@@ -5,6 +5,7 @@ import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.jobposting.facade.CrawlingJobPostingFacadeService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.presentation.jobposting.api.CrawlingJobPostingApi
+import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingFavoriteResponse
 import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.common.CrawlingJobPostingResponse
@@ -32,6 +33,20 @@ class CrawlingJobPostingController(
         return crawlingJobPostingFacadeService.getCrawlingJobPostingsInRange(
             request = request,
             location = location
+        )
+    }
+
+    override fun getFavoriteCrawlingJobPostings(): CrawlingJobPostingFavoriteResponse {
+        val carer = carerService.getById(getUserAuthentication().userId)
+
+        val location = PointConverter.convertToPoint(
+            latitude = carer.latitude.toDouble(),
+            longitude = carer.longitude.toDouble(),
+        )
+
+        return crawlingJobPostingFacadeService.getFavoriteCrawlingJobPostings(
+            carer = carer,
+            location = location,
         )
     }
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
@@ -1,0 +1,79 @@
+package com.swm.idle.support.transfer.jobposting.carer
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
+import com.swm.idle.domain.jobposting.enums.JobPostingType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
+
+@Schema(
+    name = "CrawlingJobPostingFavoriteResponse",
+    description = "즐겨찾기한 크롤링 공고 전체 조회 API"
+)
+data class CrawlingJobPostingFavoriteResponse(
+    val favoriteCrawlingJobPostings: List<CrawlingJobPostingFavoriteDto>,
+) {
+
+    data class CrawlingJobPostingFavoriteDto(
+        @Schema(description = "공고 ID")
+        val id: UUID,
+
+        @Schema(description = "공고 제목")
+        val title: String,
+
+        @Schema(description = "근무 시간")
+        val workingTime: String,
+
+        @Schema(description = "근무 스케줄")
+        val workingSchedule: String,
+
+        @Schema(description = "급여 정보")
+        val payInfo: String,
+
+        @Schema(description = "공고 모집 마감 기한")
+        val applyDeadline: String,
+
+        @Schema(description = "직선 거리", example = "760(단위 : 미터)")
+        val distance: Int,
+
+        @get:JsonProperty("isFavorite")
+        @param:JsonProperty("isFavorite")
+        @Schema(description = "즐겨찾기 설정 여부, 항상 true")
+        val isFavorite: Boolean = true,
+
+        @Schema(description = "공고 타입", example = "WORKNET")
+        val jobPostingType: JobPostingType = JobPostingType.WORKNET,
+    ) {
+
+        companion object {
+
+            fun from(
+                crawledJobPosting: CrawledJobPosting,
+                distance: Int,
+            ): CrawlingJobPostingFavoriteDto {
+                return CrawlingJobPostingFavoriteDto(
+                    id = crawledJobPosting.id,
+                    title = crawledJobPosting.title,
+                    workingTime = crawledJobPosting.workTime,
+                    workingSchedule = crawledJobPosting.workSchedule,
+                    payInfo = crawledJobPosting.payInfo,
+                    applyDeadline = crawledJobPosting.applyDeadline.toString(),
+                    distance = distance,
+                    isFavorite = true,
+                )
+            }
+
+        }
+    }
+
+    companion object {
+
+        fun from(
+            favoriteCrawlingJobPostings: List<CrawlingJobPostingFavoriteDto>,
+        ): CrawlingJobPostingFavoriteResponse {
+            return CrawlingJobPostingFavoriteResponse(favoriteCrawlingJobPostings)
+        }
+
+    }
+
+}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingScrollResponse.kt
@@ -85,6 +85,7 @@ data class CrawlingJobPostingScrollResponse(
                 total = total,
             )
         }
+
     }
 
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CreateJobPostingFavoriteRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CreateJobPostingFavoriteRequest.kt
@@ -8,6 +8,9 @@ import io.swagger.v3.oas.annotations.media.Schema
     description = "공고 즐겨찾기 등록 요청"
 )
 data class CreateJobPostingFavoriteRequest(
-    @Schema(description = "공고 타입")
+    @Schema(
+        description = "공고 타입",
+        allowableValues = ["WORKNET", "CAREMEET"]
+    )
     val jobPostingType: JobPostingType,
 )

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/JobPostingFavoriteResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/JobPostingFavoriteResponse.kt
@@ -8,24 +8,17 @@ import com.swm.idle.domain.jobposting.vo.PayType
 import com.swm.idle.domain.jobposting.vo.Weekdays
 import com.swm.idle.domain.user.common.enum.GenderType
 import com.swm.idle.domain.user.common.vo.BirthYear
-import com.swm.idle.support.transfer.common.ScrollResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
 @Schema(
-    name = "GetMyFavoriteJobPostingResponse",
+    name = "JobPostingFavoriteResponse",
     description = "즐겨찾기 공고 전체 조회 API"
 )
-data class GetMyFavoriteJobPostingScrollResponse(
-    override val items: List<MyFavoriteJobPostingDto>,
-    override val next: UUID?,
-    override val total: Int = 0,
-) : ScrollResponse<GetMyFavoriteJobPostingScrollResponse.MyFavoriteJobPostingDto, UUID?>(
-    items = items,
-    next = next,
-    total = total,
+data class JobPostingFavoriteResponse(
+    val favoriteJobPostings: List<MyFavoriteJobPostingDto>,
 ) {
 
     data class MyFavoriteJobPostingDto(
@@ -90,8 +83,9 @@ data class GetMyFavoriteJobPostingScrollResponse(
 
         companion object {
 
-            fun from(
+            fun of(
                 jobPostingPreviewDto: JobPostingPreviewDto,
+                distance: Int,
             ): MyFavoriteJobPostingDto {
                 return MyFavoriteJobPostingDto(
                     id = jobPostingPreviewDto.jobPosting.id,
@@ -108,7 +102,7 @@ data class GetMyFavoriteJobPostingScrollResponse(
                     isExperiencePreferred = jobPostingPreviewDto.jobPosting.isExperiencePreferred,
                     applyDeadline = jobPostingPreviewDto.jobPosting.applyDeadline,
                     applyDeadlineType = jobPostingPreviewDto.jobPosting.applyDeadlineType,
-                    distance = jobPostingPreviewDto.distance,
+                    distance = distance,
                     applyTime = jobPostingPreviewDto.applyTime,
                     isFavorite = true
                 )
@@ -120,15 +114,9 @@ data class GetMyFavoriteJobPostingScrollResponse(
     companion object {
 
         fun from(
-            items: List<JobPostingPreviewDto>,
-            next: UUID?,
-            total: Int,
-        ): GetMyFavoriteJobPostingScrollResponse {
-            return GetMyFavoriteJobPostingScrollResponse(
-                items = items.map(MyFavoriteJobPostingDto::from),
-                next = next,
-                total = total,
-            )
+            favoriteJobPostings: List<MyFavoriteJobPostingDto>,
+        ): JobPostingFavoriteResponse {
+            return JobPostingFavoriteResponse(favoriteJobPostings)
         }
 
     }


### PR DESCRIPTION
## 1. 📄 Summary
* 즐겨찾기한 크롤링 공고 전체 조회 API를 구현하였습니다.
* 즐겨찾기 케어밋 공고 전체 조회 API 내 페이지네이션을 제거합니다.

## 2. ✏️ Documentation

### API
요양 보호사 - [즐겨찾기한 크롤링 공고 전체 조회 API] GET /api/v1/crawling-job-postings/my/favorites
- request
    - method & path: `GET /api/v1/crawling-job-postings/my/favorites`
    
- response
    - 정상 처리된 경우
        - status code: `200 OK`
        - body
        
        ```json
        {
          "favoriteCrawlingJobPostings": [
            {
              "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
              "title": "string",
              "distance": "int",
              "workingTime": "string",
              "workingSchedule": "string",
              "payInfo": "string",
              "applyDeadline": "string",
              "isFavorite": "boolean", // 즐겨찾기 설정 여부
              "jobPostingType": "WORKNET", // WORKNET 고정
            }
          ]
        }
        ```