### PR TITLE
[IDLE-000] 크롤링 공고 반경범위 조회 필터를 위한 where절 추가

### DIFF
--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 00 01 * * *")
+    @Scheduled(cron = "0 00 01 * * *", zone = "KST")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
@@ -7,7 +7,6 @@ import com.swm.idle.domain.common.config.RedisConfig
 import com.swm.idle.infrastructure.aws.common.AwsConfig
 import com.swm.idle.infrastructure.client.common.config.ClientConfig
 import com.swm.idle.infrastructure.sms.common.config.SmsConfig
-import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import
@@ -27,15 +26,11 @@ import java.util.*
 )
 class IdleServerApplication {
 
-    @PostConstruct
-    fun started() {
-        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
-    }
-
     companion object {
 
         @JvmStatic
         fun main(args: Array<String>) {
+            TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
             runApplication<IdleServerApplication>(*args)
         }
     }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
@@ -10,8 +10,10 @@ import com.swm.idle.infrastructure.sms.common.config.SmsConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import
+import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.*
 
+@EnableScheduling
 @SpringBootApplication
 @Import(
     value = [


### PR DESCRIPTION
## 1. 📄 Summary
* 크롤링 공고 반경범위 조회 필터링을 위한 where 절을 추가합니다.
* 현재 활성화된 공고만 조회 가능하도록 조건을 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 활성 상태의 구인 게시물만 필터링하여 조회하는 기능 개선.
	- 스케줄링 지원을 활성화하여 정해진 시간에 작업을 실행하도록 설정.
- **변경 사항**
	- 변수 이름을 `jobPostingIds`에서 `crawledJobPostingIds`로 변경하여 더 구체적인 맥락 반영.
	- 애플리케이션 시작 시 기본 시간대를 설정하는 로직을 초기화 단계에서 메인 메서드로 이동.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->