### PR TITLE
[IDLE-351] 로깅을 위한 요양 보호사 정보 조회 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/facade/CarerFacadeService.kt
@@ -6,6 +6,7 @@ import com.swm.idle.domain.user.carer.enums.JobSearchStatus
 import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.infrastructure.client.geocode.service.GeoCodeService
 import com.swm.idle.support.transfer.user.carer.GetCarerProfileResponse
+import com.swm.idle.support.transfer.user.common.logging.GetMyCarerInfoResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -81,5 +82,13 @@ class CarerFacadeService(
                 jobSearchStatus = jobSearchStatus,
             )
         }
+    }
+
+    fun getMyCarerInfo(): GetMyCarerInfoResponse {
+        val carer = getUserAuthentication().userId.let {
+            carerService.getById(it)
+        }
+
+        return GetMyCarerInfoResponse(carer.id)
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/api/CarerLoggingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/api/CarerLoggingApi.kt
@@ -1,0 +1,22 @@
+package com.swm.idle.presentation.user.carer.api
+
+import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.user.common.logging.GetMyCarerInfoResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@Tag(name = "[Logging] User-Carer", description = "[Logging] Users - 요양 보호사 API")
+@RequestMapping("/api/v1/logs/users/carer", produces = ["application/json;charset=UTF-8"])
+interface CarerLoggingApi {
+
+    @Secured
+    @Operation(summary = "로그인 된 요양 보호사 정보 조회 API")
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    fun getMyCarerInfo(): GetMyCarerInfoResponse
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/api/CarerLoggingApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/api/CarerLoggingApi.kt
@@ -15,7 +15,7 @@ interface CarerLoggingApi {
 
     @Secured
     @Operation(summary = "로그인 된 요양 보호사 정보 조회 API")
-    @GetMapping
+    @GetMapping("/my")
     @ResponseStatus(HttpStatus.OK)
     fun getMyCarerInfo(): GetMyCarerInfoResponse
 

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/controller/CarerLoggingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/user/carer/controller/CarerLoggingController.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.presentation.user.carer.controller
+
+import com.swm.idle.application.user.carer.facade.CarerFacadeService
+import com.swm.idle.presentation.user.carer.api.CarerLoggingApi
+import com.swm.idle.support.transfer.user.common.logging.GetMyCarerInfoResponse
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CarerLoggingController(
+    private val carerFacadeService: CarerFacadeService,
+) : CarerLoggingApi {
+
+    override fun getMyCarerInfo(): GetMyCarerInfoResponse {
+        return carerFacadeService.getMyCarerInfo()
+    }
+
+}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/common/logging/GetMyCarerInfoResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/common/logging/GetMyCarerInfoResponse.kt
@@ -1,0 +1,13 @@
+package com.swm.idle.support.transfer.user.common.logging
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
+
+@Schema(
+    name = "GetMyCarerInfoResponse",
+    description = "로그인된 요양 보호사 정보 조회 응답"
+)
+data class GetMyCarerInfoResponse(
+    @Schema(description = "요양 보호사 ID")
+    val carerId: UUID,
+)


### PR DESCRIPTION
## Background

케어밋 서비스에서는 유저의 행동 분석을 위한 비즈니스 매트릭을 수집하고 있습니다.

이에 따라, 서비스 API를 제외하고도 필요 시에, 비즈니스 매트릭 수집을 위한 별도 API를 제공할 수 있어야 합니다.

## Goals & Non-Goals

### Goals

- 로그인한 요양 보호사에 대한 구분자(ID)와 더불어 유저 정보를 제공할 수 있어야 합니다.

## **Methodology & Design(Proposal)**

### API

- API
    - [요양 보호사 정보 조회 API] GET /api/v1/logs/users/carer/my
        - request
            - method & path: `GET /api/v1/logs/users/carer/my`
        
        - response
            - 정상 처리된 경우
                - status code: `200 OK`
                - body
                
                ```jsx
                {
                  "carerId": "string(UUID)"
                }
                ```
                

## Schedule

- [x]  설계 및 문서 작성
- [x]  요양 보호사 정보 조회 API
- [x]  dev 배포
- [ ]  Client API 연동 및 상호 QA