### PR TITLE
[IDLE-396] FCM 모듈 추가 및 firebase 의존성 설정

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -43,6 +43,11 @@ jobs:
               --port 22 \
               --cidr ${{ steps.publicip.outputs.ip }}/32
 
+      - name: Set Up Firebase Service Key
+        run : |
+          mkdir ./idle-infrastructure/fcm/main/resources/firebase
+          echo ${{ secrets.FIREBASE_SERVICE_KEY_BASE64_ENCODE }} | base64 -d > /idle-infrastructure/fcm/main/resources/firebase/adminkey.json
+
       - name: Copy Docker Compose file to server
         uses: appleboy/scp-action@master
         with:

--- a/.github/workflows/prod-server-deployer.yaml
+++ b/.github/workflows/prod-server-deployer.yaml
@@ -73,6 +73,11 @@ jobs:
             jq -s '.[0] * .[1]' <(echo "$VARS_CONTEXT") <(echo "$SECRETS_CONTEXT") \
               | jq -r 'to_entries | map("\(.key)=\(.value)") | .[]' > .env
 
+      - name: Set Up Firebase Service Key
+        run: |
+          mkdir ./idle-infrastructure/fcm/main/resources/firebase
+          echo ${{ secrets.FIREBASE_SERVICE_KEY_BASE64_ENCODE }} | base64 -d > /idle-infrastructure/fcm/main/resources/firebase/adminkey.json
+
       - name: Run Docker
         uses: appleboy/ssh-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### JSON ###
+idle-infrastructure/fcm/src/main/resources/firebase

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ subprojects {
         implementation(rootProject.libs.locationtech)
         implementation(rootProject.libs.jakarta.persistence.api)
         implementation(rootProject.libs.jackson.module.kotlin)
-
         implementation(rootProject.libs.sentry.spring.boot.starter.jakarta)
         implementation(rootProject.libs.sentry.logback)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,8 @@ jackson-module-kotlin = "2.17.0"
 
 sentry = "7.14.0"
 
+fcm = "9.3.0"
+
 [libraries]
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
@@ -100,6 +102,8 @@ jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackso
 
 sentry-spring-boot-starter-jakarta = { group = "io.sentry", name = "sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
 sentry-logback = { group = "io.sentry", name = "sentry-logback", version.ref = "sentry" }
+
+fcm = { group = 'com.google.firebase', name = 'firebase-admin', version.ref = "fcm"}
 
 [plugins]
 sonarqube = { id = "org.sonarqube", version.ref = "sonar-cloud" }

--- a/idle-infrastructure/fcm/build.gradle.kts
+++ b/idle-infrastructure/fcm/build.gradle.kts
@@ -1,0 +1,13 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true
+
+dependencies {
+    implementation(project(":idle-support:common"))
+
+    implementation(rootProject.libs.fcm)
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FcmConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FcmConfig.kt
@@ -1,0 +1,29 @@
+package com.swm.idle.infrastructure.fcm.common.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+
+@Configuration
+class FcmConfig {
+
+    @Value("\${firebase.json.path}")
+    lateinit var firebaseConfigJsonPath: String
+
+    @PostConstruct
+    fun initializeFirebaseApp() {
+        val googleCredentials =
+            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
+
+        val fireBaseOptions = FirebaseOptions.builder()
+            .setCredentials(googleCredentials)
+            .build()
+
+        FirebaseApp.initializeApp(fireBaseOptions)
+    }
+
+}

--- a/idle-infrastructure/fcm/src/main/resources/application-fcm.yaml
+++ b/idle-infrastructure/fcm/src/main/resources/application-fcm.yaml
@@ -1,0 +1,3 @@
+firebase:
+  json:
+    path: ./firebase/adminsdk.json

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,9 @@ project(":idle-infrastructure:client").projectDir = file("idle-infrastructure/cl
 include(":idle-infrastructure:sms")
 project(":idle-infrastructure:sms").projectDir = file("idle-infrastructure/sms")
 
+include(":idle-infrastructure:fcm")
+project(":idle-infrastructure:fcm").projectDir = file("idle-infrastructure/fcm")
+
 // support modules
 include(":idle-support:common")
 project(":idle-support:common").projectDir = file("idle-support/common")


### PR DESCRIPTION
## 1. 📄 Summary
* infrastructure 모듈 내 fcm 모듈 추가
* FCM 알림을 위한 firebase admin sdk 의존성 설정
* firebase 내 service key 주입 설정

## 2. 🤔 고민했던 점

## Firebase Service Key 설정값 노출 방지

공식 문서에서는 firebase에 대한 service key 파일을 설정하기 위해 여러 credential 정보가 들어 있는 json 파일을 프로젝트 디렉토리 내에서 저장하고, FileInputStream을 통해 읽어들인 후  initialize를 하는 방식을 소개하고 있습니다.

이러한 경우 secret key를 비롯한 해당 configuration 값이 고스란히 노출된다는 단점이 존재합니다.

### GoogleCredentials.class

<img width="764" alt="스크린샷 2024-09-28 오후 9 14 08" src="https://github.com/user-attachments/assets/4a71dd37-3487-4d2c-b688-d79c28f26091">

FileInputStream으로 값을 전달한 후 Json으로 파싱하여 GoogleCredentials 인스턴스를 생성해주고 있습니다.
→ 그 외의 별도 생성자는 없는 것으로 파악됩니다. 즉, FileInputStream으로 주입은 불가피해 보입니다.

### solution
해당 json file을 github secrets에 저장한 뒤 주입하는 방향이 최선책이라고 판단했습니다.

다만 github secrets에서 json을 저장하는 것을 권장하지 않으므로, 해당 json을 base64로 인코딩하여 secrets에 저장하고 CD 과정에서 디코딩한 후에 주입하는 방식으로 처리하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Firebase 서비스 키 설정을 위한 새로운 단계가 GitHub Actions 워크플로에 추가되었습니다.
	- Firebase Cloud Messaging(FCM) 라이브러리 의존성이 추가되었습니다.
	- 새로운 FCM 모듈이 프로젝트 구조에 포함되었습니다.
	- Firebase 설정을 위한 새로운 구성 클래스가 도입되었습니다.
	- Firebase Admin SDK JSON 파일 경로를 정의하는 새로운 구성 섹션이 추가되었습니다.

- **Chores**
	- `.gitignore` 파일이 업데이트되어 특정 디렉토리가 무시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->