### PR TITLE
[IDLE-000] 크롤링 공고 즐겨찾기 조회 로직 버그 수정

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/domain/JobPostingFavoriteService.kt
@@ -54,8 +54,8 @@ class JobPostingFavoriteService(
         )
     }
 
-    fun existsByJobPostingId(jobPostingId: UUID): Boolean {
-        return jobPostingFavoriteJpaRepository.existsByJobPostingId(jobPostingId)
+    fun findByByJobPostingId(jobPostingId: UUID): JobPostingFavorite? {
+        return jobPostingFavoriteJpaRepository.findByJobPostingId(jobPostingId)
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CrawlingJobPostingFacadeService.kt
@@ -6,6 +6,7 @@ import com.swm.idle.application.jobposting.domain.CrawlingJobPostingService
 import com.swm.idle.application.jobposting.domain.JobPostingFavoriteService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.domain.common.dto.CrawlingJobPostingPreviewDto
+import com.swm.idle.domain.common.enums.EntityStatus
 import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import com.swm.idle.support.transfer.common.CursorScrollRequest
 import com.swm.idle.support.transfer.jobposting.carer.CrawlingJobPostingFavoriteResponse
@@ -39,7 +40,9 @@ class CrawlingJobPostingFacadeService(
 
         return crawlingJobPostingService.getById(crawlingJobPostingId).let {
             val isFavorite =
-                jobPostingFavoriteService.existsByJobPostingId(crawlingJobPostingId)
+                jobPostingFavoriteService.findByByJobPostingId(crawlingJobPostingId)?.let {
+                    it.entityStatus == EntityStatus.ACTIVE
+                } ?: false
 
             CrawlingJobPostingResponse.from(
                 crawlingJobPosting = it,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingFavoriteJpaRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/repository/jpa/JobPostingFavoriteJpaRepository.kt
@@ -15,6 +15,6 @@ interface JobPostingFavoriteJpaRepository : JpaRepository<JobPostingFavorite, UU
         carerId: UUID,
     ): JobPostingFavorite?
 
-    fun existsByJobPostingId(jobPostingId: UUID): Boolean
+    fun findByJobPostingId(jobPostingId: UUID): JobPostingFavorite?
 
 }


### PR DESCRIPTION
## 1. 📄 Summary
* 크롤링 공고 즐겨찾기 조회 로직 버그 수정
* soft delete 적용 이후, db에 존재 여부로 체크하는 로직에 더해 현재 ACTIVE한 상태인지 더블 체크하는 로직으로 변경
