### PR TITLE
[IDLE-415] 알림 읽음 처리 API

### DIFF
--- a/idle-application/build.gradle.kts
+++ b/idle-application/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":idle-infrastructure:aws"))
     implementation(project(":idle-infrastructure:client"))
     implementation(project(":idle-infrastructure:sms"))
+    implementation(project(":idle-infrastructure:fcm"))
     implementation(project(":idle-support:common"))
     implementation(project(":idle-support:security"))
     implementation(project(":idle-support:transfer"))

--- a/idle-application/src/main/kotlin/com/swm/idle/application/applys/domain/CarerApplyEventPublisher.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applys/domain/CarerApplyEventPublisher.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.application.applys.domain
+
+import com.swm.idle.domain.applys.event.ApplyEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class CarerApplyEventPublisher(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+
+    fun publish(applyEvent: ApplyEvent) {
+        eventPublisher.publishEvent(applyEvent)
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/applys/domain/CarerApplyService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applys/domain/CarerApplyService.kt
@@ -15,8 +15,8 @@ class CarerApplyService(
         jobPostingId: UUID,
         carerId: UUID,
         applyMethodType: ApplyMethodType,
-    ) {
-        carerApplyJpaRepository.save(
+    ): Applys {
+        return carerApplyJpaRepository.save(
             Applys(
                 jobPostingId = jobPostingId,
                 carerId = carerId,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/applys/facade/CarerApplyFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applys/facade/CarerApplyFacadeService.kt
@@ -1,10 +1,17 @@
 package com.swm.idle.application.applys.facade
 
+import com.swm.idle.application.applys.domain.CarerApplyEventPublisher
 import com.swm.idle.application.applys.domain.CarerApplyService
 import com.swm.idle.application.common.security.getUserAuthentication
+import com.swm.idle.application.jobposting.domain.JobPostingService
+import com.swm.idle.application.notification.domain.DeviceTokenService
+import com.swm.idle.application.user.carer.domain.CarerService
+import com.swm.idle.domain.applys.event.ApplyEvent
 import com.swm.idle.domain.applys.exception.ApplyException
 import com.swm.idle.domain.jobposting.enums.ApplyMethodType
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
@@ -12,28 +19,47 @@ import java.util.*
 @Transactional(readOnly = true)
 class CarerApplyFacadeService(
     private val carerApplyService: CarerApplyService,
+    private val carerApplyEventPublisher: CarerApplyEventPublisher,
+    private val deviceTokenService: DeviceTokenService,
+    private val jobPostingService: JobPostingService,
+    private val carerService: CarerService,
 ) {
 
-    @Transactional
+    private val logger = KotlinLogging.logger { }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun createApply(
         jobPostingId: UUID,
         applyMethodType: ApplyMethodType,
     ) {
-        val carerId = getUserAuthentication().userId
+        val carer = getUserAuthentication().userId.let {
+            carerService.getById(it)
+        }
+        val deviceToken = deviceTokenService.findByUserId(carer.id)
+        val jobPosting = jobPostingService.getById(jobPostingId)
 
         if (carerApplyService.existsByJobPostingIdAndCarerId(
                 jobPostingId = jobPostingId,
-                carerId = carerId,
+                carerId = carer.id,
             )
         ) {
             throw ApplyException.AlreadyApplied()
         }
 
-        carerApplyService.create(
-            jobPostingId = jobPostingId,
-            carerId = carerId,
-            applyMethodType = applyMethodType,
-        )
+        carerApplyService.create(jobPostingId, carer.id, applyMethodType)
+
+        deviceToken?.let {
+            carerApplyEventPublisher.publish(
+                ApplyEvent.createApplyEvent(
+                    deviceToken = deviceToken,
+                    jobPosting = jobPosting,
+                    carer = carer,
+                )
+            )
+        } ?: run {
+            logger.warn { "${carer.id} 요양 보호사의 device Token이 존재하지 않아 알림이 발송되지 않았습니다." }
+        }
+
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/DeviceTokenService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/DeviceTokenService.kt
@@ -17,6 +17,10 @@ class DeviceTokenService(
         return deviceTokenJpaRepository.findByDeviceToken(deviceToken)
     }
 
+    fun findByUserId(userId: UUID): DeviceToken? {
+        return deviceTokenJpaRepository.findByUserId(userId)
+    }
+
     @Transactional
     fun updateDeviceTokenUserId(
         deviceToken: DeviceToken,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/NotificationService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/NotificationService.kt
@@ -1,0 +1,42 @@
+package com.swm.idle.application.notification.domain
+
+import com.swm.idle.domain.common.exception.PersistenceException
+import com.swm.idle.domain.notification.jpa.Notification
+import com.swm.idle.domain.notification.jpa.NotificationInfo
+import com.swm.idle.domain.notification.repository.NotificationJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+class NotificationService(
+    private val notificationJpaRepository: NotificationJpaRepository,
+) {
+
+    @Transactional
+    fun create(notificationInfo: NotificationInfo): Notification {
+        return notificationJpaRepository.save(
+            Notification(
+                isRead = false,
+                title = notificationInfo.title,
+                body = notificationInfo.body,
+                notificationType = notificationInfo.notificationType,
+                receiverId = notificationInfo.receiverId,
+                imageUrl = notificationInfo.imageUrl,
+                notificationDetails = notificationInfo.notificationDetails
+            )
+        )
+    }
+
+    fun getById(notificationId: UUID): Notification {
+        return notificationJpaRepository.findByIdOrNull(notificationId)
+            ?: throw PersistenceException.ResourceNotFound("Notification(=$notificationId) 를 찾을 수 없습니다.")
+    }
+
+    @Transactional
+    fun read(notification: Notification) {
+        notification.read()
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/notification/facade/NotificationFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/notification/facade/NotificationFacadeService.kt
@@ -1,0 +1,28 @@
+package com.swm.idle.application.notification.facade
+
+import com.swm.idle.application.common.security.getUserAuthentication
+import com.swm.idle.application.notification.domain.NotificationService
+import com.swm.idle.support.security.exception.SecurityException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+@Transactional(readOnly = true)
+class NotificationFacadeService(
+    private val notificationService: NotificationService,
+) {
+
+    fun readNotification(notificationId: UUID) {
+        val notification = notificationService.getById(notificationId)
+
+        if (notification.receiverId != getUserAuthentication().userId) {
+            throw SecurityException.UnAuthorizedRequest()
+        }
+
+        notificationService.getById(notificationId).also {
+            notificationService.read(it)
+        }
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/domain/CenterManagerService.kt
@@ -85,4 +85,10 @@ class CenterManagerService(
         centerManager.updateAccountStatusToPending()
     }
 
+    fun findAllByCenterBusinessRegistrationNumber(centerBusinessRegistrationNumber: BusinessRegistrationNumber): List<CenterManager>? {
+        return centerManagerJpaRepository.findAllByCenterBusinessRegistrationNumber(
+            centerBusinessRegistrationNumber.value
+        )
+    }
+
 }

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -23,4 +23,3 @@ class CrawlingJobScheduler(
     }
 
 }
-

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/event/ApplyEvent.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/event/ApplyEvent.kt
@@ -1,0 +1,25 @@
+package com.swm.idle.domain.applys.event
+
+import com.swm.idle.domain.jobposting.entity.jpa.JobPosting
+import com.swm.idle.domain.notification.jpa.DeviceToken
+import com.swm.idle.domain.user.carer.entity.jpa.Carer
+
+data class ApplyEvent(
+    val deviceToken: DeviceToken,
+    val jobPosting: JobPosting,
+    val carer: Carer,
+) {
+
+    companion object {
+
+        fun createApplyEvent(
+            deviceToken: DeviceToken,
+            jobPosting: JobPosting,
+            carer: Carer,
+        ): ApplyEvent {
+            return ApplyEvent(deviceToken, jobPosting, carer)
+        }
+
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/event/ApplyEvent.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/event/ApplyEvent.kt
@@ -5,7 +5,7 @@ import com.swm.idle.domain.notification.jpa.DeviceToken
 import com.swm.idle.domain.user.carer.entity.jpa.Carer
 
 data class ApplyEvent(
-    val deviceToken: DeviceToken,
+    val deviceTokens: List<DeviceToken>,
     val jobPosting: JobPosting,
     val carer: Carer,
 ) {
@@ -13,11 +13,11 @@ data class ApplyEvent(
     companion object {
 
         fun createApplyEvent(
-            deviceToken: DeviceToken,
+            deviceTokens: List<DeviceToken>,
             jobPosting: JobPosting,
             carer: Carer,
         ): ApplyEvent {
-            return ApplyEvent(deviceToken, jobPosting, carer)
+            return ApplyEvent(deviceTokens, jobPosting, carer)
         }
 
     }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/enums/NotificationType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/enums/NotificationType.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.domain.notification.enums
+
+enum class NotificationType {
+    APPLYCANT
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/Notification.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/Notification.kt
@@ -1,8 +1,13 @@
 package com.swm.idle.domain.notification.jpa
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.swm.idle.domain.common.entity.BaseEntity
+import com.swm.idle.domain.notification.enums.NotificationType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import java.util.*
 
@@ -13,6 +18,9 @@ class Notification(
     title: String,
     body: String,
     receiverId: UUID,
+    imageUrl: String?,
+    notificationType: NotificationType,
+    notificationDetails: Map<String, Any>?,
 ) : BaseEntity() {
 
     @Column(columnDefinition = "varchar(255)")
@@ -29,5 +37,31 @@ class Notification(
 
     var receiverId: UUID = receiverId
         private set
+
+    @Enumerated(EnumType.STRING)
+    var notificationType: NotificationType = notificationType
+        private set
+
+    @Column(columnDefinition = "varchar(255)")
+    var imageUrl: String? = imageUrl
+        private set
+
+    @Column(columnDefinition = "json")
+    var notificationDetailsJson: String? = notificationDetails?.let { convertMapToJson(it) }
+        private set
+
+    fun getNotificationDetails(): Map<String, Any> {
+        val objectMapper = jacksonObjectMapper()
+        return objectMapper.readValue(notificationDetailsJson.toString())
+    }
+
+    private fun convertMapToJson(details: Map<String, Any>): String {
+        val objectMapper = jacksonObjectMapper()
+        return objectMapper.writeValueAsString(details)
+    }
+
+    fun read() {
+        this.isRead = true
+    }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/NotificationInfo.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/jpa/NotificationInfo.kt
@@ -1,0 +1,14 @@
+package com.swm.idle.domain.notification.jpa
+
+import com.swm.idle.domain.notification.enums.NotificationType
+import java.util.*
+
+interface NotificationInfo {
+
+    val title: String
+    val body: String
+    val receiverId: UUID
+    val notificationType: NotificationType
+    val imageUrl: String?
+    val notificationDetails: Map<String, Any>?
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/DeviceTokenJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/DeviceTokenJpaRepository.kt
@@ -12,4 +12,6 @@ interface DeviceTokenJpaRepository : JpaRepository<DeviceToken, UUID> {
 
     fun deleteByDeviceToken(deviceToken: String)
 
+    fun findByUserId(userId: UUID): DeviceToken?
+
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/NotificationJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/NotificationJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.swm.idle.domain.notification.repository
+
+import com.swm.idle.domain.notification.jpa.Notification
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface NotificationJpaRepository : JpaRepository<Notification, UUID> {
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/repository/jpa/CenterManagerJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/repository/jpa/CenterManagerJpaRepository.kt
@@ -8,10 +8,12 @@ import java.util.*
 @Repository
 interface CenterManagerJpaRepository : JpaRepository<CenterManager, UUID> {
 
-    fun findByIdentifier(value: String): CenterManager?
+    fun findByIdentifier(identifier: String): CenterManager?
 
-    fun existsByIdentifier(value: String): Boolean
+    fun existsByIdentifier(identifier: String): Boolean
 
-    fun findByPhoneNumber(value: String): CenterManager?
+    fun findByPhoneNumber(phoneNumber: String): CenterManager?
+
+    fun findAllByCenterBusinessRegistrationNumber(centerBusinessRegistrationNumber: String): List<CenterManager>?
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/GenderType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/common/enum/GenderType.kt
@@ -1,6 +1,9 @@
 package com.swm.idle.domain.user.common.enum
 
-enum class GenderType {
-    MAN,
-    WOMAN;
+enum class GenderType(
+    val value: String,
+) {
+
+    MAN("남성"),
+    WOMAN("여성");
 }

--- a/idle-infrastructure/fcm/build.gradle.kts
+++ b/idle-infrastructure/fcm/build.gradle.kts
@@ -7,6 +7,7 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation(project(":idle-domain"))
     implementation(project(":idle-support:common"))
 
     implementation(rootProject.libs.fcm)

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/applys/listener/CarerApplyEventListener.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/applys/listener/CarerApplyEventListener.kt
@@ -1,0 +1,20 @@
+package com.swm.idle.infrastructure.fcm.applys.listener
+
+import com.swm.idle.domain.applys.event.ApplyEvent
+import com.swm.idle.infrastructure.fcm.applys.service.CarerApplyEventService
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+
+class CarerApplyEventListener(
+    private val carerApplyEventService: CarerApplyEventService,
+) {
+
+    @EventListener
+    fun handleCarerApplyEvent(applyEvent: ApplyEvent) {
+        carerApplyEventService.send(applyEvent)
+    }
+
+}
+

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/applys/listener/CarerApplyEventListener.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/applys/listener/CarerApplyEventListener.kt
@@ -6,14 +6,13 @@ import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
-
 class CarerApplyEventListener(
     private val carerApplyEventService: CarerApplyEventService,
 ) {
 
     @EventListener
-    fun handleCarerApplyEvent(applyEvent: ApplyEvent) {
-        carerApplyEventService.send(applyEvent)
+    fun handleApplyEvent(applyEvent: ApplyEvent) {
+        carerApplyEventService.sendForMulticast(applyEvent)
     }
 
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/applys/service/CarerApplyEventService.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/applys/service/CarerApplyEventService.kt
@@ -1,0 +1,51 @@
+package com.swm.idle.infrastructure.fcm.applys.service
+
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import com.swm.idle.domain.applys.event.ApplyEvent
+import com.swm.idle.domain.user.common.vo.BirthYear
+import com.swm.idle.infrastructure.fcm.common.client.FcmClient
+import com.swm.idle.infrastructure.fcm.common.enums.DestinationType
+import org.springframework.stereotype.Component
+
+@Component
+class CarerApplyEventService(
+    private val fcmClient: FcmClient,
+) {
+
+    fun send(applyEvent: ApplyEvent) {
+        createMessage(applyEvent).also {
+            fcmClient.send(it)
+        }
+    }
+
+    private fun createApplyNotification(applyEvent: ApplyEvent): Notification {
+        return Notification.builder()
+            .setTitle("${applyEvent.carer.name} 님이 공고에 지원하였습니다.")
+            .setBody(createBodyMessage(applyEvent))
+            .build()
+    }
+
+    private fun createBodyMessage(applyEvent: ApplyEvent): String? {
+        val filteredLotNumberAddress = applyEvent.jobPosting.lotNumberAddress.split(" ")
+            .take(3)
+            .joinToString(" ")
+
+        return "$filteredLotNumberAddress " +
+                "${applyEvent.jobPosting.careLevel}등급 " +
+                "${BirthYear.calculateAge(applyEvent.jobPosting.birthYear)}세 " +
+                applyEvent.jobPosting.gender.value
+    }
+
+    private fun createMessage(applyEvent: ApplyEvent): Message {
+        val applyNotification = createApplyNotification(applyEvent)
+
+        return Message.builder()
+            .setToken(applyEvent.deviceToken.deviceToken)
+            .setNotification(applyNotification)
+            .putData("destination", DestinationType.APPLICANTS.toString())
+            .putData("jobPostingId", applyEvent.jobPosting.id.toString())
+            .build();
+    }
+
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/client/FcmClient.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/client/FcmClient.kt
@@ -1,0 +1,19 @@
+package com.swm.idle.infrastructure.fcm.common.client
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import org.springframework.stereotype.Component
+
+@Component
+class FcmClient {
+
+    fun send(message: Message) {
+        firebase.sendAsync(message)
+    }
+
+    companion object {
+
+        val firebase: FirebaseMessaging = FirebaseMessaging.getInstance()
+    }
+
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/client/FcmClient.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/client/FcmClient.kt
@@ -1,19 +1,14 @@
 package com.swm.idle.infrastructure.fcm.common.client
 
 import com.google.firebase.messaging.FirebaseMessaging
-import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.MulticastMessage
 import org.springframework.stereotype.Component
 
 @Component
 class FcmClient {
 
-    fun send(message: Message) {
-        firebase.sendAsync(message)
-    }
-
-    companion object {
-
-        val firebase: FirebaseMessaging = FirebaseMessaging.getInstance()
+    fun sendMulticast(message: MulticastMessage) {
+        FirebaseMessaging.getInstance().sendEachForMulticast(message)
     }
 
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FcmConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FcmConfig.kt
@@ -1,9 +1,13 @@
 package com.swm.idle.infrastructure.fcm.common.config
 
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ComponentScan(basePackages = ["com.swm.idle.infrastructure.fcm"])
-interface FcmConfig {
+@EnableConfigurationProperties
+@ConfigurationPropertiesScan(basePackages = ["com.swm.idle.infrastructure.fcm"])
+class FcmConfig {
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FcmConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FcmConfig.kt
@@ -1,29 +1,9 @@
 package com.swm.idle.infrastructure.fcm.common.config
 
-import com.google.auth.oauth2.GoogleCredentials
-import com.google.firebase.FirebaseApp
-import com.google.firebase.FirebaseOptions
-import jakarta.annotation.PostConstruct
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.io.ClassPathResource
 
 @Configuration
-class FcmConfig {
-
-    @Value("\${firebase.json.path}")
-    lateinit var firebaseConfigJsonPath: String
-
-    @PostConstruct
-    fun initializeFirebaseApp() {
-        val googleCredentials =
-            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
-
-        val fireBaseOptions = FirebaseOptions.builder()
-            .setCredentials(googleCredentials)
-            .build()
-
-        FirebaseApp.initializeApp(fireBaseOptions)
-    }
-
+@ComponentScan(basePackages = ["com.swm.idle.infrastructure.fcm"])
+interface FcmConfig {
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -1,0 +1,29 @@
+package com.swm.idle.infrastructure.fcm.common.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+
+@Configuration
+class FirebaseConfig {
+
+    @Value("\${firebase.json.path}")
+    lateinit var firebaseConfigJsonPath: String
+
+    @PostConstruct
+    fun initializeFirebaseApp() {
+        val googleCredentials =
+            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
+
+        val fireBaseOptions = FirebaseOptions.builder()
+            .setCredentials(googleCredentials)
+            .build()
+
+        FirebaseApp.initializeApp(fireBaseOptions)
+    }
+
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -9,10 +9,10 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
 
 @Configuration
-class FirebaseConfig {
-
+class FirebaseConfig(
     @Value("\${firebase.json.path}")
-    lateinit var firebaseConfigJsonPath: String
+    var firebaseConfigJsonPath: String,
+) {
 
     @PostConstruct
     fun initializeFirebaseApp() {

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/enums/DestinationType.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/enums/DestinationType.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.infrastructure.fcm.common.enums
+
+enum class DestinationType {
+    APPLICANTS
+}

--- a/idle-infrastructure/fcm/src/main/resources/application-fcm.yaml
+++ b/idle-infrastructure/fcm/src/main/resources/application-fcm.yaml
@@ -1,3 +1,0 @@
-firebase:
-  json:
-    path: ./firebase/adminsdk.json

--- a/idle-infrastructure/fcm/src/main/resources/application-fcm.yml
+++ b/idle-infrastructure/fcm/src/main/resources/application-fcm.yml
@@ -1,0 +1,3 @@
+firebase:
+  json:
+   path: ./firebase/swm-3idiots-firebase-adminsdk-si1at-8130a3deda.json

--- a/idle-presentation/build.gradle.kts
+++ b/idle-presentation/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(project(":idle-infrastructure:aws"))
     implementation(project(":idle-infrastructure:client"))
     implementation(project(":idle-infrastructure:sms"))
+    implementation(project(":idle-infrastructure:fcm"))
 
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/IdleServerApplication.kt
@@ -6,6 +6,7 @@ import com.swm.idle.domain.common.config.DomainConfig
 import com.swm.idle.domain.common.config.RedisConfig
 import com.swm.idle.infrastructure.aws.common.AwsConfig
 import com.swm.idle.infrastructure.client.common.config.ClientConfig
+import com.swm.idle.infrastructure.fcm.common.config.FcmConfig
 import com.swm.idle.infrastructure.sms.common.config.SmsConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
@@ -24,6 +25,7 @@ import java.util.*
         SmsConfig::class,
         AwsConfig::class,
         BatchConfig::class,
+        FcmConfig::class,
     ]
 )
 class IdleServerApplication {

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/api/NotificationApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/api/NotificationApi.kt
@@ -1,0 +1,48 @@
+package com.swm.idle.presentation.notification.api
+
+import com.swm.idle.presentation.common.exception.ErrorResponse
+import com.swm.idle.presentation.common.security.annotation.Secured
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.util.*
+
+@Tag(name = "Notification", description = "알림 API")
+@RequestMapping("/api/v1/notifications", produces = ["application/json;charset=utf-8"])
+interface NotificationApi {
+
+    @Secured
+    @Operation(summary = "알림 읽음 처리 API")
+    @PatchMapping("/{notification-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "처리 성공",
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "처리 실패 - 본인이 아닌, 인증되지 않은 사용자가 읽음 처리를 시도한 경우",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = ErrorResponse::class
+                        )
+                    ),
+                ]
+            ),
+        ]
+    )
+    fun readNotification(@PathVariable("notification-id") notificationId: UUID)
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/controller/NotificationController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/controller/NotificationController.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.presentation.notification.controller
+
+import com.swm.idle.application.notification.facade.NotificationFacadeService
+import com.swm.idle.presentation.notification.api.NotificationApi
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+
+@RestController
+class NotificationController(
+    private val notificationFacadeService: NotificationFacadeService,
+) : NotificationApi {
+
+    override fun readNotification(notificationId: UUID) {
+        notificationFacadeService.readNotification(notificationId)
+    }
+
+}

--- a/idle-presentation/src/main/resources/application.yml
+++ b/idle-presentation/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       - sms
       - client
       - batch
+      - fcm
 
 swagger:
   server:


### PR DESCRIPTION
## 1. 📄 Summary

<img width="390" alt="스크린샷 2024-10-16 오후 5 27 46" src="https://github.com/user-attachments/assets/3bea4a09-7180-4634-9a17-830a211f4218">

* 알림 읽음 처리 API 구현 

## 2. ✏️ Documentation

- [알림 읽음 처리 API] PATCH /api/v1/notifications/{notification-id}
    - request
        - method & path: `PATCH /api/v1/notifications/{notification-id}`
        
    - response
        - 정상 처리된 경우
        - status code: `204 No Content` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
  - Firebase Cloud Messaging(FCM) 통합을 위한 새로운 서비스 및 이벤트 리스너 추가.
  - 알림을 읽는 RESTful API 인터페이스 및 컨트롤러 추가.
  - 지원하는 알림 유형 및 이벤트 클래스 생성.

- **변경 사항**
  - 알림 관리 기능 개선을 위한 새로운 메서드 및 클래스 추가.
  - 기존 메서드의 반환 타입 변경 및 로직 개선.

- **구성 변경**
  - Firebase 설정을 위한 새로운 YAML 구성 추가.
  - 로컬 환경에서 FCM 프로파일 포함.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->