### PR TITLE
[IDLE-513] 센터 관리자 공고 등록 시, 주변 요양보호사에게 FCM 알림을 일괄 전송한다.

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/event/CreateJobPostingEventPublisher.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/event/CreateJobPostingEventPublisher.kt
@@ -1,0 +1,16 @@
+package com.swm.idle.application.jobposting.event
+
+import com.swm.idle.domain.jobposting.event.CreateJobPostingEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class CreateJobPostingEventPublisher(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+
+    fun publish(createJobPostingEvent: CreateJobPostingEvent) {
+        eventPublisher.publishEvent(createJobPostingEvent)
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
@@ -103,7 +103,7 @@ class CenterJobPostingFacadeService(
             val deviceTokens = deviceTokenService.findAllByUserId(carer.id)
 
             val notificationInfo = CreateJobPostingNotificationInfo(
-                title = "${carer.name} 님이 공고에 지원하였습니다.",
+                title = "주변에 새로운 공고가 등록되었어요, 얼른 확인해 보세요!",
                 body = createBodyMessage(jobPosting),
                 receiverId = carer.id,
                 notificationType = NotificationType.NEW_JOB_POSTING,

--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/vo/CreateJobPostingNotificationInfo.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/vo/CreateJobPostingNotificationInfo.kt
@@ -1,0 +1,42 @@
+package com.swm.idle.application.jobposting.vo
+
+import com.swm.idle.application.applys.vo.CarerApplyNotificationInfo
+import com.swm.idle.domain.notification.enums.NotificationType
+import com.swm.idle.domain.notification.event.NotificationInfo
+import java.util.*
+
+class CreateJobPostingNotificationInfo(
+    override val title: String,
+    override val body: String,
+    override val receiverId: UUID,
+    override val notificationType: NotificationType,
+    override val imageUrl: String?,
+    override val notificationDetails: Map<String, Any>?,
+) : NotificationInfo {
+
+    companion object {
+
+        fun create(
+            title: String,
+            body: String,
+            receiverId: UUID,
+            notificationType: NotificationType,
+            imageUrl: String?,
+            jobPostingId: UUID,
+        ): CarerApplyNotificationInfo {
+            val notificationDetails = mapOf(
+                "jobPostingId" to jobPostingId,
+            )
+            return CarerApplyNotificationInfo(
+                title,
+                body,
+                receiverId,
+                notificationType,
+                imageUrl,
+                notificationDetails,
+            )
+        }
+
+    }
+
+}

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/carer/domain/CarerService.kt
@@ -1,12 +1,15 @@
 package com.swm.idle.application.user.carer.domain
 
+import com.swm.idle.application.common.converter.PointConverter
 import com.swm.idle.domain.common.exception.PersistenceException
 import com.swm.idle.domain.user.carer.entity.jpa.Carer
 import com.swm.idle.domain.user.carer.enums.JobSearchStatus
 import com.swm.idle.domain.user.carer.repository.jpa.CarerJpaRepository
+import com.swm.idle.domain.user.carer.repository.jpa.CarerQueryRepository
 import com.swm.idle.domain.user.common.enum.GenderType
 import com.swm.idle.domain.user.common.vo.BirthYear
 import com.swm.idle.domain.user.common.vo.PhoneNumber
+import org.locationtech.jts.geom.Point
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,6 +19,7 @@ import java.util.*
 @Service
 class CarerService(
     private val carerJpaRepository: CarerJpaRepository,
+    private val carerQueryRepository: CarerQueryRepository,
 ) {
 
     @Transactional
@@ -39,6 +43,10 @@ class CarerService(
                 lotNumberAddress = lotNumberAddress,
                 longitude = BigDecimal(longitude),
                 latitude = BigDecimal(latitude),
+                location = PointConverter.convertToPoint(
+                    latitude = latitude.toDouble(),
+                    longitude = longitude.toDouble(),
+                )
             )
         )
     }
@@ -72,6 +80,10 @@ class CarerService(
             introduce = introduce,
             speciality = speciality,
             jobSearchStatus = jobSearchStatus,
+            location = PointConverter.convertToPoint(
+                longitude.toDouble(),
+                latitude.toDouble()
+            )
         )
     }
 
@@ -93,6 +105,10 @@ class CarerService(
     @Transactional
     fun delete(id: UUID) {
         carerJpaRepository.deleteById(id)
+    }
+
+    fun findAllByLocationWithinRadius(location: Point): List<Carer>? {
+        return carerQueryRepository.findAllByLocationWithinRadius(location)
     }
 
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/event/CreateJobPostingEvent.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/jobposting/event/CreateJobPostingEvent.kt
@@ -1,0 +1,28 @@
+package com.swm.idle.domain.jobposting.event
+
+import com.swm.idle.domain.notification.event.NotificationInfo
+import com.swm.idle.domain.notification.jpa.DeviceToken
+import java.util.*
+
+data class CreateJobPostingEvent(
+    val deviceToken: DeviceToken,
+    val notificationId: UUID,
+    val notificationInfo: NotificationInfo,
+) {
+
+    companion object {
+
+        fun of(
+            deviceToken: DeviceToken,
+            notificationId: UUID,
+            notificationInfo: NotificationInfo,
+        ): CreateJobPostingEvent {
+            return CreateJobPostingEvent(
+                deviceToken = deviceToken,
+                notificationId = notificationId,
+                notificationInfo = notificationInfo
+            )
+        }
+    }
+
+}

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/enums/NotificationType.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/enums/NotificationType.kt
@@ -3,4 +3,5 @@ package com.swm.idle.domain.notification.enums
 enum class NotificationType {
     APPLICANT,
     CENTER_AUTHENTICATION,
+    NEW_JOB_POSTING,
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/entity/jpa/Carer.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import org.hibernate.annotations.DynamicUpdate
+import org.locationtech.jts.geom.Point
 import java.math.BigDecimal
 
 @Entity
@@ -30,6 +31,7 @@ class Carer(
     profileImageUrl: String? = null,
     jobSearchStatus: JobSearchStatus = JobSearchStatus.YES,
     carerAccountStatus: CarerAccountStatus = CarerAccountStatus.ACTIVE,
+    location: Point,
 ) : User(phoneNumber, carerName) {
 
     @Column(nullable = false)
@@ -83,6 +85,10 @@ class Carer(
     var carerAccountStatus: CarerAccountStatus = carerAccountStatus
         private set
 
+    @Column(nullable = false, columnDefinition = "POINT SRID 4326")
+    var location: Point = location
+        private set
+
     fun update(
         experienceYear: Int?,
         roadNameAddress: String,
@@ -92,6 +98,7 @@ class Carer(
         introduce: String?,
         speciality: String?,
         jobSearchStatus: JobSearchStatus?,
+        location: Point,
     ) {
         this.experienceYear = experienceYear
         this.roadNameAddress = roadNameAddress
@@ -101,6 +108,7 @@ class Carer(
         this.introduce = introduce
         this.speciality = speciality
         this.jobSearchStatus = jobSearchStatus ?: this.jobSearchStatus
+        this.location = location
     }
 
     fun updateWithoutAddress(

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/enums/CarerAccountStatus.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/enums/CarerAccountStatus.kt
@@ -2,5 +2,5 @@ package com.swm.idle.domain.user.carer.enums
 
 enum class CarerAccountStatus {
     ACTIVE,
-    INACTIVE;
+    DELETED;
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/repository/jpa/CarerQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/carer/repository/jpa/CarerQueryRepository.kt
@@ -1,0 +1,38 @@
+package com.swm.idle.domain.user.carer.repository.jpa
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.swm.idle.domain.user.carer.entity.jpa.Carer
+import com.swm.idle.domain.user.carer.entity.jpa.QCarer.carer
+import com.swm.idle.domain.user.carer.enums.CarerAccountStatus
+import com.swm.idle.domain.user.carer.enums.JobSearchStatus
+import org.locationtech.jts.geom.Point
+import org.springframework.stereotype.Repository
+
+@Repository
+class CarerQueryRepository(
+    private val jpaQueryFactory: JPAQueryFactory,
+) {
+
+    fun findAllByLocationWithinRadius(location: Point): List<Carer>? {
+        return jpaQueryFactory
+            .selectFrom(carer)
+            .where(
+                isExistInRange(location)
+                    .and(carer.jobSearchStatus.eq(JobSearchStatus.YES))
+                    .and(carer.carerAccountStatus.eq(CarerAccountStatus.ACTIVE))
+            )
+            .fetch()
+    }
+
+    private fun isExistInRange(location: Point): BooleanExpression {
+        return Expressions.booleanTemplate(
+            "ST_Contains(ST_BUFFER({0}, 5000), {1})",
+            location,
+            carer.location
+        )
+    }
+
+
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/jobposting/listener/CreateJobPostingEventListener.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/jobposting/listener/CreateJobPostingEventListener.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.infrastructure.fcm.jobposting.listener
+
+import com.swm.idle.domain.jobposting.event.CreateJobPostingEvent
+import com.swm.idle.infrastructure.fcm.jobposting.service.CreateJobPostingEventService
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class CreateJobPostingEventListener(
+    private val createJobPostingEventService: CreateJobPostingEventService,
+) {
+
+    @EventListener
+    fun handleCreateJobPostingEvent(createJobPostingEvent: CreateJobPostingEvent) {
+        createJobPostingEventService.send(createJobPostingEvent)
+    }
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/jobposting/service/CreateJobPostingEventService.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/jobposting/service/CreateJobPostingEventService.kt
@@ -1,0 +1,52 @@
+package com.swm.idle.infrastructure.fcm.jobposting.service
+
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import com.swm.idle.domain.jobposting.event.CreateJobPostingEvent
+import com.swm.idle.infrastructure.fcm.common.client.FcmClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+
+@Component
+class CreateJobPostingEventService(
+    private val fcmClient: FcmClient,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    fun send(createJobPostingEvent: CreateJobPostingEvent) {
+        val message = createMessage(createJobPostingEvent)
+
+        try {
+            fcmClient.send(message)
+        } catch (e: Exception) {
+            logger.warn { "FCM 알림 전송에 실패했습니다 : ${message}, 실패한 Event : CreateJobPostingEvent" }
+        }
+    }
+
+    private fun createJobPostingNotification(createJobPostingEvent: CreateJobPostingEvent): Notification {
+        return Notification.builder()
+            .setTitle(createJobPostingEvent.notificationInfo.title)
+            .setBody(createJobPostingEvent.notificationInfo.body)
+            .build()
+    }
+
+    private fun createMessage(createJobPostingEvent: CreateJobPostingEvent): Message {
+        val createJobPostingNotification = createJobPostingNotification(createJobPostingEvent)
+
+        return Message.builder()
+            .setToken(createJobPostingEvent.deviceToken.deviceToken)
+            .setNotification(createJobPostingNotification)
+            .putData("notificationId", createJobPostingEvent.notificationId.toString())
+            .putData(
+                "notificationType",
+                createJobPostingEvent.notificationInfo.notificationType.toString()
+            )
+            .putData(
+                "jobPostingId",
+                createJobPostingEvent.notificationInfo.notificationDetails!!["jobPostingId"].toString()
+            )
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 관리자가 구인 공고를 등록한 경우, 반경 5km 이내에 거주하는 요양 보호사에게 FCM 알림을 일괄 전송합니다.

## 2. ✏️ Documentation

### Server to FCM Request Spec

---

서버 → Firebase SDK 요청 스펙에 대한 명세입니다.

- 공고 등록 알림(`NEW_JOB_POSTING`)
    
    ```json
    {
      "message":{
        "notification":{
          "body" : "00시 00구 00동 0등급 00세 남자",
          "title" : "주변에 새로운 공고가 등록되었어요, 얼른 확인해 보세요!",
        },
        "data" : {
          "notificationId": "string(uuid)",
          "notificationType" : "NEW_JOB_POSTING",
          "jobPostingId" : "string(uuid)"
        }
    }
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 새로운 구인 공고 생성 이벤트 발행 기능이 추가되었습니다.
	- 구인 공고 생성 시 알림을 발송하는 기능이 통합되었습니다.
	- 위치 기반으로 활동 중인 간호사를 검색하는 기능이 추가되었습니다.
	- 새로운 구인 공고 알림 정보를 위한 클래스가 도입되었습니다.
	- 구인 공고 알림 이벤트 리스너가 추가되어 이벤트 처리 기능이 강화되었습니다.

- **버그 수정**
	- 간호사 계정 상태에서 'INACTIVE' 대신 'DELETED' 상태로 업데이트되었습니다.

- **문서화**
	- 코드 내 주석 및 문서화가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->