### PR TITLE
[IDLE-518] bastion서버를 통해 production 서버로 접근 후, 배포하도록 설정

### DIFF
--- a/.github/workflows/prod-server-deployer.yaml
+++ b/.github/workflows/prod-server-deployer.yaml
@@ -43,59 +43,48 @@ jobs:
               --port 22 \
               --cidr ${{ steps.publicip.outputs.ip }}/32
 
-      - name: Install Docker if not present
+      - name: SSH to Bastion and Install Docker if not present on Production server
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ vars.INSTANCE_HOST }}
-          username: ${{ vars.INSTANCE_USERNAME }}
+          host: ${{ vars.BASTION_HOST }}
+          username: ${{ vars.BASTION_USERNAME }}
           key: ${{ secrets.INSTANCE_PEM_KEY }}
           script: |
-            if ! command -v docker >/dev/null 2>&1; then
-              echo "Installing Docker..."
-              sudo apt-get update
-              sudo apt-get install -y docker.io
-            else
-              echo "Docker already installed."
-            fi
-            if ! command -v docker-compose >/dev/null 2>&1; then
-              echo "Installing Docker Compose..."
-              sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-              sudo chmod +x /usr/local/bin/docker-compose
-            else
-              echo "Docker Compose already installed."
-            fi
+            ssh -o "ProxyJump=${{ vars.BASTION_HOST }}" -i ${{ secrets.INSTANCE_PEM_KEY }} ${{ vars.INSTANCE_USERNAME }}@${{ vars.INSTANCE_HOST }} << 'EOF'
+              if ! command -v docker >/dev/null 2>&1; then
+                echo "Installing Docker..."
+                sudo apt-get update
+                sudo apt-get install -y docker.io
+              else
+                echo "Docker already installed."
+              fi
+              if ! command -v docker-compose >/dev/null 2>&1; then
+                echo "Installing Docker Compose..."
+                sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+                sudo chmod +x /usr/local/bin/docker-compose
+              else
+                echo "Docker Compose already installed."
+              fi
+            EOF
 
-      - name: Configuration Env file
-        uses: appleboy/ssh-action@master
-        env:
-          VARS_CONTEXT: ${{ toJson(vars) }}
-          SECRETS_CONTEXT: ${{ toJson(secrets) }}
-        with:
-          host: ${{ vars.INSTANCE_HOST }}
-          username: ${{ vars.INSTANCE_USERNAME }}
-          key: ${{ secrets.INSTANCE_PEM_KEY }}
-          envs: VARS_CONTEXT,SECRETS_CONTEXT
-          script: |
-            cd ~/app/docker
-            jq -s '.[0] * .[1] | del(.INSTANCE_PEM_KEY)' <(echo "$VARS_CONTEXT") <(echo "$SECRETS_CONTEXT") \
-              | jq -r 'to_entries | map("\(.key)=\(.value)") | .[]' > .env
-
-      - name: Run Docker
+      - name: SSH to Bastion and deploy to Production server
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ vars.INSTANCE_HOST }}
-          username: ${{ vars.INSTANCE_USERNAME }}
+          host: ${{ vars.BASTION_HOST }}
+          username: ${{ vars.BASTION_USERNAME }}
           key: ${{ secrets.INSTANCE_PEM_KEY }}
           script: |
+            ssh -o "ProxyJump=${{ vars.BASTION_HOST }}" -i ${{ secrets.INSTANCE_PEM_KEY }} ${{ vars.INSTANCE_USERNAME }}@${{ vars.INSTANCE_HOST }} << 'EOF'
             sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
             sudo docker pull public.ecr.aws/f5q3r6m5/idle-prod-ecr:$IMAGE_TAG
             if [ $(sudo docker ps -q -f name=caremeet_server_prod) ]; then
-            sudo docker stop caremeet_server_prod
-            sudo docker rm caremeet_server_prod
+              sudo docker stop caremeet_server_prod
+              sudo docker rm caremeet_server_prod
             fi
             sudo docker run --name caremeet_server_prod --env-file ./app/docker/.env \
             -e SPRING_PROFILES_ACTIVE=prod \
             -d -p 8080:8080 public.ecr.aws/f5q3r6m5/idle-prod-ecr:$IMAGE_TAG
+            EOF
 
       - name: Remove GitHub Actions IP
         run: |


### PR DESCRIPTION
## 1. 📄 Summary
Bastion 서버를 통해 VPC private subnet에 속한 서버로 접근하여 배포하는 구조로 수정  

## 2. ✏️ Documentation
- 기존 workflow YAML 파일에서 수정한 내용을 최소화하면서 배포 구조를 변경  
- Bastion 서버를 경유하여 private subnet에 위치한 서버에 접근 및 배포 가능하도록 설정  

## 3. 🤔 고민했던 점
- 기존 설정을 최대한 유지하며 변경 사항을 최소화하고자 했습니다.  
- 배포 과정에서 CD 설정 누락으로 인한 이슈를 사전에 방지할 필요가 있었습니다.  

## 4. 💡 알게된 점, 궁금한 점
- MySQL, Redis, EC2 서버들의 경우 내부에서 주로 사용되지만, 외부로 호출되는 경우가 많아 보안 관리가 어려웠던 점이 있었습니다.  
- Bastion 서버를 통해 접근 구조를 변경함으로써 보안성이 향상되었으나, CD 과정에서 수정이 필요하다는 점을 간과했습니다.  
- 이번 작업은 Bastion 서버를 활용한 배포 구조 구축 경험이 처음이라 새로운 학습이 많았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **배포**
	- 프로덕션 서버 배포 워크플로우 최적화
	- Docker 및 Docker Compose 설치 프로세스 간소화
	- SSH 기반 배포 방식으로 변경
	- 베스천 호스트를 통한 서버 접근 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->