### PR TITLE
[IDLE-492] 동일 유저가 여러 개의 디바이스를 사용 시, 알림이 중복 조회되는 현상

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/applys/facade/CarerApplyFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applys/facade/CarerApplyFacadeService.kt
@@ -62,20 +62,20 @@ class CarerApplyFacadeService(
         centerManagers?.forEach { centerManager ->
             val deviceTokens = deviceTokenService.findAllByUserId(centerManager.id)
 
-            deviceTokens?.forEach { deviceToken ->
-                val notificationInfo = CarerApplyNotificationInfo(
-                    title = "${carer.name} 님이 공고에 지원하였습니다.",
-                    body = createBodyMessage(jobPosting),
-                    receiverId = centerManager.id,
-                    notificationType = NotificationType.APPLICANT,
-                    imageUrl = carer.profileImageUrl,
-                    notificationDetails = mapOf(
-                        "jobPostingId" to jobPostingId,
-                    )
+            val notificationInfo = CarerApplyNotificationInfo(
+                title = "${carer.name} 님이 공고에 지원하였습니다.",
+                body = createBodyMessage(jobPosting),
+                receiverId = centerManager.id,
+                notificationType = NotificationType.APPLICANT,
+                imageUrl = carer.profileImageUrl,
+                notificationDetails = mapOf(
+                    "jobPostingId" to jobPostingId,
                 )
+            )
 
-                val notification = notificationService.create(notificationInfo)
+            val notification = notificationService.create(notificationInfo)
 
+            deviceTokens?.forEach { deviceToken ->
                 ApplyEvent.createApplyEvent(
                     deviceToken = deviceToken,
                     notificationId = notification.id,

--- a/idle-domain/src/main/resources/db/migration/V4__alter_table_notification_add_column_device_token.sql
+++ b/idle-domain/src/main/resources/db/migration/V4__alter_table_notification_add_column_device_token.sql
@@ -1,0 +1,4 @@
+-- V4__alter_table_notification_add_column_device_token.sql
+
+-- Add secondary index on deviceToken and userId columns
+CREATE INDEX idx_user_id ON notification(userId);


### PR DESCRIPTION
## 1. 📄 Summary
![스크린샷 2024-11-04 오후 1 58 17](https://github.com/user-attachments/assets/dba45322-101b-43a0-86d0-d9674d32652b)

* 동일 유저가 여러 개의 디바이스를 사용하는 환경에서, 디바이스별로 생성된 알림을 RDB에 저장하여 조회 시점에 중복 조회되는 문제가 있었습니다. 
* 한 디바이스에서 해당 알림을 읽은 경우, 다른 디바이스에서도 읽음 처리가 적용되는 것이 정책적으로 더 낫다고 판단하여 알림을 디바이스 수에 관계없이 최초 1회만 저장하는 로직으로 변경하여 조치했습니다.
* 유저별 알림 조회는 필수적이므로, userId 필드에 Secondary Index를 추가하여 조회 성능을 높였습니다.