### PR TITLE
[IDLE-424] 요양 보호사 공고 전체 조회 시, 삭제된 공고가 함께 보이는 문제 해결

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingQueryRepository.kt
@@ -30,6 +30,7 @@ class JobPostingQueryRepository(
             .where(
                 applys.carerId.eq(carerId)
                     .and(next?.let { jobPosting.id.goe(it) })
+                    .and(jobPosting.entityStatus.eq(EntityStatus.ACTIVE))
             )
             .limit(limit)
             .fetch()


### PR DESCRIPTION
## 1. 📄 Summary
* 요양 보호사 공고 전체 조회 시, 삭제된 공고가 함께 보이는 문제 해결
* 쿼리에서 현재 삭제되지 않은(ACTIVE)한 공고만 노출되도록 where 절 조건 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 활성 상태의 구인 공고만 필터링하여 검색하는 기능 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->