### PR TITLE
[IDLE-181] 센터 관리자 회원가입 상태 조회 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ subprojects {
         implementation("com.querydsl:querydsl-apt:5.1.0:jakarta")
         implementation(rootProject.libs.locationtech)
         implementation(rootProject.libs.jakarta.persistence.api)
-        implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+        implementation(rootProject.libs.jackson.module.kotlin)
 
         kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
         kapt(rootProject.libs.spring.boot.configuration.processor)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,7 @@ jakarta-annotation-api = { group = "jakarta.annotation", name = "jakarta.annotat
 jakarta-persistence-api = { group = "jakarta.persistence", name = "jakarta.persistence-api", version.ref = "jakarta-persistence-api"}
 
 locationtech = { group = "org.locationtech.jts", name = "jts-core", version.ref = "jts-core"}
-jackson-module-kotlin = { group = "com.fasterxml.jackson.moudle", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin"}
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin"}
 [plugins]
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-cloud" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerService.kt
@@ -2,7 +2,7 @@ package com.swm.idle.application.user.center.service.domain
 
 import com.swm.idle.domain.common.exception.PersistenceException
 import com.swm.idle.domain.user.center.entity.jpa.CenterManager
-import com.swm.idle.domain.user.center.enums.CenterAccountStatus
+import com.swm.idle.domain.user.center.enums.CenterManagerAccountStatus
 import com.swm.idle.domain.user.center.exception.CenterException
 import com.swm.idle.domain.user.center.repository.jpa.CenterManagerJpaRepository
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
@@ -36,7 +36,7 @@ class CenterManagerService(
             password = encryptedPassword,
             phoneNumber = phoneNumber.value,
             managerName = managerName,
-            status = CenterAccountStatus.PENDING,
+            status = CenterManagerAccountStatus.PENDING,
             centerBusinessRegistrationNumber = centerBusinessRegistrationNumber.value,
         ).also {
             centerManagerJpaRepository.save(it)

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -19,6 +19,7 @@ import com.swm.idle.support.security.exception.SecurityException
 import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.common.LoginResponse
+import com.swm.idle.support.transfer.user.center.JoinStatusInfoResponse
 import org.springframework.stereotype.Service
 
 @Service
@@ -48,6 +49,14 @@ class CenterAuthFacadeService(
             managerName = managerName,
             centerBusinessRegistrationNumber = centerBusinessRegistrationNumber,
         )
+    }
+
+    fun getCenterManagerJoinStatusInfo(): JoinStatusInfoResponse {
+        val centerManager = getUserAuthentication().userId.let {
+            centerManagerService.getById(it)
+        }
+
+        return JoinStatusInfoResponse.from(centerManager)
     }
 
     fun validateCompany(businessRegistrationNumber: BusinessRegistrationNumber): ValidateBusinessRegistrationNumberResponse {

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
@@ -1,6 +1,6 @@
 package com.swm.idle.domain.user.center.entity.jpa
 
-import com.swm.idle.domain.user.center.enums.CenterAccountStatus
+import com.swm.idle.domain.user.center.enums.CenterManagerAccountStatus
 import com.swm.idle.domain.user.common.entity.jpa.User
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -17,7 +17,7 @@ class CenterManager(
     password: String,
     managerName: String,
     phoneNumber: String,
-    status: CenterAccountStatus,
+    status: CenterManagerAccountStatus,
     centerBusinessRegistrationNumber: String,
 ) : User(id, phoneNumber, managerName) {
 
@@ -31,7 +31,7 @@ class CenterManager(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "varchar(255)")
-    var status: CenterAccountStatus = status
+    var status: CenterManagerAccountStatus = status
         private set
 
     @Column(nullable = false, columnDefinition = "varchar(255)")

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/enums/CenterManagerAccountStatus.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/enums/CenterManagerAccountStatus.kt
@@ -1,7 +1,6 @@
 package com.swm.idle.domain.user.center.enums
 
-enum class CenterAccountStatus {
-    ACTIVE,
+enum class CenterManagerAccountStatus {
     PENDING,
-    INACTIVE,
+    APPROVED,
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
@@ -7,6 +7,7 @@ import com.swm.idle.support.transfer.auth.center.JoinRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
+import com.swm.idle.support.transfer.user.center.JoinStatusInfoResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -31,6 +32,12 @@ interface CenterAuthApi {
     fun join(
         @RequestBody request: JoinRequest,
     )
+
+    @Secured
+    @Operation(summary = "센터 관리자 회원가입 상태 조회 API")
+    @GetMapping("/join/status")
+    @ResponseStatus(HttpStatus.OK)
+    fun getJoinStatusInfo(): JoinStatusInfoResponse
 
     @Operation(summary = "사업자 등록번호 인증 API")
     @GetMapping("/authentication/{business-registration-number}")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
@@ -11,6 +11,7 @@ import com.swm.idle.support.transfer.auth.center.JoinRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
+import com.swm.idle.support.transfer.user.center.JoinStatusInfoResponse
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -26,6 +27,10 @@ class CenterAuthController(
             managerName = request.managerName,
             centerBusinessRegistrationNumber = BusinessRegistrationNumber(request.centerBusinessRegistrationNumber),
         )
+    }
+
+    override fun getJoinStatusInfo(): JoinStatusInfoResponse {
+        return centerAuthFacadeService.getCenterManagerJoinStatusInfo()
     }
 
     override fun validateBusinessRegistrationNumber(businessRegistrationNumber: String): ValidateBusinessRegistrationNumberResponse {

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/JoinStatusInfoResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/JoinStatusInfoResponse.kt
@@ -1,0 +1,30 @@
+package com.swm.idle.support.transfer.user.center
+
+import com.swm.idle.domain.user.center.entity.jpa.CenterManager
+import com.swm.idle.domain.user.center.enums.CenterManagerAccountStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
+
+@Schema(
+    name = "JoinStatusInfoResponse",
+    description = "센터 관리자 회원가입 상태 응답"
+)
+data class JoinStatusInfoResponse(
+    val id: UUID,
+    val managerName: String,
+    val phoneNumber: String,
+    val centerManagerAccountStatus: CenterManagerAccountStatus,
+) {
+
+    companion object {
+
+        fun from(centerManager: CenterManager): JoinStatusInfoResponse {
+            return JoinStatusInfoResponse(
+                id = centerManager.id,
+                managerName = centerManager.name,
+                phoneNumber = centerManager.phoneNumber,
+                centerManagerAccountStatus = centerManager.status
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 관리자 회원가입 상태 조회 API를 구현했습니다.

## 2. ✏️ Documentation

## Background

- 센터 관리자로 회원가입 이후, 가입을 시도한 사용자가 실제로 센터 소속 직원인지를 검증해야 합니다.
- 해당 인증절차는 요청 이후, 케어밋측의 확인 절차 이후에 적용됩니다!
<img width="594" alt="스크린샷 2024-09-06 오후 6 05 20" src="https://github.com/user-attachments/assets/e570c6ff-87f7-497a-b3e9-1846f47a9ac6">
- UI 레벨에서 PENDING 상태의 경우 기존 메뉴를 masking한 페이지를 직접 노출시키지 않는 방향으로 협의 중에 있습니다. 온보딩 페이지를 넣어 디지털 리터러시를 확보하는 방향을 우선적으로 고려하고 있습니다.

## Goals & Non-Goals

### Goals

- 센터 관리자로 회원가입 요청 시, 실제 센터 소속임을 확인할 수 있어야 합니다.
    - 이는 케어밋 측에서 직접 전화 통화를 통해 검증해야 합니다.

## **Methodology & Design(Proposal)**

### API

- 센터 소속 인증 API
    - [센터 관리자 회원가입 상태 조회 API] GET /api/v1/auth/center/join/status
        - request
            - method & path: `GET /api/v1/auth/center/join/status`
        
        - response
            - 정상 처리된 경우
                - status code: `200 OK`
                - body
                    
                    ```json
                    {
                    	"id": "string(UUID)",
                    	"managerName": "string",
                    	"phoneNumber": "string",
                    	"centerManagerAccountStatus": "PENDING"
                    }
                    ```
                    
                - description
                    - CenterManagerAccountStatus : 센터 관리자 회원의 회원가입 상태
                        - PENDING : 센터 관리자 회원가입 승인 대기 상태
                        - APPROVED : 센터 관리자 회원가입 승인 상태