### PR TITLE
[IDLE-504] 센터 관리자 인증 승인 및 거절 API

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/event/CenterManagerVerificationApproveEventPublisher.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/event/CenterManagerVerificationApproveEventPublisher.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.application.user.center.service.event
+
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationApproveEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class CenterManagerVerificationApproveEventPublisher(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+
+    fun publish(centerManagerVerificationApproveEvent: CenterManagerVerificationApproveEvent) {
+        eventPublisher.publishEvent(centerManagerVerificationApproveEvent)
+    }
+
+}
+

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/event/CenterManagerVerificationRejectEventPublisher.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/event/CenterManagerVerificationRejectEventPublisher.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.application.user.center.service.event
+
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationRejectEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class CenterManagerVerificationRejectEventPublisher(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+
+    fun publish(centerManagerVerificationRejectEvent: CenterManagerVerificationRejectEvent) {
+        eventPublisher.publishEvent(centerManagerVerificationRejectEvent)
+    }
+
+}
+

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterAuthFacadeService.kt
@@ -1,13 +1,22 @@
 package com.swm.idle.application.user.center.service.facade
 
 import com.swm.idle.application.common.security.getUserAuthentication
+import com.swm.idle.application.notification.domain.DeviceTokenService
+import com.swm.idle.application.notification.domain.NotificationService
 import com.swm.idle.application.user.center.service.domain.CenterManagerService
+import com.swm.idle.application.user.center.service.event.CenterManagerVerificationApproveEventPublisher
+import com.swm.idle.application.user.center.service.event.CenterManagerVerificationRejectEventPublisher
 import com.swm.idle.application.user.center.service.event.CenterManagerVerificationRequestEventPublisher
+import com.swm.idle.application.user.center.vo.CenterManagerVerificationApproveNotificationInfo
+import com.swm.idle.application.user.center.vo.CenterManagerVerificationRejectNotificationInfo
 import com.swm.idle.application.user.common.service.domain.DeletedUserInfoService
 import com.swm.idle.application.user.common.service.domain.RefreshTokenService
 import com.swm.idle.application.user.common.service.util.JwtTokenService
 import com.swm.idle.domain.common.enums.EntityStatus
 import com.swm.idle.domain.common.exception.PersistenceException
+import com.swm.idle.domain.notification.enums.NotificationType
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationApproveEvent
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationRejectEvent
 import com.swm.idle.domain.user.center.event.CenterManagerVerificationRequestEvent.Companion.createVerifyEvent
 import com.swm.idle.domain.user.center.exception.CenterException
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
@@ -26,6 +35,7 @@ import com.swm.idle.support.transfer.user.center.JoinStatusInfoResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @Service
 class CenterAuthFacadeService(
@@ -35,6 +45,10 @@ class CenterAuthFacadeService(
     private val jwtTokenService: JwtTokenService,
     private val refreshTokenService: RefreshTokenService,
     private val centerManagerVerificationRequestEventPublisher: CenterManagerVerificationRequestEventPublisher,
+    private val centerManagerVerificationApproveEventPublisher: CenterManagerVerificationApproveEventPublisher,
+    private val centerManagerVerificationRejectEventPublisher: CenterManagerVerificationRejectEventPublisher,
+    private val deviceTokenService: DeviceTokenService,
+    private val notificationService: NotificationService,
 ) {
 
     fun join(
@@ -152,6 +166,7 @@ class CenterAuthFacadeService(
         }
     }
 
+
     fun getCenterManagerForPending(): CenterManagerForPendingResponse {
         val centerManagers = centerManagerService.findAllByStatusPending()
 
@@ -160,6 +175,67 @@ class CenterAuthFacadeService(
         }?.let {
             CenterManagerForPendingResponse.of(it)
         } ?: CenterManagerForPendingResponse.of(emptyList())
+    }
+
+    @Transactional
+    fun approveVerification(centerManagerId: UUID) {
+        val centerManager = centerManagerService.getById(centerManagerId)
+
+        if (centerManager.isPending().not()) {
+            throw CenterException.IsNotPendingException()
+        }
+
+        centerManager.approve()
+
+        deviceTokenService.findByUserId(centerManagerId)?.let {
+            val notificationInfo = CenterManagerVerificationApproveNotificationInfo.of(
+                title = "[케어밋] 센터 관리자 인증 요청이 승인되었어요!",
+                body = "${centerManager.name} 관리자님! 센터 관리자 인증 요청이 최종 승인되었어요! 어서 확인해 보세요!",
+                receiverId = centerManager.id,
+                notificationType = NotificationType.CENTER_AUTHENTICATION,
+            )
+
+            val notification = notificationService.create(notificationInfo)
+
+
+            CenterManagerVerificationApproveEvent(
+                deviceToken = it.toString(),
+                notificationId = notification.id,
+                notificationInfo = notificationInfo
+            ).also {
+                centerManagerVerificationApproveEventPublisher.publish(it)
+            }
+        }
+    }
+
+    @Transactional
+    fun rejectVerification(centerManagerId: UUID) {
+        val centerManager = centerManagerService.getById(centerManagerId)
+
+        if (centerManager.isPending().not()) {
+            throw CenterException.IsNotPendingException()
+        }
+
+        centerManager.reject()
+
+        deviceTokenService.findByUserId(centerManagerId)?.let {
+            val notificationInfo = CenterManagerVerificationRejectNotificationInfo.of(
+                title = "[케어밋] 센터 관리자 인증 요청이 거절되었어요.",
+                body = "${centerManager.name} 관리자님, 센터 관리자 인증 요청이 거절되었어요. 문의사항을 통해 연락해 주세요.",
+                receiverId = centerManager.id,
+                notificationType = NotificationType.CENTER_AUTHENTICATION,
+            )
+
+            val notification = notificationService.create(notificationInfo)
+
+            CenterManagerVerificationRejectEvent(
+                deviceToken = it.toString(),
+                notificationId = notification.id,
+                notificationInfo = notificationInfo
+            ).also {
+                centerManagerVerificationRejectEventPublisher.publish(it)
+            }
+        }
     }
 
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/vo/CenterManagerVerificationApproveNotificationInfo.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/vo/CenterManagerVerificationApproveNotificationInfo.kt
@@ -1,10 +1,10 @@
-package com.swm.idle.application.applys.vo
+package com.swm.idle.application.user.center.vo
 
 import com.swm.idle.domain.notification.enums.NotificationType
 import com.swm.idle.domain.notification.event.NotificationInfo
 import java.util.*
 
-data class CarerApplyNotificationInfo(
+data class CenterManagerVerificationApproveNotificationInfo(
     override val title: String,
     override val body: String,
     override val receiverId: UUID,
@@ -15,28 +15,21 @@ data class CarerApplyNotificationInfo(
 
     companion object {
 
-        fun create(
+        fun of(
             title: String,
             body: String,
             receiverId: UUID,
             notificationType: NotificationType,
-            imageUrl: String?,
-            jobPostingId: UUID,
-        ): CarerApplyNotificationInfo {
-            val notificationDetails = mapOf(
-                "jobPostingId" to jobPostingId,
-            )
-
-            return CarerApplyNotificationInfo(
+        ): CenterManagerVerificationApproveNotificationInfo {
+            return CenterManagerVerificationApproveNotificationInfo(
                 title,
                 body,
                 receiverId,
                 notificationType,
-                imageUrl,
-                notificationDetails,
+                null,
+                null
             )
         }
 
     }
-
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/vo/CenterManagerVerificationRejectNotificationInfo.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/vo/CenterManagerVerificationRejectNotificationInfo.kt
@@ -1,10 +1,10 @@
-package com.swm.idle.application.applys.vo
+package com.swm.idle.application.user.center.vo
 
 import com.swm.idle.domain.notification.enums.NotificationType
 import com.swm.idle.domain.notification.event.NotificationInfo
 import java.util.*
 
-data class CarerApplyNotificationInfo(
+data class CenterManagerVerificationRejectNotificationInfo(
     override val title: String,
     override val body: String,
     override val receiverId: UUID,
@@ -15,28 +15,21 @@ data class CarerApplyNotificationInfo(
 
     companion object {
 
-        fun create(
+        fun of(
             title: String,
             body: String,
             receiverId: UUID,
             notificationType: NotificationType,
-            imageUrl: String?,
-            jobPostingId: UUID,
-        ): CarerApplyNotificationInfo {
-            val notificationDetails = mapOf(
-                "jobPostingId" to jobPostingId,
-            )
-
-            return CarerApplyNotificationInfo(
+        ): CenterManagerVerificationApproveNotificationInfo {
+            return CenterManagerVerificationApproveNotificationInfo(
                 title,
                 body,
                 receiverId,
                 notificationType,
-                imageUrl,
-                notificationDetails,
+                null,
+                null
             )
         }
 
     }
-
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/querydsl/NotificationQueryRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/notification/repository/querydsl/NotificationQueryRepository.kt
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.swm.idle.domain.common.dto.NotificationQueryDto
 import com.swm.idle.domain.common.enums.EntityStatus
+import com.swm.idle.domain.notification.enums.NotificationType
 import com.swm.idle.domain.notification.jpa.QNotification.notification
 import org.springframework.stereotype.Repository
 import java.util.*
@@ -37,6 +38,7 @@ class NotificationQueryRepository(
                 notification.receiverId.eq(userId)
                     .and(next?.let { notification.id.loe(it) })
                     .and(notification.entityStatus.eq(EntityStatus.ACTIVE))
+                    .and(notification.notificationType.ne(NotificationType.CENTER_AUTHENTICATION))
             )
             .orderBy(notification.id.desc())
             .limit(limit)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/entity/jpa/CenterManager.kt
@@ -52,11 +52,11 @@ class CenterManager(
         return status == CenterManagerAccountStatus.PENDING
     }
 
-    fun updateStatusToApproved() {
+    fun approve() {
         this.status = CenterManagerAccountStatus.APPROVED
     }
 
-    fun updateStatusToRejected() {
+    fun reject() {
         this.status = CenterManagerAccountStatus.REJECTED
     }
 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/event/CenterManagerVerificationApproveEvent.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/event/CenterManagerVerificationApproveEvent.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.domain.user.center.event
+
+import com.swm.idle.domain.notification.event.NotificationInfo
+import java.util.*
+
+data class CenterManagerVerificationApproveEvent(
+    val notificationId: UUID,
+    val notificationInfo: NotificationInfo,
+    val deviceToken: String,
+)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/event/CenterManagerVerificationRejectEvent.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/event/CenterManagerVerificationRejectEvent.kt
@@ -1,0 +1,10 @@
+package com.swm.idle.domain.user.center.event
+
+import com.swm.idle.domain.notification.event.NotificationInfo
+import java.util.*
+
+data class CenterManagerVerificationRejectEvent(
+    val notificationId: UUID,
+    val notificationInfo: NotificationInfo,
+    val deviceToken: String,
+)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/exception/CenterException.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/user/center/exception/CenterException.kt
@@ -19,6 +19,9 @@ sealed class CenterException(
     class NotFoundException(message: String = "존재하지 않는 센터입니다.") :
         CenterException(codeNumber = 4, message = message)
 
+    class IsNotPendingException(message: String = "관리자 인증 요청이 가능한 상태가 아닙니다.") :
+        CenterException(codeNumber = 5, message = message)
+
     companion object {
 
         const val CODE_PREFIX = "CENTER"

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/listener/CenterManagerVerificationApproveEventListener.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/listener/CenterManagerVerificationApproveEventListener.kt
@@ -1,0 +1,17 @@
+package com.swm.idle.infrastructure.fcm.users.listener
+
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationApproveEvent
+import com.swm.idle.infrastructure.fcm.users.service.CenterManagerVerificationApproveEventService
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class CenterManagerVerificationApproveEventListener(
+    private val centerManagerVerificationApproveEventService: CenterManagerVerificationApproveEventService,
+) {
+
+    @EventListener
+    fun handleCenterManagerVerifyApproveEvent(centerManagerVerificationApproveEvent: CenterManagerVerificationApproveEvent) {
+        centerManagerVerificationApproveEventService.send(centerManagerVerificationApproveEvent)
+    }
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/listener/CenterManagerVerificationRejectEventListener.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/listener/CenterManagerVerificationRejectEventListener.kt
@@ -1,0 +1,18 @@
+package com.swm.idle.infrastructure.fcm.users.listener
+
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationRejectEvent
+import com.swm.idle.infrastructure.fcm.users.service.CenterManagerVerificationRejectEventService
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class CenterManagerVerificationRejectEventListener(
+    private val centerManagerVerificationRejectEventService: CenterManagerVerificationRejectEventService,
+) {
+
+    @EventListener
+    fun handleCenterManagerVerifyRejectEvent(centerManagerVerificationRejectEvent: CenterManagerVerificationRejectEvent) {
+        centerManagerVerificationRejectEventService.send(centerManagerVerificationRejectEvent)
+    }
+
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/service/CenterManagerVerificationApproveEventService.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/service/CenterManagerVerificationApproveEventService.kt
@@ -1,0 +1,54 @@
+package com.swm.idle.infrastructure.fcm.users.service
+
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationApproveEvent
+import com.swm.idle.infrastructure.fcm.common.client.FcmClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+
+@Component
+class CenterManagerVerificationApproveEventService(
+    private val fcmClient: FcmClient,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    fun send(centerManagerVerificationApproveEvent: CenterManagerVerificationApproveEvent) {
+        val message = createMessage(centerManagerVerificationApproveEvent)
+
+        try {
+            fcmClient.send(message)
+        } catch (e: Exception) {
+            logger.warn { "FCM 알림 전송에 실패했습니다 : ${message}, 실패한 Event : CenterManagerVerificationApproveEvent" }
+        }
+    }
+
+
+    private fun createJobPostingNotification(centerManagerVerificationApproveEvent: CenterManagerVerificationApproveEvent): Notification {
+        return Notification.builder()
+            .setTitle(centerManagerVerificationApproveEvent.notificationInfo.title)
+            .setBody(centerManagerVerificationApproveEvent.notificationInfo.body)
+            .build()
+    }
+
+    private fun createMessage(centerManagerVerificationApproveEvent: CenterManagerVerificationApproveEvent): Message {
+        val createJobPostingNotification =
+            createJobPostingNotification(centerManagerVerificationApproveEvent)
+
+        return Message.builder()
+            .setToken(centerManagerVerificationApproveEvent.deviceToken)
+            .setNotification(createJobPostingNotification)
+            .putData(
+                "notificationId",
+                centerManagerVerificationApproveEvent.notificationId.toString()
+            )
+            .putData(
+                "notificationType",
+                centerManagerVerificationApproveEvent.notificationInfo.notificationType.toString()
+            )
+            .build();
+    }
+
+
+}

--- a/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/service/CenterManagerVerificationRejectEventService.kt
+++ b/idle-infrastructure/fcm/src/main/kotlin/com/swm/idle/infrastructure/fcm/users/service/CenterManagerVerificationRejectEventService.kt
@@ -1,0 +1,53 @@
+package com.swm.idle.infrastructure.fcm.users.service
+
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import com.swm.idle.domain.user.center.event.CenterManagerVerificationRejectEvent
+import com.swm.idle.infrastructure.fcm.common.client.FcmClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+
+@Component
+class CenterManagerVerificationRejectEventService(
+    private val fcmClient: FcmClient,
+) {
+
+    private val logger = KotlinLogging.logger {}
+
+    fun send(centerManagerVerificationRejectEvent: CenterManagerVerificationRejectEvent) {
+        val message = createMessage(centerManagerVerificationRejectEvent)
+
+        try {
+            fcmClient.send(message)
+        } catch (e: Exception) {
+            logger.warn { "FCM 알림 전송에 실패했습니다 : ${message}, 실패한 Event : CenterManagerVerificationRejectEvent" }
+        }
+    }
+
+
+    private fun createJobPostingNotification(centerManagerVerificationRejectEvent: CenterManagerVerificationRejectEvent): Notification {
+        return Notification.builder()
+            .setTitle(centerManagerVerificationRejectEvent.notificationInfo.title)
+            .setBody(centerManagerVerificationRejectEvent.notificationInfo.body)
+            .build()
+    }
+
+    private fun createMessage(centerManagerVerificationRejectEvent: CenterManagerVerificationRejectEvent): Message {
+        val createJobPostingNotification =
+            createJobPostingNotification(centerManagerVerificationRejectEvent)
+
+        return Message.builder()
+            .setToken(centerManagerVerificationRejectEvent.deviceToken)
+            .setNotification(createJobPostingNotification)
+            .putData(
+                "notificationId",
+                centerManagerVerificationRejectEvent.notificationId.toString()
+            )
+            .putData(
+                "notificationType",
+                centerManagerVerificationRejectEvent.notificationInfo.notificationType.toString()
+            )
+            .build();
+    }
+
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/api/CenterAuthApi.kt
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
+import java.util.*
 
 @Tag(name = "Auth-Center", description = "Center Auth API")
 @RequestMapping("/api/v1/auth/center", produces = ["application/json"])
@@ -54,6 +55,18 @@ interface CenterAuthApi {
     @GetMapping("/join/requests")
     @ResponseStatus(HttpStatus.OK)
     fun getCenterManagerForPending(): CenterManagerForPendingResponse
+
+    @Hidden
+    @Operation(summary = "센터 관리자 인증 요청 승인 API")
+    @PostMapping("/join/requests/{center-manager-id}/approval")
+    @ResponseStatus(HttpStatus.OK)
+    fun approveCenterManagerVerification(@PathVariable("center-manager-id") centerManagerId: UUID)
+
+    @Hidden
+    @Operation(summary = "센터 관리자 인증 요청 거절 API")
+    @PostMapping("/join/requests/{center-manager-id}/rejection")
+    @ResponseStatus(HttpStatus.OK)
+    fun rejectCenterManagerVerification(@PathVariable("center-manager-id") centerManagerId: UUID)
 
     @Operation(summary = "사업자 등록번호 인증 API")
     @GetMapping("/authentication/{business-registration-number}")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/auth/center/controller/CenterAuthController.kt
@@ -15,6 +15,7 @@ import com.swm.idle.support.transfer.auth.center.WithdrawRequest
 import com.swm.idle.support.transfer.auth.common.LoginResponse
 import com.swm.idle.support.transfer.user.center.JoinStatusInfoResponse
 import org.springframework.web.bind.annotation.RestController
+import java.util.*
 
 @RestController
 class CenterAuthController(
@@ -41,6 +42,14 @@ class CenterAuthController(
 
     override fun getCenterManagerForPending(): CenterManagerForPendingResponse {
         return centerAuthFacadeService.getCenterManagerForPending()
+    }
+
+    override fun approveCenterManagerVerification(centerManagerId: UUID) {
+        centerAuthFacadeService.approveVerification(centerManagerId)
+    }
+
+    override fun rejectCenterManagerVerification(centerManagerId: UUID) {
+        centerAuthFacadeService.rejectVerification(centerManagerId)
     }
 
     override fun validateBusinessRegistrationNumber(businessRegistrationNumber: String): ValidateBusinessRegistrationNumberResponse {


### PR DESCRIPTION
## 1. 📄 Summary
* 센터 관리자 인증 승인 API
* 센터 관리자 인증 거절 API
* 인증 승인 혹은 거절 시, 센터 관리자에게 FCM notification을 발송하는 로직
* notification 조회 시, 센터 관리자 승인 및 거절에 따라 생성된 알림은 조회하지 않도록 쿼리문 수정

## 2. ✏️ Documentation
## Goals & Non-Goals

### Goals

- 센터 관리자 인증 요청에 따라, 가입 승인을 할 수 있는 백오피스 시스템이 있어야 한다.
    - PENDING(인증 요청 완료) 상태에 있는 센터 관리자들의 목록을 조회할 수 있어야 한다.
    - 센터 관리자들의 인증 결과에 따라 승인 및 거절을 할 수 있어야 한다.

---

## **Methodology & Design(Proposal)**

### API

- API    
    - [**센터 관리자 인증 요청 승인 API**] POST /api/v1/auth/center/join/requests/{center-manager-id}/approval
        - request
            - method & path: `POST /api/v1/auth/center/join/requests/{center-manager-id}/approval`
        - response
            - 정상 처리된 경우
                - status code: `204 NO CONTENT`
    
    - [**센터 관리자 인증 요청 거절 API**] POST /api/v1/auth/center/join/requests/{center-manager-id}/rejection
        - request
            - method & path: `POST /api/v1/auth/center/join/requests/{center-manager-id}/rejection`
        - response
            - 정상 처리된 경우
                - status code: `204 NO CONTENT`
    
    ### FCM Notification Spec
    
    ---
    
    - 센터 관리자 인증 요청 승인 API
        
        ```json
        {
          "message" : {
            "notification" : {
              "body" : "000 관리자님, 센터 관리자 인증 요청이 최종 승인되었어요! 어서 확인해 보세요!",
              "title" : "[케어밋] 센터 관리자 인증 요청이 승인되었어요",
            },
            "data" : {
              "notificationId": "string(uuid)",
              "notificationType" : "CENTER_AUTHENTICATION",
            }
        }
        ```
        
    - 센터 관리자 인증 요청 거절 API
        
        ```json
        {
          "message" : {
            "notification" : {
              "body" : "000 관리자님, 센터 관리자 인증 요청이 거절되었어요. 문의사항을 통해 연락해 주세요.",
              "title" : "[케어밋] 센터 관리자 인증 요청이 거절되었어요.",
            },
            "data" : {
              "notificationId": "string(uuid)",
              "notificationType" : "CENTER_AUTHENTICATION",
            }
        }
        ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 센터 관리자 인증 요청 승인 및 거부를 위한 API 메서드 추가.
	- 센터 관리자 인증 요청 승인 및 거부를 처리하는 새로운 서비스 및 이벤트 리스너 클래스 추가.
	- 승인 및 거부 알림을 위한 새로운 데이터 클래스 추가.
- **버그 수정**
	- 특정 알림 유형을 제외하는 쿼리 조건 추가.
- **문서화**
	- API 문서에 새로운 메서드에 대한 설명 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->