### PR TITLE
[IDLE-509] 크롤링 전체 조회 시, 공고가 중복 노출되는 현상 해결

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/CrawlingJobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/CrawlingJobPostingService.kt
@@ -29,11 +29,13 @@ class CrawlingJobPostingService(
     }
 
     fun findAllByCarerLocationInRange(
+        carerId: UUID,
         location: Point,
         next: UUID?,
         limit: Long,
     ): List<CrawlingJobPostingPreviewDto> {
         return crawlingJobPostingSpatialQueryRepository.findAllInRange(
+            carerId = carerId,
             location = location,
             next = next,
             limit = limit,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingService.kt
@@ -11,7 +11,6 @@ import com.swm.idle.domain.jobposting.enums.PayType
 import com.swm.idle.domain.jobposting.repository.jpa.JobPostingJpaRepository
 import com.swm.idle.domain.jobposting.repository.querydsl.JobPostingQueryRepository
 import com.swm.idle.domain.jobposting.repository.querydsl.JobPostingSpatialQueryRepository
-import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import com.swm.idle.domain.user.common.enum.GenderType
 import com.swm.idle.domain.user.common.vo.BirthYear
 import org.locationtech.jts.geom.Point
@@ -195,13 +194,13 @@ class JobPostingService(
     }
 
     fun findAllByCarerLocationInRange(
-        carer: Carer,
+        carerId: UUID,
         location: Point,
         next: UUID?,
         limit: Long,
     ): List<JobPostingPreviewDto> {
         return jobPostingSpatialQueryRepository.findAllWithWeekdaysInRange(
-            carer = carer,
+            carerId = carerId,
             location = location,
             next = next,
             limit = limit,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CarerJobPostingFacadeService.kt
@@ -106,18 +106,16 @@ class CarerJobPostingFacadeService(
         }
 
         val jobPostingPreviewDtos = jobPostingService.findAllByCarerLocationInRange(
-            carer = carer,
+            carerId = carer.id,
             location = location,
             next = next,
             limit = limit + 1,
         )
 
-
         val carerLocation = PointConverter.convertToPoint(
             latitude = carer.latitude.toDouble(),
             longitude = carer.longitude.toDouble(),
         )
-
 
         for (jobPostingPreviewDto in jobPostingPreviewDtos) {
             jobPostingPreviewDto.distance = jobPostingService.calculateDistance(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
@@ -7,7 +7,6 @@ import com.swm.idle.application.jobposting.domain.JobPostingFavoriteService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.domain.common.dto.CrawlingJobPostingPreviewDto
 import com.swm.idle.domain.user.carer.entity.jpa.Carer
-import com.swm.idle.infrastructure.client.geocode.service.GeoCodeService
 import com.swm.idle.support.transfer.common.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingFavoriteResponse
 import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingScrollResponse
@@ -19,7 +18,6 @@ import java.util.*
 @Service
 class CrawlingJobPostingFacadeService(
     private val crawlingJobPostingService: CrawlingJobPostingService,
-    private val geoCodeService: GeoCodeService,
     private val carerService: CarerService,
     private val jobPostingFavoriteService: JobPostingFavoriteService,
 ) {

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
@@ -110,14 +110,10 @@ class CrawlingJobPostingFacadeService(
             limit = limit + 1,
         )
 
-        val carerLocation = getUserAuthentication().userId.let {
-            carerService.getById(it)
-        }.let {
-            PointConverter.convertToPoint(
-                latitude = it.latitude.toDouble(),
-                longitude = it.longitude.toDouble(),
-            )
-        }
+        val carerLocation = PointConverter.convertToPoint(
+            latitude = carer.latitude.toDouble(),
+            longitude = carer.longitude.toDouble(),
+        )
 
         for (crawlingJobPostingPreviewDto in crawlingJobPostingPreviewDtos) {
             crawlingJobPostingPreviewDto.distance = crawlingJobPostingService.calculateDistance(

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
@@ -99,7 +99,12 @@ class CrawlingJobPostingFacadeService(
         next: UUID?,
         limit: Long,
     ): Pair<List<CrawlingJobPostingPreviewDto>, UUID?> {
+        val carer = getUserAuthentication().userId.let {
+            carerService.getById(it)
+        }
+
         val crawlingJobPostingPreviewDtos = crawlingJobPostingService.findAllByCarerLocationInRange(
+            carerId = carer.id,
             location = location,
             next = next,
             limit = limit + 1,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/CrawlingJobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/CrawlingJobPostingSpatialQueryRepository.kt
@@ -19,6 +19,7 @@ class CrawlingJobPostingSpatialQueryRepository(
 ) {
 
     fun findAllInRange(
+        carerId: UUID,
         location: Point,
         next: UUID?,
         limit: Long,
@@ -41,8 +42,11 @@ class CrawlingJobPostingSpatialQueryRepository(
         return jpaQueryFactory
             .select(crawledJobPosting, jobPostingFavorite)
             .from(crawledJobPosting)
-            .leftJoin(jobPostingFavorite).fetchJoin()
-            .on(crawledJobPosting.id.eq(jobPostingFavorite.jobPostingId))
+            .leftJoin(jobPostingFavorite)
+            .on(
+                crawledJobPosting.id.eq(jobPostingFavorite.jobPostingId)
+                    .and(jobPostingFavorite.carerId.eq(carerId))
+            )
             .where(crawledJobPosting.id.`in`(crawledJobPostingIds))
             .transform(
                 groupBy(crawledJobPosting.id)
@@ -61,7 +65,7 @@ class CrawlingJobPostingSpatialQueryRepository(
         location: Point,
     ): BooleanExpression {
         return Expressions.booleanTemplate(
-            "ST_Contains(ST_BUFFER({0}, 3000), {1})",
+            "ST_Contains(ST_BUFFER({0}, 5000), {1})",
             location,
             crawledJobPosting.location,
         )

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/querydsl/JobPostingSpatialQueryRepository.kt
@@ -13,7 +13,6 @@ import com.swm.idle.domain.jobposting.entity.jpa.QJobPosting.jobPosting
 import com.swm.idle.domain.jobposting.entity.jpa.QJobPostingFavorite.jobPostingFavorite
 import com.swm.idle.domain.jobposting.entity.jpa.QJobPostingWeekday.jobPostingWeekday
 import com.swm.idle.domain.jobposting.enums.JobPostingStatus
-import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import org.locationtech.jts.geom.Point
 import org.springframework.stereotype.Repository
 import java.util.*
@@ -24,7 +23,7 @@ class JobPostingSpatialQueryRepository(
 ) {
 
     fun findAllWithWeekdaysInRange(
-        carer: Carer,
+        carerId: UUID,
         location: Point,
         next: UUID?,
         limit: Long,
@@ -58,7 +57,7 @@ class JobPostingSpatialQueryRepository(
             .leftJoin(applys)
             .on(
                 jobPosting.id.eq(applys.jobPostingId)
-                    .and(applys.carerId.eq(carer.id))
+                    .and(applys.carerId.eq(carerId))
             )
             .leftJoin(jobPostingFavorite)
             .on(jobPosting.id.eq(jobPostingFavorite.jobPostingId))
@@ -86,7 +85,7 @@ class JobPostingSpatialQueryRepository(
         location: Point,
     ): BooleanExpression {
         return Expressions.booleanTemplate(
-            "ST_Contains(ST_BUFFER({0}, 3000), {1})",
+            "ST_Contains(ST_BUFFER({0}, 5000), {1})",
             location,
             jobPosting.location,
         )


### PR DESCRIPTION
## 1. 📄 Summary
* 크롤링된 공고 전체 조회 API에서 간헐적으로 같은 공고가 두번 이상 조회되는 문제가 발생하였습니다.
* 즐겨찾기 내역에 대한 유저별 필터를 위해 where 조건절을 추가하였습니다.
* 공고 탐색 반경을 기존 3km에서 5km로 변경 조치하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 구직 게시물 검색 시, 보호자 ID를 기반으로 필터링 기능 추가.
  - 인증된 사용자의 위치 기반으로 거리 계산 개선.

- **버그 수정**
  - 날짜 파싱 로직 개선으로 신청 마감일 처리 강화.

- **문서화**
  - 메서드 시그니처 업데이트로 코드 가독성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->