### PR TITLE
[IDLE-76] 센터 관리자 비밀번호 신규 발급 기능 구현

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerService.kt
@@ -43,6 +43,17 @@ class CenterManagerService(
         }
     }
 
+    fun updatePassword(centerManager: CenterManager, newPassword: Password) {
+        val encryptedPassword = PasswordEncryptor.encrypt(rawPassword = newPassword.value)
+
+        centerManager.updatePassword(encryptedPassword)
+    }
+
+    @Transactional
+    fun delete(centerManagerId: UUID) {
+        centerManagerJpaRepository.deleteById(centerManagerId)
+    }
+
     fun findByIdentifier(identifier: Identifier): CenterManager? {
         return centerManagerJpaRepository.findByIdentifier(identifier.value)
     }
@@ -61,11 +72,6 @@ class CenterManagerService(
 
     fun existsById(centerManagerId: UUID): Boolean {
         return centerManagerJpaRepository.existsById(centerManagerId)
-    }
-
-    @Transactional
-    fun delete(centerManagerId: UUID) {
-        centerManagerJpaRepository.deleteById(centerManagerId)
     }
 
     fun findByPhoneNumber(phoneNumber: PhoneNumber): CenterManager? {

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -16,11 +16,11 @@ import com.swm.idle.infrastructure.client.businessregistration.exception.Busines
 import com.swm.idle.infrastructure.client.businessregistration.service.BusinessRegistrationNumberValidationService
 import com.swm.idle.support.common.encrypt.PasswordEncryptor
 import com.swm.idle.support.security.exception.SecurityException
-import com.swm.idle.support.transfer.auth.center.RefreshLoginTokenResponse
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import com.swm.idle.support.transfer.user.center.JoinStatusInfoResponse
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CenterAuthFacadeService(
@@ -88,17 +88,6 @@ class CenterAuthFacadeService(
         )
     }
 
-    fun refreshLoginToken(refreshToken: String): RefreshLoginTokenResponse {
-        // 이거 센터인지 요양 보호사인지 열어가지구 확인할 수 있도록 해야 함! 이 로직 추가 필요.
-        return refreshTokenService.create(refreshToken)
-            .let {
-                RefreshLoginTokenResponse(
-                    accessToken = it.accessToken,
-                    refreshToken = it.refreshToken,
-                )
-            }
-    }
-
     fun validateIdentifier(identifier: Identifier) {
         centerManagerService.validateDuplicateIdentifier(identifier)
     }
@@ -134,6 +123,15 @@ class CenterAuthFacadeService(
         )
 
         centerManagerService.delete(centerManagerId)
+    }
+
+    @Transactional
+    fun changePassword(newPassword: Password) {
+        val centerManager = getUserAuthentication().userId.let {
+            centerManagerService.getById(it)
+        }
+
+        centerManagerService.updatePassword(centerManager, newPassword)
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
@@ -38,4 +38,8 @@ class CenterManager(
     var centerBusinessRegistrationNumber: String = centerBusinessRegistrationNumber
         private set
 
+    fun updatePassword(newPassword: String) {
+        this.password = newPassword
+    }
+
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
@@ -3,6 +3,7 @@ package com.swm.idle.presentation.auth.center.api
 import com.swm.idle.presentation.common.exception.ErrorResponse
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.auth.center.CenterLoginRequest
+import com.swm.idle.support.transfer.auth.center.ChangePasswordRequest
 import com.swm.idle.support.transfer.auth.center.JoinRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -92,5 +94,11 @@ interface CenterAuthApi {
     fun validateIdentifier(
         @PathVariable("identifier") identifier: String,
     )
+
+    @Secured
+    @Operation(summary = "비밀번호 신규 발급 API")
+    @PatchMapping("/password/new")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun changePassword(@RequestBody request: ChangePasswordRequest)
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
@@ -7,6 +7,7 @@ import com.swm.idle.domain.user.center.vo.Password
 import com.swm.idle.domain.user.common.vo.PhoneNumber
 import com.swm.idle.presentation.auth.center.api.CenterAuthApi
 import com.swm.idle.support.transfer.auth.center.CenterLoginRequest
+import com.swm.idle.support.transfer.auth.center.ChangePasswordRequest
 import com.swm.idle.support.transfer.auth.center.JoinRequest
 import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNumberResponse
 import com.swm.idle.support.transfer.auth.center.WithdrawRequest
@@ -48,6 +49,10 @@ class CenterAuthController(
 
     override fun validateIdentifier(identifier: String) {
         centerAuthFacadeService.validateIdentifier(Identifier(identifier))
+    }
+
+    override fun changePassword(request: ChangePasswordRequest) {
+        centerAuthFacadeService.changePassword(Password(request.newPassword))
     }
 
     override fun logout() {

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/exception/CustomExceptionHandler.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/exception/CustomExceptionHandler.kt
@@ -71,8 +71,7 @@ class CustomExceptionHandler {
     fun handlerSecurityException(
         exception: SecurityException,
         request: HttpServletRequest,
-
-        ): ErrorResponse {
+    ): ErrorResponse {
         val requestMethod: String = request.method
         val requestUrl: String = request.requestURI
         val queryString: String = request.queryString?.let { "?$it" } ?: ""

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/ChangePasswordRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/auth/center/ChangePasswordRequest.kt
@@ -1,0 +1,12 @@
+package com.swm.idle.support.transfer.auth.center
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "ChangePasswordRequest",
+    description = "센터 관리자 비밀번호 변경 요청"
+)
+data class ChangePasswordRequest(
+    @Schema(description = "신규 비밀번호")
+    val newPassword: String,
+)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CarerJobPostingResponse.kt
@@ -2,9 +2,9 @@ package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
-import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.enums.ApplyDeadlineType
 import com.swm.idle.domain.jobposting.enums.ApplyMethodType
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.enums.LifeAssistanceType
 import com.swm.idle.domain.jobposting.enums.MentalStatus
 import com.swm.idle.domain.jobposting.enums.PayType


### PR DESCRIPTION
## Background
![스크린샷 2024-09-07 오후 1 40 25](https://github.com/user-attachments/assets/d962a909-49ba-4e7e-b440-4b73c86bf34e)

## Goals & Non-Goals

### Goals

- ID, 비밀번호를 통해 로그인하는 센터 관리자의 경우, 비밀번호 변경 기능을 지원할 수 있어야 합니다.
- 비밀번호 변경의 경우, 보안과 직결된 문제이므로 SMS 인증을 통해 해당 접근에 대한 사용자 검증이 선행된 후에 수행이 가능하도록 합니다.

## **Methodology & Design(Proposal)**

### API

- API
    - [비밀번호 신규 발급 API] PATCH /api/v1/auth/center/password/new
        - request
            - method & path: `PATCH /api/v1/auth/center/password/new`
            - body
            
            ```jsx
            {
            	"newPassword": "string" // 변경하고자 하는 신규 비밀번호
            }
            ```
            
        
        - response
            - 정상 처리된 경우
                - status code: `204 NO CONTENT`

## Schedule

- [x]  설계 및 문서 작성
- [x]  비밀번호 신규 발급 API
- [x]  dev 배포
- [ ]  Client API 연동 및 상호 QA