### PR TITLE
[IDLE-000] 공고 전체 조회 쿼리 롤백

### DIFF
--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 00 01 * * *", zone = "KST")
+    @Scheduled(cron = "0 00 01 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -1,9 +1,10 @@
 package com.swm.idle.domain.jobposting.repository.querydsl
 
+import com.querydsl.core.group.GroupBy.groupBy
+import com.querydsl.core.group.GroupBy.list
 import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
-import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.swm.idle.domain.applys.entity.jpa.QApplys.applys
 import com.swm.idle.domain.common.dto.JobPostingPreviewDto
@@ -42,33 +43,29 @@ class JobPostingSpatialQueryRepository(
             return emptyList()
         }
 
-        val applysSub = JPAExpressions
-            .select(applys.jobPostingId, applys.createdAt)
-            .from(applys)
-            .where(applys.jobPostingId.`in`(jobPostingIds))
-
-        val favoriteSub = JPAExpressions
-            .select(jobPostingFavorite.jobPostingId)
-            .from(jobPostingFavorite)
-            .where(
-                jobPostingFavorite.jobPostingId.`in`(jobPostingIds)
-                    .and(jobPostingFavorite.entityStatus.eq(EntityStatus.ACTIVE))
-            )
-
         return jpaQueryFactory
-            .selectDistinct(
-                Projections.constructor(
-                    JobPostingPreviewDto::class.java,
-                    jobPosting,
-                    jobPostingWeekday,
-                    applysSub,
-                    favoriteSub.exists()
-                )
-            )
+            .selectDistinct(jobPosting, jobPostingWeekday, jobPostingFavorite, applys)
             .from(jobPosting)
-            .leftJoin(jobPostingWeekday).on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
+            .leftJoin(jobPostingWeekday).fetchJoin()
+            .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
+            .leftJoin(applys).fetchJoin()
+            .on(jobPosting.id.eq(applys.jobPostingId))
+            .leftJoin(jobPostingFavorite).fetchJoin()
+            .on(jobPosting.id.eq(jobPostingFavorite.jobPostingId))
             .where(jobPosting.id.`in`(jobPostingIds))
-            .fetch()
+            .transform(
+                groupBy(jobPosting.id)
+                    .list(
+                        Projections.constructor(
+                            JobPostingPreviewDto::class.java,
+                            jobPosting,
+                            list(jobPostingWeekday),
+                            applys.createdAt ?: null,
+                            jobPostingFavorite.id.isNotNull
+                                .and(jobPostingFavorite.entityStatus.eq(EntityStatus.ACTIVE))
+                        )
+                    )
+            )
     }
 
     private fun isExistInRange(


### PR DESCRIPTION
## 1. 📄 Summary
* 공고 전체 조회 쿼리 롤백

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 스케줄 작업의 실행 시간이 이제 서버의 로컬 시간대에 따라 해석됩니다.
  
- **성능 향상**
	- 작업 게시물 조회 로직이 개선되어, 서브쿼리 대신 조인 방식을 사용하여 데이터 검색 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->