### PR TITLE
[IDLE-000] firebase config의 현재 경로를 출력하도록 print문 추가

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -43,17 +43,6 @@ jobs:
               --port 22 \
               --cidr ${{ steps.publicip.outputs.ip }}/32
 
-      - name: Create firebase directory
-        run: mkdir ./idle-infrastructure/fcm/src/main/resources/firebase/
-
-      - name: Create Firebase Admin SDK JSON file
-        id: create-json
-        uses: jsdaniell/create-json@v1.2.3
-        with:
-          name: "adminkey.json"
-          json: ${{ secrets.FIREBASE_SERVICE_KEY_FILE }}
-          dir: './idle-infrastructure/fcm/src/main/resources/firebase/'
-
       - name: Copy Docker Compose file to server
         uses: appleboy/scp-action@master
         with:

--- a/.github/workflows/dev-server-integrator.yaml
+++ b/.github/workflows/dev-server-integrator.yaml
@@ -3,7 +3,7 @@ name: Develop Server Integrator (CI)
 on:
   push:
     branches:
-      - develop
+      - docs/IDLE-000
 
 jobs:
   build_and_push:

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -8,12 +8,11 @@ import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import java.io.ByteArrayInputStream
-import java.util.*
 
 @Configuration
 class FirebaseConfig(
     @Value("\${firebase.json}")
-    private val firebaseJsonBase64: String,
+    var firebaseJsonString: String, // JSON 문자열을 주입받음
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -21,8 +20,8 @@ class FirebaseConfig(
     @PostConstruct
     fun initializeFirebaseApp() {
         try {
-            val decodedBytes = Base64.getDecoder().decode(firebaseJsonBase64)
-            val inputStream = ByteArrayInputStream(decodedBytes)
+            // JSON 문자열을 InputStream으로 변환
+            val inputStream = ByteArrayInputStream(firebaseJsonString.toByteArray(Charsets.UTF_8))
 
             val googleCredentials = GoogleCredentials.fromStream(inputStream)
 

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -1,34 +1,33 @@
-//package com.swm.idle.infrastructure.fcm.common.config
-//
-//import io.github.oshai.kotlinlogging.KotlinLogging
-//import jakarta.annotation.PostConstruct
-//import org.springframework.beans.factory.annotation.Value
-//import org.springframework.context.annotation.Configuration
-//
-//@Configuration
-//class FirebaseConfig(
+package com.swm.idle.infrastructure.fcm.common.config
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.annotation.PostConstruct
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FirebaseConfig(
 //    @Value("\${firebase.json.path}")
 //    var firebaseConfigJsonPath: String,
-//) {
-//
-//    private val logger = KotlinLogging.logger {}
-//
-////    @PostConstruct
-////    fun initializeFirebaseApp() {
-////        val googleCredentials =
-////            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
-////
-////        val fireBaseOptions = FirebaseOptions.builder()
-////            .setCredentials(googleCredentials)
-////            .build()
-////
-////        FirebaseApp.initializeApp(fireBaseOptions)
-////    }
-//
+) {
+
+    private val logger = KotlinLogging.logger {}
+
 //    @PostConstruct
-//    fun printWorkingDirectory() {
-//        logger.warn { "Current working directory: " + System.getProperty("user.dir") }
+//    fun initializeFirebaseApp() {
+//        val googleCredentials =
+//            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
+//
+//        val fireBaseOptions = FirebaseOptions.builder()
+//            .setCredentials(googleCredentials)
+//            .build()
+//
+//        FirebaseApp.initializeApp(fireBaseOptions)
 //    }
-//
-//
-//}
+
+    @PostConstruct
+    fun printWorkingDirectory() {
+        logger.warn { "Current working directory: " + System.getProperty("user.dir") }
+    }
+
+
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -1,13 +1,9 @@
 package com.swm.idle.infrastructure.fcm.common.config
 
-import com.google.auth.oauth2.GoogleCredentials
-import com.google.firebase.FirebaseApp
-import com.google.firebase.FirebaseOptions
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.io.ClassPathResource
 
 @Configuration
 class FirebaseConfig(
@@ -17,17 +13,17 @@ class FirebaseConfig(
 
     private val logger = KotlinLogging.logger {}
 
-    @PostConstruct
-    fun initializeFirebaseApp() {
-        val googleCredentials =
-            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
-
-        val fireBaseOptions = FirebaseOptions.builder()
-            .setCredentials(googleCredentials)
-            .build()
-
-        FirebaseApp.initializeApp(fireBaseOptions)
-    }
+//    @PostConstruct
+//    fun initializeFirebaseApp() {
+//        val googleCredentials =
+//            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
+//
+//        val fireBaseOptions = FirebaseOptions.builder()
+//            .setCredentials(googleCredentials)
+//            .build()
+//
+//        FirebaseApp.initializeApp(fireBaseOptions)
+//    }
 
     @PostConstruct
     fun printWorkingDirectory() {

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -3,6 +3,7 @@ package com.swm.idle.infrastructure.fcm.common.config
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
@@ -13,6 +14,8 @@ class FirebaseConfig(
     @Value("\${firebase.json.path}")
     var firebaseConfigJsonPath: String,
 ) {
+
+    private val logger = KotlinLogging.logger {}
 
     @PostConstruct
     fun initializeFirebaseApp() {
@@ -28,7 +31,7 @@ class FirebaseConfig(
 
     @PostConstruct
     fun printWorkingDirectory() {
-        println("Current working directory: " + System.getProperty("user.dir"))
+        logger.warn { "Current working directory: " + System.getProperty("user.dir") }
     }
 
 

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -8,11 +8,12 @@ import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import java.io.ByteArrayInputStream
+import java.util.*
 
 @Configuration
 class FirebaseConfig(
     @Value("\${firebase.json}")
-    var firebaseJsonString: String, // JSON 문자열을 주입받음
+    private val firebaseJsonBase64: String,
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -20,9 +21,9 @@ class FirebaseConfig(
     @PostConstruct
     fun initializeFirebaseApp() {
         try {
-            logger.info { "Loaded Firebase JSON: $firebaseJsonString" }
+            val decodedBytes = Base64.getDecoder().decode(firebaseJsonBase64)
+            val inputStream = ByteArrayInputStream(decodedBytes)
 
-            val inputStream = ByteArrayInputStream(firebaseJsonString.toByteArray(Charsets.UTF_8))
             val googleCredentials = GoogleCredentials.fromStream(inputStream)
 
             val fireBaseOptions = FirebaseOptions.builder()
@@ -36,6 +37,5 @@ class FirebaseConfig(
             logger.error(e) { "Error initializing FirebaseApp." }
         }
     }
-
 
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -20,9 +20,9 @@ class FirebaseConfig(
     @PostConstruct
     fun initializeFirebaseApp() {
         try {
-            // JSON 문자열을 InputStream으로 변환
-            val inputStream = ByteArrayInputStream(firebaseJsonString.toByteArray(Charsets.UTF_8))
+            logger.info { "Loaded Firebase JSON: $firebaseJsonString" }
 
+            val inputStream = ByteArrayInputStream(firebaseJsonString.toByteArray(Charsets.UTF_8))
             val googleCredentials = GoogleCredentials.fromStream(inputStream)
 
             val fireBaseOptions = FirebaseOptions.builder()
@@ -36,5 +36,6 @@ class FirebaseConfig(
             logger.error(e) { "Error initializing FirebaseApp." }
         }
     }
+
 
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -26,4 +26,10 @@ class FirebaseConfig(
         FirebaseApp.initializeApp(fireBaseOptions)
     }
 
+    @PostConstruct
+    fun printWorkingDirectory() {
+        println("Current working directory: " + System.getProperty("user.dir"))
+    }
+
+
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -1,33 +1,39 @@
 package com.swm.idle.infrastructure.fcm.common.config
 
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
+import java.io.ByteArrayInputStream
 
 @Configuration
 class FirebaseConfig(
-//    @Value("\${firebase.json.path}")
-//    var firebaseConfigJsonPath: String,
+    @Value("\${firebase.json}")
+    var firebaseJsonString: String,
 ) {
 
     private val logger = KotlinLogging.logger {}
 
-//    @PostConstruct
-//    fun initializeFirebaseApp() {
-//        val googleCredentials =
-//            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
-//
-//        val fireBaseOptions = FirebaseOptions.builder()
-//            .setCredentials(googleCredentials)
-//            .build()
-//
-//        FirebaseApp.initializeApp(fireBaseOptions)
-//    }
-
     @PostConstruct
-    fun printWorkingDirectory() {
-        logger.warn { "Current working directory: " + System.getProperty("user.dir") }
-    }
+    fun initializeFirebaseApp() {
+        try {
+            val inputStream = ByteArrayInputStream(firebaseJsonString.toByteArray(Charsets.UTF_8))
 
+            val googleCredentials = GoogleCredentials.fromStream(inputStream)
+
+            val fireBaseOptions = FirebaseOptions.builder()
+                .setCredentials(googleCredentials)
+                .build()
+
+            FirebaseApp.initializeApp(fireBaseOptions)
+
+            logger.info { "FirebaseApp has been initialized successfully." }
+        } catch (e: Exception) {
+            logger.error(e) { "Error initializing FirebaseApp." }
+        }
+    }
 
 }

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -1,34 +1,34 @@
-package com.swm.idle.infrastructure.fcm.common.config
-
-import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.annotation.PostConstruct
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.context.annotation.Configuration
-
-@Configuration
-class FirebaseConfig(
-    @Value("\${firebase.json.path}")
-    var firebaseConfigJsonPath: String,
-) {
-
-    private val logger = KotlinLogging.logger {}
-
+//package com.swm.idle.infrastructure.fcm.common.config
+//
+//import io.github.oshai.kotlinlogging.KotlinLogging
+//import jakarta.annotation.PostConstruct
+//import org.springframework.beans.factory.annotation.Value
+//import org.springframework.context.annotation.Configuration
+//
+//@Configuration
+//class FirebaseConfig(
+//    @Value("\${firebase.json.path}")
+//    var firebaseConfigJsonPath: String,
+//) {
+//
+//    private val logger = KotlinLogging.logger {}
+//
+////    @PostConstruct
+////    fun initializeFirebaseApp() {
+////        val googleCredentials =
+////            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
+////
+////        val fireBaseOptions = FirebaseOptions.builder()
+////            .setCredentials(googleCredentials)
+////            .build()
+////
+////        FirebaseApp.initializeApp(fireBaseOptions)
+////    }
+//
 //    @PostConstruct
-//    fun initializeFirebaseApp() {
-//        val googleCredentials =
-//            GoogleCredentials.fromStream(ClassPathResource(firebaseConfigJsonPath).inputStream)
-//
-//        val fireBaseOptions = FirebaseOptions.builder()
-//            .setCredentials(googleCredentials)
-//            .build()
-//
-//        FirebaseApp.initializeApp(fireBaseOptions)
+//    fun printWorkingDirectory() {
+//        logger.warn { "Current working directory: " + System.getProperty("user.dir") }
 //    }
-
-    @PostConstruct
-    fun printWorkingDirectory() {
-        logger.warn { "Current working directory: " + System.getProperty("user.dir") }
-    }
-
-
-}
+//
+//
+//}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/common/config/FirebaseConfig.kt
@@ -8,11 +8,12 @@ import jakarta.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import java.io.ByteArrayInputStream
+import java.util.*
 
 @Configuration
 class FirebaseConfig(
     @Value("\${firebase.json}")
-    var firebaseJsonString: String,
+    private val firebaseJsonBase64: String,
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -20,7 +21,8 @@ class FirebaseConfig(
     @PostConstruct
     fun initializeFirebaseApp() {
         try {
-            val inputStream = ByteArrayInputStream(firebaseJsonString.toByteArray(Charsets.UTF_8))
+            val decodedBytes = Base64.getDecoder().decode(firebaseJsonBase64)
+            val inputStream = ByteArrayInputStream(decodedBytes)
 
             val googleCredentials = GoogleCredentials.fromStream(inputStream)
 

--- a/idle-infrastructure/fcm/src/main/resources/application-fcm.yml
+++ b/idle-infrastructure/fcm/src/main/resources/application-fcm.yml
@@ -1,3 +1,2 @@
 firebase:
-  json:
-    path: ./firebase/adminkey.json
+  json: ${FIREBASE_SERVICE_KEY_JSON}


### PR DESCRIPTION
## 1. 📄 Summary
* firebase config의 현재 경로를 출력하도록 print문 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **변경 사항**
	- CI 프로세스 트리거 브랜치가 `develop`에서 `docs/IDLE-000`으로 업데이트되었습니다.
	- Firebase 초기화 프로세스가 JSON 문자열을 사용하도록 수정되었습니다.
	- Firebase 관련 디렉토리 생성 및 JSON 파일 생성 단계가 배포 프로세스에서 제거되었습니다.
	- Firebase 서비스 키 제공 방식이 하드코딩된 파일 경로에서 환경 변수로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->