### PR TITLE
[IDLE-475] 채팅, 채팅방 도메인 설계

### DIFF
--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/entity/jpa/ChatMessage.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/entity/jpa/ChatMessage.kt
@@ -1,0 +1,48 @@
+package com.swm.idle.domain.chat.entity.jpa
+
+import com.swm.idle.domain.chat.enums.ContentType
+import com.swm.idle.domain.chat.enums.SenderType
+//import com.swm.idle.domain.chat.vo.Content
+import com.swm.idle.domain.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.util.*
+
+@Entity
+@Table(name = "chat_message")
+class ChatMessage(
+    roomId: UUID,
+    senderId: UUID,
+    senderType: SenderType,
+    contents: List<Content>,
+) : BaseEntity() {
+
+    @Column(updatable = false)
+    var roomId: UUID = roomId
+        private set
+
+    @Column(updatable = false)
+    var senderId: UUID = senderId
+        private set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_type", updatable = false)
+    var senderType: SenderType = senderType
+        private set
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "contents", nullable = false, columnDefinition = "json")
+    var contents: List<Content> = contents
+        private set
+
+    data class Content(
+        val type: ContentType,
+        val value: String,
+    )
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/entity/jpa/ChatRoom.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/entity/jpa/ChatRoom.kt
@@ -1,0 +1,24 @@
+package com.swm.idle.domain.chat.entity.jpa
+
+import com.swm.idle.domain.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "chat_room")
+class ChatRoom(
+    senderId: UUID,
+    receiverId: UUID,
+) : BaseEntity() {
+
+    @Column(nullable = false, updatable = false)
+    var senderId: UUID = senderId
+        private set
+
+    @Column(nullable = false, updatable = false)
+    var receiverId: UUID = receiverId
+        private set
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/enums/ContentType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/enums/ContentType.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.domain.chat.enums
+
+enum class ContentType {
+    TEXT,
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/enums/SenderType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/enums/SenderType.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.domain.chat.enums
+
+enum class SenderType {
+    USER,
+    SYSTEM
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/Content.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/Content.kt
@@ -1,0 +1,8 @@
+package com.swm.idle.domain.chat.vo
+
+import com.swm.idle.domain.chat.enums.ContentType
+
+data class Content(
+    val type: ContentType,
+    val value: String,
+)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/Content.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/Content.kt
@@ -5,4 +5,15 @@ import com.swm.idle.domain.chat.enums.ContentType
 data class Content(
     val type: ContentType,
     val value: String,
-)
+) {
+
+    init {
+        require(value.isBlank()) { "채팅 메세지는 비어 있을 수 없습니다. " }
+        require(value.length <= MAXIMUM_CHAT_MESSAGE_LENGTH) { "채팅 메세지 최대 길이는 1,000자 입니다." }
+    }
+
+    companion object {
+
+        const val MAXIMUM_CHAT_MESSAGE_LENGTH = 1_000
+    }
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/SendUser.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/SendUser.kt
@@ -1,0 +1,7 @@
+package com.swm.idle.domain.chat.vo
+
+import java.util.*
+
+data class SendUser(
+    val userId: UUID,
+)

--- a/idle-domain/src/main/resources/db/migration/V2__create_table_chat_room.sql
+++ b/idle-domain/src/main/resources/db/migration/V2__create_table_chat_room.sql
@@ -1,0 +1,13 @@
+-- V2__create_table_chat_room.sql
+
+-- Create table for chat room
+CREATE TABLE chat_room (
+    id BINARY(16) PRIMARY KEY,
+    sender_id BINARY(16) NOT NULL,
+    receiver_id BINARY(16) NOT NULL,
+    entity_status VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX (sender_id),
+    INDEX (receiver_id)
+)

--- a/idle-domain/src/main/resources/db/migration/V3__create_table_chat_message.sql
+++ b/idle-domain/src/main/resources/db/migration/V3__create_table_chat_message.sql
@@ -1,0 +1,19 @@
+-- V3__create_table_chat_message.sql
+
+-- Create table for chat message
+CREATE TABLE chat_message (
+    id BINARY(16) PRIMARY KEY,
+    room_id BINARY(16) NOT NULL,
+    sender_id BINARY(16) NOT NULL,
+    sender_type ENUM('USER', 'SYSTEM') NOT NULL,
+    contents JSON NOT NULL,
+    entity_status VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX (room_id),
+    INDEX (sender_id),
+    INDEX (created_at)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+


### PR DESCRIPTION
## 1. 📄 Summary
* 채팅방, 채팅 메세지 도메인 설계에 관한 PR입니다.

## 2. ✏️ Documentation
[설계 문서](https://www.notion.so/4fde4dd7ba5a47e4b47df0c3bc411c77)

## 3. 🤔 고민했던 점

## 4. 💡 알게된 점, 궁금한 점

채팅 메세지 도메인을 설계하면서, 채팅 메세지 내용을 JSON 형태로 관리하고자 했습니다.

이전 구현에서는 `AttributeConverter` 를 상속한 별도의 컨버터 객체를 각각 구현해서 처리하였는데, 이에 따라 매 상황마다 컨버터 객체가 생겨나 관리 포인트가 많아져 불편하다는 생각이 들었습니다. 

Hibernate 6버전 이상부터 해당 [레퍼런스]([https://velog.io/@happyjamy/JPA-에서-MySql-Json-타입-사용하기-hibernate-6-이상](https://velog.io/@happyjamy/JPA-%EC%97%90%EC%84%9C-MySql-Json-%ED%83%80%EC%9E%85-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-hibernate-6-%EC%9D%B4%EC%83%81))를 참고하여 
아래와 같은 형식으로 Hibernate에서 제공하는 `@JdbcTypeCode(SqlTypes.JSON)`으로 별도의 컨버터 구현 없이 해결헀습니다.

```kotlin
    @JdbcTypeCode(SqlTypes.JSON)
    @Column(name = "contents", nullable = false, columnDefinition = "json")
    var contents: List<Content> = contents
        private set
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 채팅 메시지를 위한 `ChatMessage` 클래스 및 관련 데이터 구조 추가
	- 채팅 방을 위한 `ChatRoom` 클래스 추가
	- 콘텐츠 유형을 정의하는 `ContentType` 및 발신자 유형을 정의하는 `SenderType` 열거형 추가
	- 사용자 식별을 위한 `SendUser` 데이터 클래스 추가

- **데이터베이스 변경**
	- `chat_room` 및 `chat_message` 테이블 생성에 대한 SQL 마이그레이션 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->