### PR TITLE
[IDLE-000] 센터 공고 등록 알림 제목 변경 및 프로필 url null로 수정

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/jobposting/facade/CenterJobPostingFacadeService.kt
@@ -103,11 +103,11 @@ class CenterJobPostingFacadeService(
             val deviceTokens = deviceTokenService.findAllByUserId(carer.id)
 
             val notificationInfo = CreateJobPostingNotificationInfo(
-                title = "주변에 새로운 공고가 등록되었어요, 얼른 확인해 보세요!",
+                title = "주변에 새로운 공고가 등록되었어요!",
                 body = createBodyMessage(jobPosting),
                 receiverId = carer.id,
                 notificationType = NotificationType.NEW_JOB_POSTING,
-                imageUrl = carer.profileImageUrl,
+                imageUrl = null,
                 notificationDetails = mapOf(
                     "jobPostingId" to jobPosting.id,
                 )


### PR DESCRIPTION
## 1. 📄 Summary
* 아래와 같이 알림 목록에서 제목이 짤리는 문제가 있어, 센터 공고 등록 시, 요양 보호사에게 전송되는 알림 제목을 짧게 수정하였습니다.
![image](https://github.com/user-attachments/assets/902742c9-dde9-4252-a0a4-1983d97572fc)

* 알림 목록에서 프로필 이미지 대신 기본 이미지 사용을 위해 image url을 null로 지정하여 전송하도록 수정하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 알림 제목이 간소화되어 "주변에 새로운 공고가 등록되었어요!"로 변경되었습니다.
	- 프로필 이미지 참조가 제거되어 `imageUrl` 필드가 `null`로 설정되었습니다.
  
- **버그 수정**
	- 기존의 오류 처리 로직은 유지되어 예외 처리가 계속 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->