### PR TITLE
[IDLE-000] Batch 메타데이터 테이블 스크립트 변경 및 크롤링 수행 주기 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ### JSON ###
 idle-infrastructure/fcm/src/main/resources/firebase
+idle-batch/src/main/resources/script

--- a/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
+++ b/idle-batch/src/main/kotlin/com/swm/idle/batch/common/scheduler/CrawlingJobScheduler.kt
@@ -13,7 +13,7 @@ class CrawlingJobScheduler(
     private val crawlingJobConfig: CrawlingJobConfig,
 ) {
 
-    @Scheduled(cron = "0 0/30 * * * *")
+    @Scheduled(cron = "0 00 01 * * *")
     fun scheduleJob() {
         val jobParameters: JobParameters = JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())


### PR DESCRIPTION
## 1. 📄 Summary
* 운영 환경에서 크롤러가 동작하지 않는 문제를 해결하기 위한 PR입니다.
* Batch 메타데이터 테이블 스크립트를 spring-batch 공식 repository에서 제공하는 [스크립트](https://github.com/spring-projects/spring-batch/blob/main/spring-batch-core/src/main/resources/org/springframework/batch/core/schema-mysql.sql)로 설정했습니다.
* 테스트를 위해 조정해 두었던 크롤링 주기를 새벽 01시에 1회 동작하는 것으로 수정하였습니다.
