### PR TITLE
[IDLE-000] 13시 00분 기준 크롤링 시각 변경

### DIFF
--- a/.github/workflows/dev-server-integrator.yaml
+++ b/.github/workflows/dev-server-integrator.yaml
@@ -3,7 +3,7 @@ name: Develop Server Integrator (CI)
 on:
   push:
     branches:
-      - develop
+      - chore/IDLE-000
 
 jobs:
   build_and_push:

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 22 13 * * *")
+    @Scheduled(cron = "0 33 13 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 50 13 * * *")
+    @Scheduled(cron = "0 00 14 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 33 13 * * *")
+    @Scheduled(cron = "0 50 13 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 00 13 * * *")
+    @Scheduled(cron = "0 10 13 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 10 13 * * *")
+    @Scheduled(cron = "0 22 13 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 00 01 * * *")
+    @Scheduled(cron = "0 00 13 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/resources/application-batch.yml
+++ b/idle-batch/src/main/resources/application-batch.yml
@@ -1,7 +1,7 @@
 spring:
   batch:
     jdbc:
-      initialize-schema: never
+      initialize-schema: always
 ---
 spring:
   config:

--- a/idle-batch/src/main/resources/application-batch.yml
+++ b/idle-batch/src/main/resources/application-batch.yml
@@ -1,7 +1,7 @@
 spring:
   batch:
     jdbc:
-      initialize-schema: always
+      initialize-schema: never
 ---
 spring:
   config:


### PR DESCRIPTION
## 1. 📄 Summary
* 13시 00분 기준 크롤링 시각 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **변경 사항**
	- CI 워크플로우 트리거를 위한 브랜치가 `develop`에서 `chore/IDLE-000`으로 변경되었습니다.
	- 예약된 작업의 실행 시간이 매일 오전 1시에서 오후 1시 10분으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->