### PR TITLE
[IDLE-417] 읽지 않은 알림 수 집계 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/NotificationService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/notification/domain/NotificationService.kt
@@ -39,4 +39,8 @@ class NotificationService(
         notification.read()
     }
 
+    fun countUnreadNotificationByUserId(userId: UUID): Int {
+        return notificationJpaRepository.countByUserIdWithUnreadStatus(userId)
+    }
+
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/notification/facade/NotificationFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/notification/facade/NotificationFacadeService.kt
@@ -3,6 +3,7 @@ package com.swm.idle.application.notification.facade
 import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.notification.domain.NotificationService
 import com.swm.idle.support.security.exception.SecurityException
+import com.swm.idle.support.transfer.notification.UnreadNotificationCountResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -22,6 +23,16 @@ class NotificationFacadeService(
 
         notificationService.getById(notificationId).also {
             notificationService.read(it)
+        }
+    }
+
+    fun countUnreadNotification(): UnreadNotificationCountResponse {
+        val userId = getUserAuthentication().userId
+
+        return notificationService.countUnreadNotificationByUserId(userId).let {
+            UnreadNotificationCountResponse(
+                unreadNotificationCount = it
+            )
         }
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/enums/NotificationType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/enums/NotificationType.kt
@@ -1,5 +1,5 @@
 package com.swm.idle.domain.notification.enums
 
 enum class NotificationType {
-    APPLYCANT
+    APPLICANT
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/NotificationJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/NotificationJpaRepository.kt
@@ -2,7 +2,19 @@ package com.swm.idle.domain.notification.repository
 
 import com.swm.idle.domain.notification.jpa.Notification
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.util.*
 
 interface NotificationJpaRepository : JpaRepository<Notification, UUID> {
+
+    @Query(
+        """
+            SELECT COUNT(*) 
+            FROM notification
+            WHERE notification.receiver_id = :userId
+            AND notification.is_read = false
+        """,
+        nativeQuery = true
+    )
+    fun countByUserIdWithUnreadStatus(userId: UUID): Int
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/api/NotificationApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/api/NotificationApi.kt
@@ -2,6 +2,7 @@ package com.swm.idle.presentation.notification.api
 
 import com.swm.idle.presentation.common.exception.ErrorResponse
 import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.notification.UnreadNotificationCountResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -44,5 +46,11 @@ interface NotificationApi {
         ]
     )
     fun readNotification(@PathVariable("notification-id") notificationId: UUID)
+
+    @Secured
+    @Operation(summary = "읽지 않은 알림 수 집계 API")
+    @GetMapping("/count")
+    @ResponseStatus(HttpStatus.OK)
+    fun countUnreadNotification(): UnreadNotificationCountResponse
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/controller/NotificationController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/notification/controller/NotificationController.kt
@@ -2,6 +2,7 @@ package com.swm.idle.presentation.notification.controller
 
 import com.swm.idle.application.notification.facade.NotificationFacadeService
 import com.swm.idle.presentation.notification.api.NotificationApi
+import com.swm.idle.support.transfer.notification.UnreadNotificationCountResponse
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
@@ -12,6 +13,10 @@ class NotificationController(
 
     override fun readNotification(notificationId: UUID) {
         notificationFacadeService.readNotification(notificationId)
+    }
+
+    override fun countUnreadNotification(): UnreadNotificationCountResponse {
+        return notificationFacadeService.countUnreadNotification()
     }
 
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/notification/UnreadNotificationCountResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/notification/UnreadNotificationCountResponse.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.support.transfer.notification
+
+data class UnreadNotificationCountResponse(
+    val unreadNotificationCount: Int,
+)


### PR DESCRIPTION
## 1. 📄 Summary
* 읽지 않은 알림 수 집계 API

## 2. ✏️ Documentation    
- [미 조회 알림 수 조회 API] GET /api/v1/notifications/count
    - request
        - method & path: `GET /api/v1/notifications/count`
    - response
        - 정상 처리된 경우
            - status code: `200 OK`
            - body
        
        ```json
        {
           "unreadNotificationCount": "int"
        }
        ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자가 읽지 않은 알림 수를 카운트하는 기능 추가.
	- 알림 관련 API 및 서비스에 새로운 메서드 추가.
- **변경 사항**
	- 알림 종류의 열거형 값 이름 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->