### PR TITLE
[IDLE-494] 요양 보호사 및 센터 프로필에서 긴 텍스트를 입력 가능한 항목을 TEXT 컬럼으로 지정한다.

### DIFF
--- a/idle-domain/src/main/resources/db/migration/V6__alter_table_carer_modify_column_type.sql
+++ b/idle-domain/src/main/resources/db/migration/V6__alter_table_carer_modify_column_type.sql
@@ -1,0 +1,5 @@
+-- V6__alter_table_carer_modify_column_type.sql
+
+ALTER TABLE carer
+MODIFY COLUMN introduce TEXT,
+MODIFY COLUMN speciality TEXT

--- a/idle-domain/src/main/resources/db/migration/V7__alter_table_center_modify_column_type.sql
+++ b/idle-domain/src/main/resources/db/migration/V7__alter_table_center_modify_column_type.sql
@@ -1,0 +1,4 @@
+-- V7__alter_table_center_modify_column_type.sql
+
+ALTER TABLE center
+MODIFY COLUMN introduce TEXT;


### PR DESCRIPTION
## 1. 📄 Summary

[센터 프로필 생성 화면]
<img width="256" alt="스크린샷 2024-11-04 오후 3 31 29" src="https://github.com/user-attachments/assets/49329f75-03f5-4fd5-8a7e-e6f39538b7e9">

[요양 보호사 프로필 생성 화면]
<img width="284" alt="스크린샷 2024-11-04 오후 3 32 28" src="https://github.com/user-attachments/assets/c0abfba5-2582-41ce-80e2-5e346214f117">

* 아래와 같이 긴 텍스트를 입력 가능한 항목을 TEXT 컬럼으로 지정한다.
* 요양 보호사 프로필 - 특기, 소개
* 센터 프로필 - 소개


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `carer` 테이블의 `introduce` 및 `speciality` 열의 데이터 타입을 `TEXT`로 변경하여 더 긴 문자열 저장 가능.
	- `center` 테이블의 `introduce` 열의 데이터 타입을 `TEXT`로 변경하여 더 많은 텍스트 데이터 저장 가능.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->