### PR TITLE
[IDLE-000] 센터 공고 수정 API 내 접수 방법 null 비허용

### DIFF
--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/UpdateJobPostingRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/center/UpdateJobPostingRequest.kt
@@ -64,7 +64,7 @@ data class UpdateJobPostingRequest(
     @Schema(description = "경력자 우대 여부", name = "isExperiencePreferred")
     val isExperiencePreferred: Boolean?,
     @Schema(description = "접수 방법", example = "[CALLING, MESSAGE]")
-    val applyMethod: List<ApplyMethodType>?,
+    val applyMethod: List<ApplyMethodType>,
     @Schema(description = "접수 마감 일자")
     val applyDeadline: String? = null,
     @Schema(description = "접수 마감일 상태")


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 공고 수정 API 내 접수 방법 필드에 null을 비허용하도록 변경합니다.
