### PR TITLE
[IDLE-000] 즐겨찾기한 공고 전체 조회 API 내 생성 일자 필드 추가(일반, 크롤링)

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/CrawlingJobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/CrawlingJobPostingSpatialQueryRepository.kt
@@ -6,8 +6,8 @@ import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.swm.idle.domain.common.dto.CrawlingJobPostingPreviewDto
+import com.swm.idle.domain.common.enums.EntityStatus
 import com.swm.idle.domain.jobposting.entity.jpa.QCrawledJobPosting.crawledJobPosting
-import com.swm.idle.domain.jobposting.entity.jpa.QJobPosting.jobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.QJobPostingFavorite.jobPostingFavorite
 import org.locationtech.jts.geom.Point
 import org.springframework.stereotype.Repository
@@ -49,6 +49,7 @@ class CrawlingJobPostingSpatialQueryRepository(
                             CrawlingJobPostingPreviewDto::class.java,
                             crawledJobPosting,
                             jobPostingFavorite.id.isNotNull
+                                .and(jobPostingFavorite.entityStatus.eq(EntityStatus.ACTIVE))
                         )
                     )
             )
@@ -60,7 +61,7 @@ class CrawlingJobPostingSpatialQueryRepository(
         return Expressions.booleanTemplate(
             "ST_Contains(ST_BUFFER({0}, 3000), {1})",
             location,
-            jobPosting.location,
+            crawledJobPosting.location,
         )
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
@@ -72,7 +72,10 @@ class JobPostingQueryRepository(
             .leftJoin(applys)
             .on(jobPosting.id.eq(applys.jobPostingId))
             .innerJoin(jobPostingFavorite).fetchJoin()
-            .on(jobPosting.id.eq(jobPostingFavorite.jobPostingId))
+            .on(
+                jobPosting.id.eq(jobPostingFavorite.jobPostingId)
+                    .and(jobPostingFavorite.entityStatus.eq(EntityStatus.ACTIVE))
+            )
             .transform(
                 groupBy(jobPosting.id)
                     .list(

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
 import com.swm.idle.domain.jobposting.enums.JobPostingType
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
 import java.util.*
 
 @Schema(
@@ -43,6 +44,9 @@ data class CrawlingJobPostingFavoriteResponse(
 
         @Schema(description = "공고 타입", example = "WORKNET")
         val jobPostingType: JobPostingType = JobPostingType.WORKNET,
+
+        @Schema(description = "공고 생성 시각")
+        val createdAt: LocalDateTime,
     ) {
 
         companion object {
@@ -60,6 +64,7 @@ data class CrawlingJobPostingFavoriteResponse(
                     applyDeadline = crawledJobPosting.applyDeadline.toString(),
                     distance = distance,
                     isFavorite = true,
+                    createdAt = crawledJobPosting.createdAt,
                 )
             }
 

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
@@ -39,8 +39,8 @@ data class CrawlingJobPostingFavoriteResponse(
 
         @get:JsonProperty("isFavorite")
         @param:JsonProperty("isFavorite")
-        @Schema(description = "즐겨찾기 설정 여부, 항상 true")
-        val isFavorite: Boolean = true,
+        @Schema(description = "즐겨찾기 설정 여부")
+        val isFavorite: Boolean,
 
         @Schema(description = "공고 타입", example = "WORKNET")
         val jobPostingType: JobPostingType = JobPostingType.WORKNET,

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/JobPostingFavoriteResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/JobPostingFavoriteResponse.kt
@@ -107,7 +107,7 @@ data class JobPostingFavoriteResponse(
                     applyDeadlineType = jobPostingPreviewDto.jobPosting.applyDeadlineType,
                     distance = distance,
                     applyTime = jobPostingPreviewDto.applyTime,
-                    isFavorite = true,
+                    isFavorite = jobPostingPreviewDto.isFavorite,
                     createdAt = jobPostingPreviewDto.jobPosting.createdAt!!
                 )
             }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/JobPostingFavoriteResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/JobPostingFavoriteResponse.kt
@@ -2,8 +2,8 @@ package com.swm.idle.support.transfer.jobposting.carer
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
-import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.enums.ApplyDeadlineType
+import com.swm.idle.domain.jobposting.enums.JobPostingType
 import com.swm.idle.domain.jobposting.enums.PayType
 import com.swm.idle.domain.jobposting.enums.Weekdays
 import com.swm.idle.domain.user.common.enum.GenderType
@@ -79,6 +79,9 @@ data class JobPostingFavoriteResponse(
 
         @Schema(description = "공고 타입")
         val jobPostingType: JobPostingType = JobPostingType.CAREMEET,
+
+        @Schema(description = "공고 생성 시각")
+        val createdAt: LocalDateTime,
     ) {
 
         companion object {
@@ -104,7 +107,8 @@ data class JobPostingFavoriteResponse(
                     applyDeadlineType = jobPostingPreviewDto.jobPosting.applyDeadlineType,
                     distance = distance,
                     applyTime = jobPostingPreviewDto.applyTime,
-                    isFavorite = true
+                    isFavorite = true,
+                    createdAt = jobPostingPreviewDto.jobPosting.createdAt!!
                 )
             }
 


### PR DESCRIPTION
## 1. 📄 Summary
* 즐겨찾기한 공고 전체 조회 API 내 생성 일자 필드 추가(일반, 크롤링)
* 즐겨찾기한 전체 공고 조회 시, 즐겨찾기 필드가 활성(ACTIVE) 상태인 공고만 조회하도록 로직 변경