### PR TITLE
[IDLE-000] Redis 비밀번호 설정 추가

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/RedisConfig.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/config/RedisConfig.kt
@@ -5,6 +5,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisPassword
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
@@ -18,7 +20,13 @@ class RedisConfig(
 
     @Bean
     fun connectionFactory(): RedisConnectionFactory {
-        return LettuceConnectionFactory(redisProperties.host, redisProperties.port)
+        RedisStandaloneConfiguration().apply {
+            hostName = redisProperties.host
+            port = redisProperties.port
+            password = RedisPassword.of(redisProperties.password)
+        }.also {
+            return LettuceConnectionFactory(it)
+        }
     }
 
     @Bean

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/common/properties/RedisProperties.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/common/properties/RedisProperties.kt
@@ -6,4 +6,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class RedisProperties(
     val host: String,
     val port: Int,
+    val password: String,
 )

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -13,7 +13,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
-      password: ${REDIS_PASSWORD}
+      password: ${REDIS_PASSWORD:redis}
 ---
 spring:
   config:

--- a/idle-domain/src/main/resources/application-domain.yml
+++ b/idle-domain/src/main/resources/application-domain.yml
@@ -13,6 +13,7 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
 ---
 spring:
   config:

--- a/idle-presentation/compose-dev.yaml
+++ b/idle-presentation/compose-dev.yaml
@@ -31,6 +31,7 @@ services:
       - "6379:6379"
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
 
 volumes:
   mysql-volume:

--- a/idle-presentation/compose-dev.yaml
+++ b/idle-presentation/compose-dev.yaml
@@ -29,6 +29,8 @@ services:
     container_name: redis_dev
     ports:
       - "6379:6379"
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
 
 volumes:
   mysql-volume:


### PR DESCRIPTION
## 1. 📄 Summary
* 클라분들께서 refresh token 만료 주기 대비 빠르게 만료된다고 제보해 주셔서 확인해본 결과
아래와 같이 redis 내부에 해킹 목적의 스크립트가 심어져 있었네요.

<img width="1009" alt="스크린샷 2024-09-24 오후 6 20 26" src="https://github.com/user-attachments/assets/72f158f8-18e2-4982-9942-ce7be59052f5">

* 해당 백업 스크립트 파일 전체 삭제 후에, redis 내 비밀번호 설정하는 방향으로 선 조치했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- Redis 연결을 위한 비밀번호 설정 가능.
	- Redis 서비스에 대한 환경 변수 구성 추가.
- **버그 수정**
	- Redis 연결 구성 개선으로 보안 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->