### PR TITLE
[IDLE-423] soft-delete가 적용된 즐겨찾기 entity에서, 즐겨찾기 해제 후 재설정 시 발생하는 에러 해결

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/JobPostingFavoriteFacadeService.kt
@@ -19,7 +19,12 @@ data class JobPostingFavoriteFacadeService(
         carerId: UUID,
         jobPostingType: JobPostingType,
     ) {
-        jobPostingFavoriteService.create(
+        jobPostingFavoriteService.findByJobPostingIdAndCarerId(
+            jobPostingId = jobPostingId,
+            carerId = carerId,
+        )?.let {
+            it.active()
+        } ?: jobPostingFavoriteService.create(
             jobPostingId = jobPostingId,
             carerId = carerId,
             jobPostingType = jobPostingType,


### PR DESCRIPTION
## 1. 📄 Summary
* soft-delete가 적용된 즐겨찾기 entity에서, 즐겨찾기 해제 후 다시 설정하는 경우 발생하는 에러를 해결합니다.
* 에러 원인은 soft-delete한 entity row가 여전히 테이블에 남아 있는 상황에서 재설정하는 경우, 새로운 entity가 생성됩니다. 
* 따라서 한 공고에 대해 여러 개의 즐겨찾기가 생기게 되어 잘못된 쿼리 결과를 유발하였습니다.

해결책
-> 즐겨찾기 생성 로직에서, 기존에 생성된 즐겨찾기 객체가 테이블에 존재하는 경우 이를 재 활성화 하도록 로직을 분기하여 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 즐겨찾기 직업 게시물 생성 로직 개선: 기존의 즐겨찾기 직업 게시물이 있는지 확인 후 활성화 또는 새로 생성하는 방식으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->