### PR TITLE
[IDLE-495] 요양 보호사는 마감된 공고에 지원이 불가능하다.

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/applys/facade/CarerApplyFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/applys/facade/CarerApplyFacadeService.kt
@@ -51,6 +51,10 @@ class CarerApplyFacadeService(
             throw ApplyException.AlreadyApplied()
         }
 
+        if (jobPosting.isCompleted()) {
+            throw ApplyException.JobPostingCompleted()
+        }
+
         val centerManagers = centerService.getById(jobPosting.centerId).let {
             centerManagerService.findAllByCenterBusinessRegistrationNumber(
                 BusinessRegistrationNumber(it.businessRegistrationNumber)

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -190,7 +190,7 @@ class JobPostingService(
         jobPosting.delete()
     }
 
-    fun updateToComplete(jobPosting: JobPosting) {
+    fun updateToCompleted(jobPosting: JobPosting) {
         jobPosting.updateToCompleted()
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -191,7 +191,7 @@ class JobPostingService(
     }
 
     fun updateToComplete(jobPosting: JobPosting) {
-        jobPosting.updateToComplete()
+        jobPosting.updateToCompleted()
     }
 
     fun findAllByCarerLocationInRange(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
@@ -193,9 +193,9 @@ class CenterJobPostingFacadeService(
     }
 
     @Transactional
-    fun updateToComplete(jobPostingId: UUID) {
+    fun updateToCompleted(jobPostingId: UUID) {
         jobPostingService.getById(jobPostingId).let {
-            jobPostingService.updateToComplete(it)
+            jobPostingService.updateToCompleted(it)
         }
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/exception/ApplyException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/applys/exception/ApplyException.kt
@@ -10,6 +10,9 @@ sealed class ApplyException(
     class AlreadyApplied(message: String = "이미 지원한 이력이 있는 공고입니다.") :
         ApplyException(codeNumber = 1, message = message)
 
+    class JobPostingCompleted(message: String = "마감된 공고에 지원할 수 없습니다.") :
+        ApplyException(codeNumber = 2, message = message)
+
     companion object {
 
         const val CODE_PREFIX = "APPLY"

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/entity/jpa/JobPosting.kt
@@ -225,8 +225,12 @@ class JobPosting(
         this.applyDeadlineType = applyDeadlineType ?: this.applyDeadlineType
     }
 
-    fun updateToComplete() {
+    fun updateToCompleted() {
         this.jobPostingStatus = JobPostingStatus.COMPLETED
+    }
+
+    fun isCompleted(): Boolean {
+        return this.jobPostingStatus == JobPostingStatus.COMPLETED
     }
 
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/jobposting/controller/CenterJobPostingController.kt
@@ -35,7 +35,7 @@ class CenterJobPostingController(
     }
 
     override fun completeJobPosting(jobPostingId: UUID) {
-        centerJobPostingFacadeService.updateToComplete(jobPostingId)
+        centerJobPostingFacadeService.updateToCompleted(jobPostingId)
     }
 
     override fun getJobPostingDetail(jobPostingId: UUID): CenterJobPostingResponse {


### PR DESCRIPTION
## 1. 📄 Summary

[문제 설명]
* 기존에 마감된 공고는 조회 시점에 노출되지 않으며, 클라이언트에서도 마감된 공고에는 지원이 불가능하도록 blocking 처리를 추가해둔 상태였습니다.
* 하지만 유저가 공고 진입 이후에 실시간으로 공고가 마감 처리된 경우, 여전히 공고에 지원이 가능하다는 엣지 케이스가 있었습니다.

[조치 방안]
* 요양 보호사는 마감된 공고에 지원할 수 없도록 지원 방지 로직을 추가하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 완료된 구인 공고에 지원할 수 없도록 하는 추가 오류 처리 기능이 도입되었습니다.
	- 구인 공고의 완료 상태를 확인하는 `isCompleted` 메서드가 추가되었습니다.

- **버그 수정**
	- 완료된 구인 공고에 대한 지원 시도 시 예외가 발생하도록 개선되었습니다.

- **문서화**
	- 메서드 이름이 `updateToComplete`에서 `updateToCompleted`로 변경되어 명확성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->