### PR TITLE
[IDLE-389] 센터 인증 요청 이벤트 발생 시, 디스코드 웹훅 알림을 전송하는 로직 작성

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerEventPublisher.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerEventPublisher.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.application.user.center.service.domain
+
+import com.swm.idle.domain.user.center.event.CenterManagerVerifyEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class CenterManagerEventPublisher(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+
+    fun publish(centerManagerVerifyEvent: CenterManagerVerifyEvent) {
+        eventPublisher.publishEvent(centerManagerVerifyEvent)
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -23,6 +23,7 @@ import com.swm.idle.support.transfer.auth.center.ValidateBusinessRegistrationNum
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import com.swm.idle.support.transfer.user.center.JoinStatusInfoResponse
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
@@ -139,7 +140,7 @@ class CenterAuthFacadeService(
         centerManagerService.updatePassword(centerManager, newPassword)
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun requestCenterManagerVerification() {
         val centerManager = getUserAuthentication().userId
             .let { centerManagerService.getById(it) }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
@@ -44,4 +44,8 @@ class CenterManager(
         this.status = CenterManagerAccountStatus.PENDING
     }
 
+    fun isNew(): Boolean {
+        return status == CenterManagerAccountStatus.NEW
+    }
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/event/CenterManagerVerifyEvent.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/event/CenterManagerVerifyEvent.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.domain.user.center.event
+
+import com.swm.idle.domain.user.center.entity.jpa.CenterManager
+
+data class CenterManagerVerifyEvent(
+    val centerManager: CenterManager,
+) {
+
+    companion object {
+
+        fun CenterManager.createVerifyEvent(): CenterManagerVerifyEvent {
+            require(isNew()) { "인증 요청이 가능한 상태가 아닙니다." }
+
+            return CenterManagerVerifyEvent(this)
+        }
+
+    }
+
+}

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/properties/BusinessRegistrationNumberProperties.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/properties/BusinessRegistrationNumberProperties.kt
@@ -3,7 +3,7 @@ package com.swm.idle.infrastructure.client.businessregistration.properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("business-registration-number")
-class ClientProperties(
+class BusinessRegistrationNumberProperties(
     val apikey: String,
     val path: String,
     val searchType: String,

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/service/BusinessRegistrationNumberValidationService.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/businessregistration/service/BusinessRegistrationNumberValidationService.kt
@@ -3,14 +3,14 @@ package com.swm.idle.infrastructure.client.businessregistration.service
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.infrastructure.client.businessregistration.dto.BusinessRegistrationNumberValidationResponse
 import com.swm.idle.infrastructure.client.businessregistration.exception.BusinessRegistrationException
-import com.swm.idle.infrastructure.client.businessregistration.properties.ClientProperties
+import com.swm.idle.infrastructure.client.businessregistration.properties.BusinessRegistrationNumberProperties
 import com.swm.idle.infrastructure.client.businessregistration.util.BusinessRegistrationNumberValidationClient
 import org.springframework.stereotype.Service
 import java.net.URI
 
 @Service
 class BusinessRegistrationNumberValidationService(
-    val clientProperties: ClientProperties,
+    val businessRegistrationNumberProperties: BusinessRegistrationNumberProperties,
     val businessRegistrationNumberValidationClient: BusinessRegistrationNumberValidationClient,
 ) {
 
@@ -27,9 +27,9 @@ class BusinessRegistrationNumberValidationService(
     }
 
     private fun generateRequestUri(businessRegistrationNumber: BusinessRegistrationNumber): String {
-        return clientProperties.path + QUERY_PARAMETER_PREFIX +
-                "key=" + clientProperties.apikey + QUERY_PARAMETER_SUFFIX +
-                "gb=" + clientProperties.searchType + QUERY_PARAMETER_SUFFIX +
+        return businessRegistrationNumberProperties.path + QUERY_PARAMETER_PREFIX +
+                "key=" + businessRegistrationNumberProperties.apikey + QUERY_PARAMETER_SUFFIX +
+                "gb=" + businessRegistrationNumberProperties.searchType + QUERY_PARAMETER_SUFFIX +
                 "q=" + businessRegistrationNumber.value + QUERY_PARAMETER_SUFFIX +
                 "type=" + RESPONSE_TYPE
     }

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/event/EventType.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/event/EventType.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.infrastructure.client.discord.common.event
+
+enum class EventType {
+    CENTER_MANAGER_VERIFICATION,
+}

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/properties/DiscordClientProperties.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/properties/DiscordClientProperties.kt
@@ -1,0 +1,15 @@
+package com.swm.idle.infrastructure.client.discord.common.properties
+
+import com.swm.idle.infrastructure.client.discord.common.event.EventType
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("client")
+class DiscordClientProperties(
+    val events: Map<EventType, Properties>,
+) {
+
+    data class Properties(
+        val active: Boolean,
+        val url: String,
+    )
+}

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/utils/DiscordMessageClient.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/utils/DiscordMessageClient.kt
@@ -1,0 +1,23 @@
+package com.swm.idle.infrastructure.client.discord.common.utils
+
+import com.swm.idle.infrastructure.client.discord.common.vo.DiscordMessage
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import java.net.URI
+
+@FeignClient(
+    name = "discord-message-client",
+    url = "discord-webhook-url"
+)
+fun interface DiscordMessageClient {
+
+    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun send(
+        uri: URI,
+        @RequestBody
+        message: DiscordMessage,
+    )
+
+}

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/vo/DiscordMessage.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/common/vo/DiscordMessage.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.infrastructure.client.discord.common.vo
+
+data class DiscordMessage(
+    val content: String,
+)

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/user/center/listener/CenterManagerEventListener.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/user/center/listener/CenterManagerEventListener.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.infrastructure.client.discord.user.center.listener
+
+import com.swm.idle.domain.user.center.event.CenterManagerVerifyEvent
+import com.swm.idle.infrastructure.client.discord.user.center.service.CenterManagerVerifyEventService
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class CenterManagerEventListener(
+    private val centerMangerVerifyEventService: CenterManagerVerifyEventService,
+) {
+
+    @EventListener
+    fun handleCenterManagerVerifyEvent(centerManagerVerifyEvent: CenterManagerVerifyEvent) {
+        centerMangerVerifyEventService.sendVerifyMessage(centerManagerVerifyEvent)
+    }
+
+}

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/user/center/listener/CenterManagerEventListener.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/user/center/listener/CenterManagerEventListener.kt
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Component
 
 @Component
 class CenterManagerEventListener(
-    private val centerMangerVerifyEventService: CenterManagerVerifyEventService,
+    private val centerManagerVerifyEventService: CenterManagerVerifyEventService,
 ) {
 
     @EventListener
     fun handleCenterManagerVerifyEvent(centerManagerVerifyEvent: CenterManagerVerifyEvent) {
-        centerMangerVerifyEventService.sendVerifyMessage(centerManagerVerifyEvent)
+        centerManagerVerifyEventService.sendVerifyMessage(centerManagerVerifyEvent)
     }
 
 }

--- a/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/user/center/service/CenterManagerVerifyEventService.kt
+++ b/idle-infrastructure/client/src/main/kotlin/com/swm/idle/infrastructure/client/discord/user/center/service/CenterManagerVerifyEventService.kt
@@ -1,0 +1,39 @@
+package com.swm.idle.infrastructure.client.discord.user.center.service
+
+import com.swm.idle.domain.user.center.event.CenterManagerVerifyEvent
+import com.swm.idle.infrastructure.client.discord.common.event.EventType
+import com.swm.idle.infrastructure.client.discord.common.properties.DiscordClientProperties
+import com.swm.idle.infrastructure.client.discord.common.utils.DiscordMessageClient
+import com.swm.idle.infrastructure.client.discord.common.vo.DiscordMessage
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import java.net.URI
+
+@Component
+class CenterManagerVerifyEventService(
+    private val discordMessageClient: DiscordMessageClient,
+    private val discordClientProperties: DiscordClientProperties,
+) {
+
+    private val logger = KotlinLogging.logger { }
+
+    fun sendVerifyMessage(centerManagerVerifyEvent: CenterManagerVerifyEvent) {
+
+        if (this.discordClientProperties.events.getValue(EventType.CENTER_MANAGER_VERIFICATION).active) {
+            val discordUri =
+                URI(this.discordClientProperties.events.getValue(EventType.CENTER_MANAGER_VERIFICATION).url)
+            val message =
+                "[🌟새로운 센터 관리자 ${centerManagerVerifyEvent.centerManager.name} 님이 관리자 인증 요청을 보냈어요! 빠르게 확인해주세요 :)"
+
+            runCatching {
+                discordMessageClient.send(
+                    uri = discordUri,
+                    message = DiscordMessage(message),
+                )
+            }.onFailure {
+                logger.error(it) { "💥센터 관리자 인증 요청 발생! 디스코드 메세지 전송에 실패했습니다." }
+            }
+        }
+    }
+
+}

--- a/idle-infrastructure/client/src/main/resources/application-client.yml
+++ b/idle-infrastructure/client/src/main/resources/application-client.yml
@@ -8,3 +8,21 @@ geocode:
     client-id: ${NAVER_MAP_API_CLIENT_ID}
     client-secret: ${NAVER_MAP_API_CLIENT_SECRET}
     base-url: ${NAVER_MAP_API_REQUEST_URL}
+
+client:
+  events:
+    center-manager-verification:
+      active: true
+      url: https://discord.com/api/webhooks/1287686530143617034/eeh-aBBsR2kd8KV2COCF5BCv-y6Oo-fGFCyQBcsYBobVEsNcpHMcHfP3dYWgG8ERoHGC
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+client:
+  events:
+    center-manager-verification:
+      active: true
+      url: https://discord.com/api/webhooks/1287686530143617034/eeh-aBBsR2kd8KV2COCF5BCv-y6Oo-fGFCyQBcsYBobVEsNcpHMcHfP3dYWgG8ERoHGC

--- a/idle-infrastructure/client/src/main/resources/application-client.yml
+++ b/idle-infrastructure/client/src/main/resources/application-client.yml
@@ -12,7 +12,7 @@ geocode:
 client:
   events:
     center-manager-verification:
-      active: true
+      active: false
       url: https://discord.com/api/webhooks/1287686530143617034/eeh-aBBsR2kd8KV2COCF5BCv-y6Oo-fGFCyQBcsYBobVEsNcpHMcHfP3dYWgG8ERoHGC
 
 ---


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 인증 요청 이벤트 발생 시, 디스코드 웹훅 알림을 전송하는 로직 작성

## 2. ✏️ Documentation

### Backgrounds
![스크린샷 2024-09-23 오후 5 40 08](https://github.com/user-attachments/assets/89472c78-4dc2-4373-b009-b219b2f98a82)
- 센터 관리자로 회원가입 이후, 가입을 시도한 사용자가 실제로 센터 소속 직원인지를 검증해야 합니다.
- 해당 인증절차는 요청 이후, 케어밋측의 확인 절차 이후에 적용됩니다!

### API
* - [센터 관리자 전화 인증 요청 API] PATCH /api/v1/auth/center/join/verify
    - request
        - method & path: `PATCH /api/v1/auth/center/join/verify`
    
    - response
        - 정상 처리된 경우
            - status code: `204 NO CONTENT`

## 3. 🤔 고민했던 점

### 기본 트랜잭션 전파 레벨(REQUIRED) 에 따른 문제점
---
케어밋에서는 센터 관리자 인증을 요청하는 비즈니스 로직 수행 되었을 때, 케어밋 측에서 discord 웹훅을 통해 메세지를 수신받아야 하는 요구사항이 존재했습니다.

가장 먼저 고려해야 하는 것은 
**메세지를 보내는 부가 기능에 에러가 발생했을 때** 비즈니스 로직 수행에 영향을 주면 안 된다는 점입니다.

@Transactional을 사용할 경우 디폴트 전파 레벨은 REQUIRED이므로, 
부모 트랜잭션 내에서 새롭게 자식 트랜잭션이 수행될 경우 부모 트랜잭션에 편승되는 구조이기 때문에
디스코드 메세지 전송 로직에서 에러가 나면 모두 롤백 처리가 되는 문제가 있습니다.

따라서, 트랜잭션 전파 레벨을 `REQUIRES_NEW`로 설정하면 이러한 문제를 방지할 수 있게 됩니다.

### Spring Event
Spring Event는 크게 Publisher - Listener 구조를 가지며, 결합도를 느슨하게 하여 명확한 관심사의 분리를 이룰 수 있다는 점에서 도입하게 되었습니다. Event를 사용하지 않으면 application service의 하위 구현체로 infrastructure 레벨의 서비스 로직이 강결합되게 됩니다.

[Application 모듈 - EventPublisher]
``` kotlin
@Service
class CenterManagerEventPublisher(
    private val eventPublisher: ApplicationEventPublisher,
) {

    fun publish(centerManagerVerifyEvent: CenterManagerVerifyEvent) {
        eventPublisher.publishEvent(centerManagerVerifyEvent)
    }

}
```


[Infrastructure-client 모듈 - EventListener]
``` kotlin
@Component
class CenterManagerEventListener(
    private val centerMangerVerifyEventService: CenterManagerVerifyEventService,
) {

    @EventListener
    fun handleCenterManagerVerifyEvent(centerManagerVerifyEvent: CenterManagerVerifyEvent) {
        centerMangerVerifyEventService.sendVerifyMessage(centerManagerVerifyEvent)
    }

}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 센터 관리자 검증 이벤트를 게시하는 기능 추가.
	- Discord에 메시지를 전송하는 서비스 추가.
	- 센터 관리자 검증을 위한 새로운 상태 확인 메서드 추가.
	- 클라이언트 이벤트 설정에서 프로덕션 환경에 따라 활성화된 센터 관리자 검증 구성 추가.

- **버그 수정**
	- 센터 관리자 검증 요청 시 메시지 전송 실패 시 오류 로그 기록 기능 추가.

- **문서화**
	- 클라이언트 이벤트에 대한 새로운 구성 섹션 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->