### PR TITLE
[IDLE-000] 스케줄링 기준 시각 14:15로 변경

### DIFF
--- a/.github/workflows/dev-server-integrator.yaml
+++ b/.github/workflows/dev-server-integrator.yaml
@@ -3,7 +3,7 @@ name: Develop Server Integrator (CI)
 on:
   push:
     branches:
-      - develop
+      - test/IDLE-000
 
 jobs:
   build_and_push:

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -11,6 +11,7 @@ import com.swm.idle.domain.jobposting.enums.PayType
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingJpaRepository
 import com.swm.idle.domain.jobposting.repository.querydsl.JobPostingQueryRepository
 import com.swm.idle.domain.jobposting.repository.querydsl.JobPostingSpatialQueryRepository
+import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import com.swm.idle.domain.user.common.enum.GenderType
 import com.swm.idle.domain.user.common.vo.BirthYear
 import org.locationtech.jts.geom.Point
@@ -194,11 +195,13 @@ class JobPostingService(
     }
 
     fun findAllByCarerLocationInRange(
+        carer: Carer,
         location: Point,
         next: UUID?,
         limit: Long,
     ): List<JobPostingPreviewDto> {
         return jobPostingSpatialQueryRepository.findAllWithWeekdaysInRange(
+            carer = carer,
             location = location,
             next = next,
             limit = limit,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
@@ -101,20 +101,23 @@ class CarerJobPostingFacadeService(
         next: UUID?,
         limit: Long,
     ): Pair<List<JobPostingPreviewDto>, UUID?> {
+        val carer = getUserAuthentication().userId.let {
+            carerService.getById(it)
+        }
+
         val jobPostingPreviewDtos = jobPostingService.findAllByCarerLocationInRange(
+            carer = carer,
             location = location,
             next = next,
             limit = limit + 1,
         )
 
-        val carerLocation = getUserAuthentication().userId.let {
-            carerService.getById(it)
-        }.let {
-            PointConverter.convertToPoint(
-                latitude = it.latitude.toDouble(),
-                longitude = it.longitude.toDouble(),
-            )
-        }
+
+        val carerLocation = PointConverter.convertToPoint(
+            latitude = carer.latitude.toDouble(),
+            longitude = carer.longitude.toDouble(),
+        )
+
 
         for (jobPostingPreviewDto in jobPostingPreviewDtos) {
             jobPostingPreviewDto.distance = jobPostingService.calculateDistance(

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
@@ -30,7 +30,7 @@ data class CrawledJobPostingDto(
             content = content,
             clientAddress = clientAddress,
             createdAt = LocalDate.parse(
-                createdAt,
+                createdAt.substring(0, 10),
                 DateTimeFormatter.ofPattern("yyyy.MM.dd")
             ),
             payInfo = payInfo,

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/dto/CrawledJobPostingDto.kt
@@ -3,7 +3,7 @@ package com.swm.idle.batch.common.dto
 import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
 import com.swm.idle.support.common.uuid.UuidCreator
 import org.locationtech.jts.geom.Point
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 data class CrawledJobPostingDto(
@@ -29,9 +29,9 @@ data class CrawledJobPostingDto(
             title = title,
             content = content,
             clientAddress = clientAddress,
-            createdAt = LocalDateTime.parse(
+            createdAt = LocalDate.parse(
                 createdAt,
-                DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss")
+                DateTimeFormatter.ofPattern("yyyy.MM.dd")
             ),
             payInfo = payInfo,
             workTime = workTime,

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 15 14 * * *")
+    @Scheduled(cron = "0 50 14 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 00 01 * * *")
+    @Scheduled(cron = "0 15 14 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJobConfig.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/job/CrawlingJobConfig.kt
@@ -27,6 +27,7 @@ class CrawlingJobConfig(
     fun crawlingJobPostStep(): Step {
         return StepBuilder("crawlingJobPostStep", jobRepository)
             .tasklet(crawlingJobPostingTasklet, transactionManager)
+            .allowStartIfComplete(true)
             .build()
     }
 

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/util/WorknetCrawler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/util/WorknetCrawler.kt
@@ -54,7 +54,7 @@ object WorknetCrawler {
         initializeDriver()
 
         val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-        val today = LocalDate.now().format(formatter)
+        val today = LocalDate.now().minusDays(1).format(formatter)
         val crawlingUrl = CRAWLING_TARGET_URL_FORMAT
             .replace("{today}", today)
             .replace("{pageIndex}", "1")

--- a/idle-batch/src/main/resources/application-batch.yml
+++ b/idle-batch/src/main/resources/application-batch.yml
@@ -20,7 +20,7 @@ spring:
   batch:
     job:
       name: crawlingJob
-      enabled: false
+      enabled: true
 ---
 spring:
   config:

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingPreviewDto.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingPreviewDto.kt
@@ -1,3 +1,5 @@
+package com.swm.idle.domain.common.dto
+
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingWeekday
 import java.time.LocalDateTime
@@ -10,21 +12,17 @@ data class JobPostingPreviewDto(
     val isFavorite: Boolean,
 ) {
 
-    init {
-        jobPostingWeekdays.distinctBy { it.weekday }
-    }
-
     constructor(
         jobPosting: JobPosting,
-        jobPostingWeekdays: List<JobPostingWeekday>,
+        jobPostingWeekdays: Set<JobPostingWeekday>,
         applyTime: LocalDateTime?,
-    ) : this(jobPosting, jobPostingWeekdays.distinctBy { it.weekday }, 0, applyTime, true)
+    ) : this(jobPosting, jobPostingWeekdays.toList(), 0, applyTime, true)
 
     constructor(
         jobPosting: JobPosting,
-        jobPostingWeekdays: List<JobPostingWeekday>,
+        jobPostingWeekdays: Set<JobPostingWeekday>,
         applyTime: LocalDateTime?,
         isFavorite: Boolean,
-    ) : this(jobPosting, jobPostingWeekdays.distinctBy { it.weekday }, 0, applyTime, isFavorite)
+    ) : this(jobPosting, jobPostingWeekdays.toList(), 0, applyTime, isFavorite)
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingPreviewDto.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/dto/JobPostingPreviewDto.kt
@@ -1,5 +1,3 @@
-package com.swm.idle.domain.common.dto
-
 import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.JobPostingWeekday
 import java.time.LocalDateTime
@@ -12,17 +10,21 @@ data class JobPostingPreviewDto(
     val isFavorite: Boolean,
 ) {
 
+    init {
+        jobPostingWeekdays.distinctBy { it.weekday }
+    }
+
     constructor(
         jobPosting: JobPosting,
         jobPostingWeekdays: List<JobPostingWeekday>,
         applyTime: LocalDateTime?,
-    ) : this(jobPosting, jobPostingWeekdays, 0, applyTime, true)
+    ) : this(jobPosting, jobPostingWeekdays.distinctBy { it.weekday }, 0, applyTime, true)
 
     constructor(
         jobPosting: JobPosting,
         jobPostingWeekdays: List<JobPostingWeekday>,
         applyTime: LocalDateTime?,
         isFavorite: Boolean,
-    ) : this(jobPosting, jobPostingWeekdays, 0, applyTime, isFavorite)
+    ) : this(jobPosting, jobPostingWeekdays.distinctBy { it.weekday }, 0, applyTime, isFavorite)
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/CrawledJobPosting.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.locationtech.jts.geom.Point
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.util.*
 
 @Entity
@@ -28,7 +28,7 @@ class CrawledJobPosting(
     centerName: String,
     centerAddress: String,
     directUrl: String,
-    createdAt: LocalDateTime,
+    createdAt: LocalDate,
     location: Point,
 ) {
 
@@ -89,7 +89,7 @@ class CrawledJobPosting(
         private set
 
     @Column(columnDefinition = "timestamp")
-    var createdAt: LocalDateTime = createdAt
+    var createdAt: LocalDate = createdAt
         private set
 
     @Column(columnDefinition = "POINT SRID 4326")

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
@@ -1,7 +1,7 @@
 package com.swm.idle.domain.jobposting.repository.querydsl
 
 import com.querydsl.core.group.GroupBy.groupBy
-import com.querydsl.core.group.GroupBy.list
+import com.querydsl.core.group.GroupBy.set
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.swm.idle.domain.applys.entity.jpa.QApplys.applys
@@ -54,7 +54,7 @@ class JobPostingQueryRepository(
                         Projections.constructor(
                             JobPostingPreviewDto::class.java,
                             jobPosting,
-                            list(jobPostingWeekday),
+                            set(jobPostingWeekday),
                             applys.createdAt,
                             jobPostingFavorite.id.isNotNull
                                 .and(jobPostingFavorite.entityStatus.eq(EntityStatus.ACTIVE))
@@ -83,7 +83,7 @@ class JobPostingQueryRepository(
                         Projections.constructor(
                             JobPostingPreviewDto::class.java,
                             jobPosting,
-                            list(jobPostingWeekday),
+                            set(jobPostingWeekday),
                             applys.createdAt ?: null,
                         )
                     )

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -53,7 +53,7 @@ class JobPostingSpatialQueryRepository(
                 jobPostingFavorite
             )
             .from(jobPosting)
-            .leftJoin(jobPostingWeekday).fetchJoin()
+            .leftJoin(jobPostingWeekday)
             .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
             .leftJoin(applys)
             .on(

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -43,9 +43,6 @@ class JobPostingSpatialQueryRepository(
             return emptyList()
         }
 
-        val isFavorite = jobPostingFavorite.id.isNotNull
-            .and(jobPostingFavorite.entityStatus.eq(EntityStatus.ACTIVE))
-
         return jpaQueryFactory
             .selectDistinct(
                 jobPosting,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -1,7 +1,7 @@
 package com.swm.idle.domain.jobposting.repository.querydsl
 
 import com.querydsl.core.group.GroupBy.groupBy
-import com.querydsl.core.group.GroupBy.list
+import com.querydsl.core.group.GroupBy.set
 import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
@@ -53,7 +53,7 @@ class JobPostingSpatialQueryRepository(
                 jobPostingFavorite
             )
             .from(jobPosting)
-            .leftJoin(jobPostingWeekday)
+            .innerJoin(jobPostingWeekday)
             .on(jobPosting.id.eq(jobPostingWeekday.jobPostingId))
             .leftJoin(applys)
             .on(
@@ -69,7 +69,7 @@ class JobPostingSpatialQueryRepository(
                         Projections.constructor(
                             JobPostingPreviewDto::class.java,
                             jobPosting,
-                            list(jobPostingWeekday),
+                            set(jobPostingWeekday),
                             applys.createdAt ?: null,
                             Expressions.booleanTemplate(
                                 "case when {0} is not null and {1} = {2} then true else false end",

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/carer/CrawlingJobPostingFavoriteResponse.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
 import com.swm.idle.domain.jobposting.enums.JobPostingType
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.util.*
 
 @Schema(
@@ -46,7 +46,7 @@ data class CrawlingJobPostingFavoriteResponse(
         val jobPostingType: JobPostingType = JobPostingType.WORKNET,
 
         @Schema(description = "공고 생성 시각")
-        val createdAt: LocalDateTime?,
+        val createdAt: LocalDate?,
     ) {
 
         companion object {
@@ -61,7 +61,7 @@ data class CrawlingJobPostingFavoriteResponse(
                     workingTime = crawledJobPosting.workTime,
                     workingSchedule = crawledJobPosting.workSchedule,
                     payInfo = crawledJobPosting.payInfo,
-                    applyDeadline = crawledJobPosting.applyDeadline.toString(),
+                    applyDeadline = crawledJobPosting.applyDeadline,
                     distance = distance,
                     isFavorite = true,
                     createdAt = crawledJobPosting.createdAt,

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
@@ -14,6 +14,9 @@ import java.util.*
 data class CrawlingJobPostingResponse(
     val id: UUID,
 
+    @Schema(description = "공고 제목")
+    val title: String?,
+
     @Schema(description = "모집 요강")
     val content: String?,
 
@@ -82,6 +85,7 @@ data class CrawlingJobPostingResponse(
         ): CrawlingJobPostingResponse {
             return CrawlingJobPostingResponse(
                 id = crawlingJobPosting.id,
+                title = crawlingJobPosting.title,
                 content = crawlingJobPosting.content,
                 clientAddress = crawlingJobPosting.clientAddress,
                 longitude = longitude.toString(),

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/jobposting/common/CrawlingJobPostingResponse.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.swm.idle.domain.jobposting.entity.jpa.CrawledJobPosting
 import com.swm.idle.domain.jobposting.enums.JobPostingType
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.util.*
 
 @Schema(
@@ -27,7 +27,7 @@ data class CrawlingJobPostingResponse(
     val latitude: String?,
 
     @Schema(description = "생성 시각")
-    val createdAt: LocalDateTime?,
+    val createdAt: LocalDate?,
 
     @Schema(description = "급여 정보")
     val payInfo: String?,


### PR DESCRIPTION
## 1. 📄 Summary
  - 작업 스케줄러의 실행 시간이 매일 오전 1시에서 오후 2시 50분으로 변경되었습니다.
  - 구인 공고 응답 구조가 개선되어 제목 정보가 추가되었습니다.
  - 구인 공고의 생성일이 시간 정보를 제외한 날짜 형식으로 변경되었습니다.
  - 구인 공고 미리보기 데이터 전송 구조가 개선되어 고유한 요일 정보가 포함됩니다.
  - 구인 공고 조회 시, 특정 카러의 정보를 기반으로 필터링할 수 있는 기능이 추가되었습니다.