### PR TITLE
[IDLE-399] FCM 디바이스 토큰 관리 API 및 알림 도메인 설계

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/DeviceTokenService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/DeviceTokenService.kt
@@ -1,0 +1,48 @@
+package com.swm.idle.application.notification.domain
+
+import com.swm.idle.domain.notification.jpa.DeviceToken
+import com.swm.idle.domain.notification.repository.DeviceTokenJpaRepository
+import com.swm.idle.domain.user.common.enum.UserType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+@Transactional(readOnly = true)
+class DeviceTokenService(
+    private val deviceTokenJpaRepository: DeviceTokenJpaRepository,
+) {
+
+    fun findByDeviceToken(deviceToken: String): DeviceToken? {
+        return deviceTokenJpaRepository.findByDeviceToken(deviceToken)
+    }
+
+    @Transactional
+    fun updateDeviceTokenUserId(
+        deviceToken: DeviceToken,
+        userId: UUID,
+    ) {
+        deviceToken.updateUserId(userId)
+    }
+
+    @Transactional
+    fun deleteByDeviceToken(deviceToken: String) {
+        deviceTokenJpaRepository.deleteByDeviceToken(deviceToken)
+    }
+
+    @Transactional
+    fun save(
+        userId: UUID,
+        deviceToken: String,
+        userType: UserType,
+    ) {
+        DeviceToken(
+            userId = userId,
+            deviceToken = deviceToken,
+            userType = userType,
+        ).also {
+            deviceTokenJpaRepository.save(it)
+        }
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/notification/facade/DeviceTokenFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/notification/facade/DeviceTokenFacadeService.kt
@@ -1,0 +1,30 @@
+package com.swm.idle.application.notification.facade
+
+import com.swm.idle.application.common.security.getUserAuthentication
+import com.swm.idle.application.notification.domain.DeviceTokenService
+import com.swm.idle.domain.user.common.enum.UserType
+import org.springframework.stereotype.Service
+
+@Service
+class DeviceTokenFacadeService(
+    private val deviceTokenService: DeviceTokenService,
+) {
+
+    fun createDeviceToken(deviceToken: String, userType: UserType) {
+        val userId = getUserAuthentication().userId
+        deviceTokenService.findByDeviceToken(deviceToken)?.let {
+            if (it.userId != userId) {
+                deviceTokenService.updateDeviceTokenUserId(it, userId)
+            }
+        } ?: deviceTokenService.save(
+            userId = userId,
+            deviceToken = deviceToken,
+            userType = userType,
+        )
+    }
+
+    fun deleteDeviceToken(deviceToken: String) {
+        deviceTokenService.deleteByDeviceToken(deviceToken)
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/DeviceToken.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/DeviceToken.kt
@@ -1,0 +1,36 @@
+package com.swm.idle.domain.notification.jpa
+
+import com.swm.idle.domain.common.entity.BaseEntity
+import com.swm.idle.domain.user.common.enum.UserType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "device_token")
+class DeviceToken(
+    deviceToken: String,
+    userId: UUID,
+    userType: UserType,
+) : BaseEntity() {
+
+    @Column(columnDefinition = "varchar(255)")
+    var deviceToken: String = deviceToken
+        private set
+
+    var userId: UUID = userId
+        private set
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(255)")
+    var userType: UserType = userType
+        private set
+
+    fun updateUserId(userId: UUID) {
+        this.userId = userId
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/Notification.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/Notification.kt
@@ -1,0 +1,33 @@
+package com.swm.idle.domain.notification.jpa
+
+import com.swm.idle.domain.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "notification")
+class Notification(
+    isRead: Boolean,
+    title: String,
+    body: String,
+    receiverId: UUID,
+) : BaseEntity() {
+
+    @Column(columnDefinition = "varchar(255)")
+    var isRead: Boolean = isRead
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var title: String = title
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var body: String = body
+        private set
+
+    var receiverId: UUID = receiverId
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/DeviceTokenJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/DeviceTokenJpaRepository.kt
@@ -1,0 +1,15 @@
+package com.swm.idle.domain.notification.repository
+
+import com.swm.idle.domain.notification.jpa.DeviceToken
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface DeviceTokenJpaRepository : JpaRepository<DeviceToken, UUID> {
+
+    fun findByDeviceToken(deviceToken: String): DeviceToken?
+
+    fun deleteByDeviceToken(deviceToken: String)
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/api/DeviceTokenApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/api/DeviceTokenApi.kt
@@ -1,0 +1,31 @@
+package com.swm.idle.presentation.notification.api
+
+import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.notification.CreateDeviceTokenRequest
+import com.swm.idle.support.transfer.notification.DeleteDeviceTokenRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@Tag(name = "FCM Device Token", description = "FCM 디바이스 토큰 API")
+@RequestMapping("/api/v1/fcm", produces = ["application/json;charset=utf-8"])
+interface DeviceTokenApi {
+
+    @Secured
+    @Operation(summary = "FCM 토큰 저장 API")
+    @PostMapping("/token")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createDeviceToken(@RequestBody request: CreateDeviceTokenRequest)
+
+    @Secured
+    @Operation(summary = "FCM 토큰 삭제 API")
+    @DeleteMapping("/token")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteDeviceToken(@RequestBody request: DeleteDeviceTokenRequest)
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/controller/DeviceTokenController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/controller/DeviceTokenController.kt
@@ -1,0 +1,25 @@
+package com.swm.idle.presentation.notification.controller
+
+import com.swm.idle.application.notification.facade.DeviceTokenFacadeService
+import com.swm.idle.presentation.notification.api.DeviceTokenApi
+import com.swm.idle.support.transfer.notification.CreateDeviceTokenRequest
+import com.swm.idle.support.transfer.notification.DeleteDeviceTokenRequest
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class DeviceTokenController(
+    private val deviceTokenFacadeService: DeviceTokenFacadeService,
+) : DeviceTokenApi {
+
+    override fun createDeviceToken(request: CreateDeviceTokenRequest) {
+        deviceTokenFacadeService.createDeviceToken(
+            deviceToken = request.deviceToken,
+            userType = request.userType,
+        )
+    }
+
+    override fun deleteDeviceToken(request: DeleteDeviceTokenRequest) {
+        deviceTokenFacadeService.deleteDeviceToken(request.deviceToken)
+    }
+
+}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/notification/CreateDeviceTokenRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/notification/CreateDeviceTokenRequest.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.support.transfer.notification
+
+import com.swm.idle.domain.user.common.enum.UserType
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "CreateDeviceTokenRequest",
+    description = "FCM 토큰 저장 요청",
+)
+data class CreateDeviceTokenRequest(
+    @Schema(description = "fcm device token")
+    val deviceToken: String,
+
+    @Schema(description = "user type")
+    val userType: UserType,
+)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/notification/DeleteDeviceTokenRequest.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/notification/DeleteDeviceTokenRequest.kt
@@ -1,0 +1,12 @@
+package com.swm.idle.support.transfer.notification
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "DeleteDeviceTokenRequest",
+    description = "FCM 토큰 삭제 요청",
+)
+data class DeleteDeviceTokenRequest(
+    @Schema(description = "fcm device token")
+    val deviceToken: String,
+)


### PR DESCRIPTION
## 1. 📄 Summary
- **FCM 디바이스 토큰 등록 API**
- **FCM 디바이스 토큰 삭제 API**
- **디바이스 토큰 및 알림 도메인 설계 & 문서화**

---

## 2. ✏️ Documentation

[설계 문서 링크](https://www.notion.so/FCM-API-42d76064cee54778b1ea1714487c4a18)

## API
### 디바이스 토큰 관리

---

- [FCM 토큰 저장 API] POST /api/v1/fcm/token
    - request
        - method & path: `POST /api/v1/fcm/token`
        - body
            
            ```json
            {
              "deviceToken": "string",
              "userType": "string(enum)" // CENTER or CARER
            }
            ```
            
    - response
        - 정상 처리된 경우
            - status code: `201 Created`
    
- [FCM 토큰 삭제 API] DELETE /api/v1/fcm/token
    - request
        - method & path: `DELETE /api/v1/fcm/token`
        - body
            
            ```json
            {
              "deviceToken": "string"
            }
            ```
            
    - response
        - 정상 처리된 경우
            - status code: `204 No Content`


## 👉🏻 3. 정책
### FCM Token Policy

#### 로그아웃 시 토큰 삭제 정책

1. **명시적 로그아웃 시**:  
   로그아웃 API를 통해 로그아웃이 발생하면 **디바이스 토큰을 삭제**한다.
   
2. **Refresh 토큰 만료 시**:  
   별도의 디바이스 토큰 삭제 처리를 하지 않는다.
   - FCM Token의 만료 주기(270일)가 모두 경과하면 알림이 발송되지 않으며, 서버에서 자체적으로 삭제한다.

#### 유저 로그인 시 토큰 저장 정책

유저가 로그인할 때, 토큰을 DB에 저장하는 API를 호출한다.  
DB에서 해당 토큰을 조회하고, 없으면 새로 생성하는 것을 원칙으로 한다.

1. **토큰 조회**:  
   토큰 값을 조건으로 검색한다.
   
2. **토큰이 존재하는 경우**:
   - `userId`가 동일하면 그대로 두고, 다르면 `userId`를 업데이트한다.
   - 같은 디바이스에서 여러 사용자가 순차적으로 로그인 한 케이스를 고려하였음.
   
3. **토큰이 존재하지 않는 경우**:  
   새롭게 토큰을 생성한다.

> 이 방식으로 처리하면 다음과 같은 edge case를 해결할 수 있다.
> 
> 1. 기존 유저가 로그아웃한 후, 동일 디바이스에 다른 유저가 로그인한 경우
> 2. 한 유저가 여러 디바이스에서 알림을 설정한 경우

#### Firebase에서 FCM 토큰이 갱신된 경우

다중 디바이스를 고려하여, FCM 토큰이 신규 갱신이 어려울 수 있다. 조회 시 여러 개의 row가 존재하기 때문이다.
이를 위해 우선 FCM Token 값을 기준으로 신규 발급된 token이므로 DB에 우선 저장하는 정책을 따른다.
-> 갱신 전 Token이 남아있긴 하지만, 해당 값은 더 이상 유효하지 않으며 추후 스케줄링을 통해 제거할 수 있기 때문이다.

---

### Firebase FCM 토큰 만료 시

만료된 FCM 토큰으로는 더 이상 알림을 보낼 수 없다.  
알림 발송 시 실패할 경우, 이를 처리하는 방법은 다음과 같다.

1. **처리 방법 1**:  
   알림 발송 실패 시 해당 토큰에 즉시 삭제 정책을 적용하면 어떻게 될까?
   - IO Bound 작업을 처리하면서 삭제 처리를 하는 경우 트랜잭션 크기가 커져서 커넥션을 오래 잡고 있을 것.
   
2. **처리 방법 2**:  
   전송 실패한 FCM 토큰 값을 Redis에 저장한 후, 주기적으로 스케줄러를 통해 삭제한다.
   - FCM 토큰 자체가 강한 일관성을 보장해야 할 만큼 중요한 값은 아님.
   - 시스템 부하를 줄이기 위해 즉시 삭제 대신 Redis에 실패한 토큰을 적재한 후, 부하가 적은 시간대에 스케줄러를 통해 주기적으로 병렬 처리를  통해 해결하는 것이 가장 적합하다고 판단함.

## ✅ 4. TO-DO
## Schedule

- [x]  설계 및 문서화
- [x]  디바이스 토큰 관리 API 구현
    - [x]  디바이스 토큰 등록 API
    - [x]  디바이스 토큰 삭제 API
- [ ]  단일 알림 조회 처리 API
- [ ]  알림 목록 페이지네이션 조회 API
    - [ ]  최근 1달(30일) 내의 알림 목록만 관리하도록 설정
- [ ]  dev 배포 및 QA
- [ ]  prod 배포 및 QA
- [ ]  클라 exp 배포 후속 팔로업