### PR TITLE
[IDLE-316] 에러 모니터링을 위한 Sentry 도입

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,9 @@ subprojects {
         implementation(rootProject.libs.jakarta.persistence.api)
         implementation(rootProject.libs.jackson.module.kotlin)
 
+        implementation(rootProject.libs.sentry.spring.boot.starter.jakarta)
+        implementation(rootProject.libs.sentry.logback)
+
         kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
         kapt(rootProject.libs.spring.boot.configuration.processor)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ jts-core = "1.19.0"
 
 jackson-module-kotlin = "2.17.0"
 
+sentry = "7.14.0"
+
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
@@ -90,11 +92,15 @@ querydsl-spatial = { group = "com.querydsl", name = "querydsl-spatial", version.
 querydsl-jpa = { group = "com.querydsl", name = "querydsl-jpa", version.ref = "querydsl"}
 querydsl-apt = { group = "com.querydsl", name = "querydsl-apt", version.ref = "querydsl"}
 
-jakarta-annotation-api = { group = "jakarta.annotation", name = "jakarta.annotation-api", version.ref = "jakarta-annotation-api"}
-jakarta-persistence-api = { group = "jakarta.persistence", name = "jakarta.persistence-api", version.ref = "jakarta-persistence-api"}
+jakarta-annotation-api = { group = "jakarta.annotation", name = "jakarta.annotation-api", version.ref = "jakarta-annotation-api" }
+jakarta-persistence-api = { group = "jakarta.persistence", name = "jakarta.persistence-api", version.ref = "jakarta-persistence-api" }
 
 locationtech = { group = "org.locationtech.jts", name = "jts-core", version.ref = "jts-core"}
-jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin"}
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson-module-kotlin" }
+
+sentry-spring-boot-starter-jakarta = { group = "io.sentry", name = "sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
+sentry-logback = { group = "io.sentry", name = "sentry-logback", version.ref = "sentry" }
+
 [plugins]
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-cloud" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/idle-presentation/src/main/resources/application.yml
+++ b/idle-presentation/src/main/resources/application.yml
@@ -46,6 +46,10 @@ springdoc:
   swagger-ui:
     enabled: true
 
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: dev
+
 logging:
   level:
     root: WARN
@@ -62,3 +66,7 @@ spring:
 springdoc:
   swagger-ui:
     enabled: true
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  environment: prod


### PR DESCRIPTION
## 1. 📄 Summary
* 서비스 운영을 위한 에러 모니터링 라이브러리인 Sentry를 도입했습니다.
* 기본적으로 500번대 에러 `Unhandled Exception` 에 대해 에러 모니터링을 진행합니다. 추후 필요에 따라 400번대 Custom Exception을 추가하려고 합니다.
* 팀 내 소통 채널인 discord에 대해 alert을 함께 설정하였습니다.

![스크린샷 2024-09-07 오후 9 03 36](https://github.com/user-attachments/assets/3b36c5db-9233-4cde-9934-3adff2c28b21)

## 2. ✏️ Documentation
[팀 스페이스 내 문서](https://www.notion.so/Sentry-8b97ea8485324daebf80277d622b98e8)
[공식 Document](https://docs.sentry.io/platforms/java/guides/spring-boot)

실제 Sentry에서 수집하는 에러 정보는 다음과 같이 설정하였습니다. 

```kotlin
  Sentry.captureException(exception) { scope ->
      scope.setExtra("requestMethod", requestMethod)
      scope.setExtra("requestUrl", requestUrl)
      scope.setExtra("queryString", queryString)
      scope.setExtra("clientIp", clientIp)
      getRequestBody(request)?.let { scope.setExtra("requestBody", it) }
  }
```