### PR TITLE
[IDLE-000] 요양 보호사 공고 상세 조회 시 즐겨찾기 필드 내 버그 수정

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
@@ -11,6 +11,7 @@ import com.swm.idle.application.jobposting.domain.JobPostingWeekdayService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
+import com.swm.idle.domain.common.enums.EntityStatus
 import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import com.swm.idle.support.transfer.jobposting.carer.CarerAppliedJobPostingScrollResponse
 import com.swm.idle.support.transfer.jobposting.carer.CarerJobPostingResponse
@@ -74,7 +75,7 @@ class CarerJobPostingFacadeService(
             center = center,
             distance = distance,
             applyTime = applyInfo?.createdAt,
-            isFavorite = jobPostingFavorite != null,
+            isFavorite = jobPostingFavorite != null && jobPostingFavorite.entityStatus == EntityStatus.ACTIVE,
         )
     }
 
@@ -213,4 +214,3 @@ class CarerJobPostingFacadeService(
     }
 
 }
-


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사 공고 상세 조회 시, 즐겨찾기 여부 필드를 조회할 때 항상 true로 떨어지는 문제를 해결했습니다.
![스크린샷 2024-09-07 오후 1 35 12](https://github.com/user-attachments/assets/b9d9fdd0-2870-4dc2-a113-354493510e8d)
