### PR TITLE
[IDLE-551] 채팅 로직 변경 및 채팅방 요약정보 쿼리 최적화

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
@@ -10,12 +10,12 @@ import java.util.*
 @Service
 class ChatRoomService (val chatroomRepository: ChatRoomRepository){
 
-    fun create(carerId: UUID, centerId:UUID) {
+    fun create(carerId: UUID, centerId:UUID):UUID {
         val chatRoom = ChatRoom(
             carerId = carerId,
             centerId = centerId,
         )
-        chatroomRepository.save(chatRoom)
+        return chatroomRepository.save(chatRoom).id
     }
 
     fun findChatroomSummaries(userId: UUID, isCarer: Boolean): List<ChatRoomSummaryInfo> {

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
@@ -21,9 +21,9 @@ class ChatRoomService (val chatroomRepository: ChatRoomRepository){
     fun findChatroomSummaries(userId: UUID, isCarer: Boolean): List<ChatRoomSummaryInfo> {
         val projections: List<ChatRoomSummaryInfoProjection>
         if(isCarer) {
-            projections = chatroomRepository.findCaresChatroomSummaries(userId)
+            projections = chatroomRepository.carerFindChatRooms(userId)
         }else {
-            projections = chatroomRepository.findCentersChatroomSummaries(userId)
+            projections = chatroomRepository.centerFindChatRooms(userId)
         }
 
         return projections.map { projection ->
@@ -44,12 +44,12 @@ class ChatRoomService (val chatroomRepository: ChatRoomRepository){
         val projections: ChatRoomSummaryInfoProjection
 
         if(isCarer) {
-            projections = chatroomRepository.carerFindByCenterIdWithCarerId(
+            projections = chatroomRepository.carerFindSingleChatRoom(
                 centerId = centerId,
                 carerId = carerId
             )
         }else {
-            projections = chatroomRepository.centerFindByCenterIdWithCarerId(
+            projections = chatroomRepository.centerFindSingleChatRoom(
                 centerId = centerId,
                 carerId = carerId
             )

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
@@ -27,13 +27,34 @@ class ChatRoomService (val chatroomRepository: ChatRoomRepository){
         }
 
         return projections.map { projection ->
-            ChatRoomSummaryInfo(
-                chatRoomId = projection.getChatRoomId(),
-                lastMessage = projection.getLastMessage(),
-                lastMessageTime = projection.getLastMessageTime(),
-                count = projection.getUnreadCount(),
-                receiverId = projection.getReceiverId()
+            mappingChatRoomSummaryInfo(projection)
+        }
+    }
+
+    private fun mappingChatRoomSummaryInfo(projection: ChatRoomSummaryInfoProjection) =
+        ChatRoomSummaryInfo(
+            chatRoomId = projection.getChatRoomId(),
+            lastMessage = projection.getLastMessage(),
+            lastMessageTime = projection.getLastMessageTime(),
+            count = projection.getUnreadCount(),
+            opponentId = projection.getOpponentId()
+        )
+
+    fun getByCenterWithCarer(centerId: UUID, carerId: UUID, isCarer: Boolean): ChatRoomSummaryInfo {
+        val projections: ChatRoomSummaryInfoProjection
+
+        if(isCarer) {
+            projections = chatroomRepository.carerFindByCenterIdWithCarerId(
+                centerId = centerId,
+                carerId = carerId
+            )
+        }else {
+            projections = chatroomRepository.centerFindByCenterIdWithCarerId(
+                centerId = centerId,
+                carerId = carerId
             )
         }
+
+        return mappingChatRoomSummaryInfo(projections)
     }
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -12,10 +12,7 @@ import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.domain.chat.vo.ReadMessage
 import com.swm.idle.infrastructure.fcm.chat.ChatNotificationService
 import com.swm.idle.support.common.uuid.UuidCreator
-import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
-import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
-import com.swm.idle.support.transfer.chat.ReadChatMessagesReqeust
-import com.swm.idle.support.transfer.chat.SendChatMessageRequest
+import com.swm.idle.support.transfer.chat.*
 import kotlinx.coroutines.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -84,12 +81,12 @@ class ChatFacadeService(
         return CreateChatRoomResponse(chatRoomId)
     }
 
-    fun getRecentMessages(chatRoomId: UUID, messageId: UUID?): List<ChatMessage> {
+    fun getRecentMessages(chatRoomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
         if(messageId == null){
             val newMessageId = UuidCreator.create()
-            return chatMessageService.getRecentMessages(chatRoomId, newMessageId)
+            return chatMessageService.getRecentMessages(chatRoomId, newMessageId).map{ChatMessageResponse(it)}
         }
-        return chatMessageService.getRecentMessages(chatRoomId, messageId)
+        return chatMessageService.getRecentMessages(chatRoomId, messageId).map{ChatMessageResponse(it)}
     }
 
     fun getChatroomSummary(isCarer: Boolean): List<ChatRoomSummaryInfo> {

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -96,13 +96,13 @@ class ChatFacadeService(
 
         return if (isCarer) {
             summary.map {
-                val center = centerService.getById(it.receiverId)
-                it.copy(receiverName = center.centerName, receiverProfileImageUrl = center.profileImageUrl)
+                val center = centerService.getById(it.opponentId)
+                it.copy(opponentName = center.centerName, opponentProfileImageUrl = center.profileImageUrl)
             }
         } else {
             summary.map {
-                val carer = carerService.getById(it.receiverId)
-                it.copy(receiverName = carer.name, receiverProfileImageUrl = carer.profileImageUrl)
+                val carer = carerService.getById(it.opponentId)
+                it.copy(opponentName = carer.name, opponentProfileImageUrl = carer.profileImageUrl)
             }
         }
     }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -52,13 +52,15 @@ class ChatFacadeService(
 
     @Transactional
     fun readMessage(request: ReadChatMessagesReqeust, userId: UUID){
-        val readRequest = ReadMessage(
-            request.chatRoomId,
-            userId
-        )
         runBlocking {
             launch { messageService.read(request, userId) }
-            launch { redisPublisher.publish(readRequest) }
+            launch {
+                val redisMessage = ReadMessage(
+                    chatRoomId = request.chatRoomId,
+                    receiverId = request.opponentId,
+                    readUserId = userId)
+                redisPublisher.publish(redisMessage)
+            }
         }
     }
 

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -13,6 +13,7 @@ import com.swm.idle.domain.chat.vo.ReadMessage
 import com.swm.idle.infrastructure.fcm.chat.ChatNotificationService
 import com.swm.idle.support.common.uuid.UuidCreator
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
+import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import com.swm.idle.support.transfer.chat.ReadChatMessagesReqeust
 import com.swm.idle.support.transfer.chat.SendChatMessageRequest
 import kotlinx.coroutines.*
@@ -65,20 +66,22 @@ class ChatFacadeService(
     }
 
     @Transactional
-    fun createChatroom(request: CreateChatRoomRequest, isCarer: Boolean) {
+    fun createChatroom(request: CreateChatRoomRequest, isCarer: Boolean):CreateChatRoomResponse {
         val userId = getUserAuthentication().userId
 
+        val chatRoomId:UUID
         if(isCarer) {
-            chatroomService.create(
+            chatRoomId = chatroomService.create(
                 carerId = userId,
                 centerId = request.opponentId,
             )
         }else{
-            chatroomService.create(
+            chatRoomId = chatroomService.create(
                 centerId = userId,
                 carerId = request.opponentId,
             )
         }
+        return CreateChatRoomResponse(chatRoomId)
     }
 
     fun getRecentMessages(chatRoomId: UUID, messageId: UUID?): List<ChatMessage> {

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
@@ -46,13 +46,13 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         LIMIT 1
     ) cm;
 """, nativeQuery = true)
-    fun findCaresChatroomSummaries(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
+    fun carerFindChatRooms(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
 
     @Query("""
     WITH FilteredChatRooms AS (
         SELECT
             cr.id AS chat_room_id,
-            cr.center_id 
+            cr.carer_id 
         FROM chat_room cr
         WHERE cr.center_id = :userId
     ),
@@ -83,7 +83,7 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         LIMIT 1
     ) cm;
 """, nativeQuery = true)
-    fun findCentersChatroomSummaries(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
+    fun centerFindChatRooms(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
 
 
     @Query("""
@@ -122,14 +122,14 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         LIMIT 1
     ) cm;
 """, nativeQuery = true)
-    fun carerFindByCenterIdWithCarerId(@Param("centerId") centerId: UUID,
-                                       @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
+    fun carerFindSingleChatRoom(@Param("centerId") centerId: UUID,
+                                @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
 
     @Query("""
     WITH FilteredChatRooms AS (
         SELECT
             cr.id AS chat_room_id,
-            cr.center_id 
+            cr.carer_id 
         FROM chat_room cr
         WHERE cr.carer_id = :carerId
         AND cr.center_id =:centerId
@@ -161,6 +161,6 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         LIMIT 1
     ) cm;
 """, nativeQuery = true)
-    fun centerFindByCenterIdWithCarerId(@Param("centerId") centerId: UUID,
-                                        @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
+    fun centerFindSingleChatRoom(@Param("centerId") centerId: UUID,
+                                 @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
@@ -12,68 +12,155 @@ import java.util.*
 interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
 
     @Query("""
+    WITH FilteredChatRooms AS (
+        SELECT
+            cr.id AS chat_room_id,
+            cr.center_id 
+        FROM chat_room cr
+        WHERE cr.carer_id = :userId
+    ),
+    
+    UnreadMessageCounts AS (
+        SELECT 
+            cm.chat_room_id,
+            COUNT(*) AS unread_count
+        FROM chat_message cm
+        WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
+          AND cm.is_read = false
+        GROUP BY cm.chat_room_id
+    )
+    
     SELECT
-        cr.id  AS chatRoomId,
-        cr.center_id  AS receiverId,
-        (
-            SELECT COUNT(*)
-            FROM chat_message cm2
-            WHERE cm2.chat_room_id = cr.id
-              AND cm2.receiver_id = :userId
-              AND cm2.is_read = false
-            LIMIT 100
-        ) AS unreadCount,
-        (
-            SELECT cm3.content
-            FROM chat_message cm3
-            WHERE cm3.chat_room_id = cr.id
-            ORDER BY cm3.id DESC
-            LIMIT 1
-        ) AS lastMessage,
-        (
-            SELECT cm3.created_at
-            FROM chat_message cm3
-            WHERE cm3.chat_room_id = cr.id
-            ORDER BY cm3.id DESC
-            LIMIT 1
-        ) AS lastMessageTime
-    FROM 
-        chat_room cr
-    WHERE 
-        cr.carer_id = :userId
+        fcr.chat_room_id AS chatRoomId,
+        fcr.center_id AS opponentId,
+        umc.unread_count AS unreadCount,  
+        cm.content AS lastMessage,
+        cm.created_at AS lastMessageTime
+    FROM FilteredChatRooms fcr
+    JOIN UnreadMessageCounts umc ON fcr.chat_room_id = umc.chat_room_id
+    JOIN LATERAL (
+        SELECT content, created_at
+        FROM chat_message
+        WHERE chat_room_id = fcr.chat_room_id AND is_read = false
+        ORDER BY id DESC
+        LIMIT 1
+    ) cm;
 """, nativeQuery = true)
     fun findCaresChatroomSummaries(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
 
     @Query("""
+    WITH FilteredChatRooms AS (
+        SELECT
+            cr.id AS chat_room_id,
+            cr.center_id 
+        FROM chat_room cr
+        WHERE cr.center_id = :userId
+    ),
+    
+    UnreadMessageCounts AS (
+        SELECT 
+            cm.chat_room_id,
+            COUNT(*) AS unread_count
+        FROM chat_message cm
+        WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
+          AND cm.is_read = false
+        GROUP BY cm.chat_room_id
+    )
+    
     SELECT
-        cr.id  AS chatRoomId,
-        cr.center_id  AS receiverId,
-        (
-            SELECT COUNT(*)
-            FROM chat_message cm2
-            WHERE cm2.chat_room_id = cr.id
-              AND cm2.receiver_id = :userId
-              AND cm2.is_read = false
-            LIMIT 100
-        ) AS unreadCount,
-        (
-            SELECT cm3.content
-            FROM chat_message cm3
-            WHERE cm3.chat_room_id = cr.id
-            ORDER BY cm3.id DESC
-            LIMIT 1
-        ) AS lastMessage,
-        (
-            SELECT cm3.created_at
-            FROM chat_message cm3
-            WHERE cm3.chat_room_id = cr.id
-            ORDER BY cm3.id DESC
-            LIMIT 1
-        ) AS lastMessageTime
-    FROM 
-        chat_room cr
-    WHERE 
-        cr.center_id = :userId
+        fcr.chat_room_id AS chatRoomId,
+        fcr.carer_id AS opponentId,
+        umc.unread_count AS unreadCount,  
+        cm.content AS lastMessage,
+        cm.created_at AS lastMessageTime
+    FROM FilteredChatRooms fcr
+    JOIN UnreadMessageCounts umc ON fcr.chat_room_id = umc.chat_room_id
+    JOIN LATERAL (
+        SELECT content, created_at
+        FROM chat_message
+        WHERE chat_room_id = fcr.chat_room_id AND is_read = false
+        ORDER BY id DESC
+        LIMIT 1
+    ) cm;
 """, nativeQuery = true)
     fun findCentersChatroomSummaries(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
+
+
+    @Query("""
+    WITH FilteredChatRooms AS (
+        SELECT
+            cr.id AS chat_room_id,
+            cr.center_id 
+        FROM chat_room cr
+        WHERE cr.carer_id = :carerId
+        AND cr.center_id =:centerId
+    ),
+    
+    UnreadMessageCounts AS (
+        SELECT 
+            cm.chat_room_id,
+            COUNT(*) AS unread_count
+        FROM chat_message cm
+        WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
+          AND cm.is_read = false
+        GROUP BY cm.chat_room_id
+    )
+    
+    SELECT
+        fcr.chat_room_id AS chatRoomId,
+        fcr.center_id AS opponentId,
+        umc.unread_count AS unreadCount,  
+        cm.content AS lastMessage,
+        cm.created_at AS lastMessageTime
+    FROM FilteredChatRooms fcr
+    JOIN UnreadMessageCounts umc ON fcr.chat_room_id = umc.chat_room_id
+    JOIN LATERAL (
+        SELECT content, created_at
+        FROM chat_message
+        WHERE chat_room_id = fcr.chat_room_id AND is_read = false
+        ORDER BY id DESC
+        LIMIT 1
+    ) cm;
+""", nativeQuery = true)
+    fun carerFindByCenterIdWithCarerId(@Param("centerId") centerId: UUID,
+                                       @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
+
+    @Query("""
+    WITH FilteredChatRooms AS (
+        SELECT
+            cr.id AS chat_room_id,
+            cr.center_id 
+        FROM chat_room cr
+        WHERE cr.carer_id = :carerId
+        AND cr.center_id =:centerId
+    ),
+    
+    UnreadMessageCounts AS (
+        SELECT 
+            cm.chat_room_id,
+            COUNT(*) AS unread_count
+        FROM chat_message cm
+        WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
+          AND cm.is_read = false
+        GROUP BY cm.chat_room_id
+    )
+    
+    SELECT
+        fcr.chat_room_id AS chatRoomId,
+        fcr.carer_id AS opponentId,
+        umc.unread_count AS unreadCount,  
+        cm.content AS lastMessage,
+        cm.created_at AS lastMessageTime
+    FROM FilteredChatRooms fcr
+    JOIN UnreadMessageCounts umc ON fcr.chat_room_id = umc.chat_room_id
+    JOIN LATERAL (
+        SELECT content, created_at
+        FROM chat_message
+        WHERE chat_room_id = fcr.chat_room_id AND is_read = false
+        ORDER BY id DESC
+        LIMIT 1
+    ) cm;
+""", nativeQuery = true)
+    fun centerFindByCenterIdWithCarerId(@Param("centerId") centerId: UUID,
+                                        @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
 }

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ChatRoomSummaryInfo.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ChatRoomSummaryInfo.kt
@@ -17,13 +17,13 @@ data class ChatRoomSummaryInfo(
                 lastMessage: String,
                 lastMessageTime: LocalDateTime,
                 count: Int,
-                receiverId: ByteArray,
+                opponentId: ByteArray,
         ) : this(
         fromByteArray(chatRoomId),
         lastMessage,
         lastMessageTime,
         count,
-        fromByteArray(receiverId),
+        fromByteArray(opponentId),
         "알 수 없음",
         null,
     )

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ChatRoomSummaryInfo.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ChatRoomSummaryInfo.kt
@@ -9,9 +9,9 @@ data class ChatRoomSummaryInfo(
     val lastMessage: String,
     val lastMessageTime: LocalDateTime,
     val count: Int,
-    val receiverId: UUID,
-    var receiverName: String,
-    var receiverProfileImageUrl: String?,
+    val opponentId: UUID,
+    var opponentName: String,
+    var opponentProfileImageUrl: String?,
 ) {
     constructor(chatRoomId: ByteArray,
                 lastMessage: String,

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ChatRoomSummaryInfoProjection.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ChatRoomSummaryInfoProjection.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 interface ChatRoomSummaryInfoProjection {
     fun getChatRoomId(): ByteArray
-    fun getReceiverId(): ByteArray
+    fun getOpponentId(): ByteArray
     fun getUnreadCount(): Int
     fun getLastMessage(): String
     fun getLastMessageTime(): LocalDateTime

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ReadMessage.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/vo/ReadMessage.kt
@@ -2,6 +2,7 @@ package com.swm.idle.domain.chat.vo
 
 import java.util.*
 
-data class ReadMessage(val chatroomId: UUID,
-                       val readUserId: UUID) {
-}
+data class ReadMessage(
+    val chatRoomId: UUID,
+    val receiverId: UUID,
+    val readUserId: UUID,)

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
@@ -36,7 +36,7 @@ interface ChatCarerApi {
 
     @Secured
     @Operation(summary = "보호사의 단일 채팅방 정보 조회 API")
-    @GetMapping("/chatrooms/{chatroom-id}/single")
+    @GetMapping("/chatrooms/{chatroom-id}/opponent/{opponent-id}")
     @ResponseStatus(HttpStatus.OK)
     fun carerSingleChatroomSummary(@PathVariable(value = "chatroom-id") chatroomId: UUID,
                                    @PathVariable(value = "opponent-id") opponentId: UUID,): ChatRoomSummaryInfo

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
@@ -1,6 +1,5 @@
 package com.swm.idle.presentation.chat.api
 
-import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.chat.ChatMessageResponse

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
@@ -3,6 +3,7 @@ package com.swm.idle.presentation.chat.api
 import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.chat.ChatMessageResponse
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
 import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -26,7 +27,7 @@ interface ChatCarerApi {
     @GetMapping("/chatrooms/{chatroom-id}/messages")
     @ResponseStatus(HttpStatus.OK)
     fun recentMessages(@PathVariable(value = "chatroom-id") chatroomId: UUID,
-                       @RequestParam(value = "message-id", required = false) messageId: UUID?): List<ChatMessage>
+                       @RequestParam(value = "message-id", required = false) messageId: UUID?): List<ChatMessageResponse>
 
     @Secured
     @Operation(summary = "보호사의 채팅방 요약 목록 조회 API")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
@@ -4,6 +4,7 @@ import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
+import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -18,7 +19,7 @@ interface ChatCarerApi {
     @Operation(summary = "보호사의 채팅방 개설 API")
     @PostMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
-    fun createChatroom(request: CreateChatRoomRequest)
+    fun createChatroom(request: CreateChatRoomRequest): CreateChatRoomResponse
 
     @Secured
     @Operation(summary = "보호사의 최근 채팅 메시지 조회 API")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
@@ -28,7 +28,7 @@ interface ChatCarerApi {
                        @RequestParam(value = "message-id", required = false) messageId: UUID?): List<ChatMessage>
 
     @Secured
-    @Operation(summary = "보호사의 채팅방 요약 조회 API")
+    @Operation(summary = "보호사의 채팅방 요약 목록 조회 API")
     @GetMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
     fun carerChatroomSummary(): List<ChatRoomSummaryInfo>

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
@@ -34,4 +34,11 @@ interface ChatCarerApi {
     @GetMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
     fun carerChatroomSummary(): List<ChatRoomSummaryInfo>
+
+    @Secured
+    @Operation(summary = "보호사의 단일 채팅방 정보 조회 API")
+    @GetMapping("/chatrooms/{chatroom-id}/single")
+    @ResponseStatus(HttpStatus.OK)
+    fun carerSingleChatroomSummary(@PathVariable(value = "chatroom-id") chatroomId: UUID,
+                                   @PathVariable(value = "opponent-id") opponentId: UUID,): ChatRoomSummaryInfo
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
@@ -28,7 +28,7 @@ interface ChatCenterApi {
                        @RequestParam(value = "message-id", required = false) messageId: UUID?): List<ChatMessage>
 
         @Secured
-    @Operation(summary = "센터장의 채팅방 요약 조회 API")
+    @Operation(summary = "센터장의 채팅방 요약 목록 조회 API")
     @GetMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
     fun centerChatroomSummary(): List<ChatRoomSummaryInfo>

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
@@ -1,6 +1,5 @@
 package com.swm.idle.presentation.chat.api
 
-import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.chat.ChatMessageResponse

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
@@ -3,6 +3,7 @@ package com.swm.idle.presentation.chat.api
 import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.common.security.annotation.Secured
+import com.swm.idle.support.transfer.chat.ChatMessageResponse
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
 import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -26,7 +27,7 @@ interface ChatCenterApi {
     @GetMapping("/chatrooms/{chatroom-id}/messages")
     @ResponseStatus(HttpStatus.OK)
     fun recentMessages(@PathVariable(value = "chatroom-id") chatroomId: UUID,
-                       @RequestParam(value = "message-id", required = false) messageId: UUID?): List<ChatMessage>
+                       @RequestParam(value = "message-id", required = false) messageId: UUID?): List<ChatMessageResponse>
 
         @Secured
     @Operation(summary = "센터장의 채팅방 요약 목록 조회 API")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
@@ -4,6 +4,7 @@ import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.common.security.annotation.Secured
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
+import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -18,7 +19,7 @@ interface ChatCenterApi {
     @Operation(summary = "센터장의 채팅방 개설 API")
     @PostMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
-    fun createChatroom(request: CreateChatRoomRequest)
+    fun createChatroom(request: CreateChatRoomRequest): CreateChatRoomResponse
 
     @Secured
     @Operation(summary = "센터장의 최근 채팅 메시지 조회 API")

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
@@ -34,4 +34,11 @@ interface ChatCenterApi {
     @GetMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
     fun centerChatroomSummary(): List<ChatRoomSummaryInfo>
+
+    @Secured
+    @Operation(summary = "센터장의 단일 채팅방 정보 조회 API")
+    @GetMapping("/chatrooms/{chatroom-id}/opponent/{opponent-id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun carerSingleChatroomSummary(@PathVariable(value = "chatroom-id") chatroomId: UUID,
+                                   @PathVariable(value = "opponent-id") opponentId: UUID): ChatRoomSummaryInfo
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
@@ -5,6 +5,7 @@ import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.chat.api.ChatCarerApi
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
+import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -13,8 +14,8 @@ class ChatCarerController(
     private val chatMessageService: ChatFacadeService,
 ) : ChatCarerApi {
 
-    override fun createChatroom(request: CreateChatRoomRequest) {
-        chatMessageService.createChatroom(request,true)
+    override fun createChatroom(request: CreateChatRoomRequest): CreateChatRoomResponse {
+        return chatMessageService.createChatroom(request,true)
     }
 
     override fun carerChatroomSummary(): List<ChatRoomSummaryInfo> {

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
@@ -1,7 +1,6 @@
 package com.swm.idle.presentation.chat.controller
 
 import com.swm.idle.application.chat.facade.ChatFacadeService
-import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.chat.api.ChatCarerApi
 import com.swm.idle.support.transfer.chat.ChatMessageResponse
@@ -25,5 +24,9 @@ class ChatCarerController(
 
     override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
         return chatMessageService.getRecentMessages(chatroomId, messageId)
+    }
+
+    override fun carerSingleChatroomSummary(chatroomId: UUID, opponentId: UUID): ChatRoomSummaryInfo {
+        return chatMessageService.getSingleChatRoomInfo(chatroomId,opponentId, true)
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
@@ -4,6 +4,7 @@ import com.swm.idle.application.chat.facade.ChatFacadeService
 import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.chat.api.ChatCarerApi
+import com.swm.idle.support.transfer.chat.ChatMessageResponse
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
 import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import org.springframework.web.bind.annotation.RestController
@@ -22,7 +23,7 @@ class ChatCarerController(
         return chatMessageService.getChatroomSummary(true)
     }
 
-    override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessage> {
+    override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
         return chatMessageService.getRecentMessages(chatroomId, messageId)
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
@@ -4,6 +4,7 @@ import com.swm.idle.application.chat.facade.ChatFacadeService
 import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.chat.api.ChatCenterApi
+import com.swm.idle.support.transfer.chat.ChatMessageResponse
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
 import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import org.springframework.web.bind.annotation.RestController
@@ -22,7 +23,7 @@ class ChatCenterController(
         return chatMessageService.getChatroomSummary(false)
     }
 
-    override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessage> {
+    override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
         return chatMessageService.getRecentMessages(chatroomId, messageId)
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
@@ -5,6 +5,7 @@ import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.chat.api.ChatCenterApi
 import com.swm.idle.support.transfer.chat.CreateChatRoomRequest
+import com.swm.idle.support.transfer.chat.CreateChatRoomResponse
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -13,8 +14,8 @@ class ChatCenterController(
     private val chatMessageService: ChatFacadeService,
 ) : ChatCenterApi {
 
-    override fun createChatroom(request: CreateChatRoomRequest) {
-        chatMessageService.createChatroom(request, false)
+    override fun createChatroom(request: CreateChatRoomRequest): CreateChatRoomResponse {
+        return chatMessageService.createChatroom(request,false)
     }
 
     override fun centerChatroomSummary(): List<ChatRoomSummaryInfo> {

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
@@ -1,7 +1,6 @@
 package com.swm.idle.presentation.chat.controller
 
 import com.swm.idle.application.chat.facade.ChatFacadeService
-import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.presentation.chat.api.ChatCenterApi
 import com.swm.idle.support.transfer.chat.ChatMessageResponse
@@ -25,5 +24,9 @@ class ChatCenterController(
 
     override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
         return chatMessageService.getRecentMessages(chatroomId, messageId)
+    }
+
+    override fun carerSingleChatroomSummary(chatroomId: UUID, opponentId: UUID): ChatRoomSummaryInfo {
+        return chatMessageService.getSingleChatRoomInfo(chatroomId, opponentId, false)
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
@@ -2,6 +2,8 @@ package com.swm.idle.presentation.chat.handler
 
 import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ReadMessage
+import com.swm.idle.support.transfer.chat.ChatMessageResponse
+import com.swm.idle.support.transfer.chat.ReadNoti
 import org.springframework.context.event.EventListener
 import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.stereotype.Controller
@@ -12,11 +14,11 @@ class ChatHandler(
 ) {
     @EventListener
     fun handleSendMessage(sendMessage: ChatMessage) {
-        messageTemplate.convertAndSend("/sub/chatrooms/${sendMessage.chatRoomId}", sendMessage)
+        messageTemplate.convertAndSend("/sub/${sendMessage.receiverId}", ChatMessageResponse(sendMessage))
     }
 
     @EventListener
     fun handleReadMessage(raedMessage: ReadMessage) {
-        messageTemplate.convertAndSend("/sub/chatrooms/${raedMessage.chatroomId}", raedMessage.readUserId)
+        messageTemplate.convertAndSend("/sub/${raedMessage.receiverId}", ReadNoti(raedMessage))
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
@@ -18,7 +18,7 @@ class ChatHandler(
     }
 
     @EventListener
-    fun handleReadMessage(raedMessage: ReadMessage) {
-        messageTemplate.convertAndSend("/sub/${raedMessage.receiverId}", ReadNoti(raedMessage))
+    fun handleReadMessage(readMessage: ReadMessage) {
+        messageTemplate.convertAndSend("/sub/${readMessage.receiverId}", ReadNoti(readMessage))
     }
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ChatMessageResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ChatMessageResponse.kt
@@ -1,0 +1,23 @@
+package com.swm.idle.support.transfer.chat
+
+import com.swm.idle.domain.chat.entity.jpa.ChatMessage
+import java.util.UUID
+import java.time.LocalDateTime
+
+data class ChatMessageResponse(
+    val id: UUID,
+    val chatRoomId: UUID,
+    val senderId: UUID,
+    val receiverId: UUID,
+    val content: String,
+    val createdAt: LocalDateTime?
+) {
+    constructor(message: ChatMessage) : this(
+        id = message.id,
+        chatRoomId = message.chatRoomId,
+        senderId = message.senderId,
+        receiverId = message.receiverId,
+        content = message.content,
+        createdAt = message.createdAt
+    )
+}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/CreateChatRoomResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/CreateChatRoomResponse.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.support.transfer.chat
+
+import java.util.*
+
+data class CreateChatRoomResponse (val opponentId: UUID)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
@@ -2,4 +2,4 @@ package com.swm.idle.support.transfer.chat
 
 import java.util.UUID
 
-data class ReadChatMessagesReqeust(val chatRoomId: UUID)
+data class ReadChatMessagesReqeust(val chatRoomId: UUID, val opponentId: UUID)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadNoti.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadNoti.kt
@@ -1,0 +1,11 @@
+package com.swm.idle.support.transfer.chat
+
+import com.swm.idle.domain.chat.vo.ReadMessage
+import java.util.*
+
+data class ReadNoti(val chatRoomId: UUID, val readByUserId: UUID) {
+    constructor(message: ReadMessage) : this(
+        readByUserId = message.readUserId,
+        chatRoomId = message.chatRoomId
+    )
+}


### PR DESCRIPTION
## 1. 📄 Summary  
 - 채팅방 목록에서 실시간으로 바뀌는 데이터를 맞추기 위해, 기존의 채팅 로직을 변경하였습니다.
 - 채팅방의 요약정보 조회 쿼리를 최적화하였습니다. 

## 2. 🤔 고민했던 점  
- 클라이언트의 채팅방 목록 탭에서 계속해서 추가되며 바뀌는 목록 정보를 제공하기 위해 구독을 목록탭에서 할 수 있도록 해야했습니다. 더불어, 채팅방을 기준으로 구독하는 것이아니라, 본인의 Id로 구독하도록 수정하였습니다.
 
- 쿼리 성능 최적화와 데이터 중복 처리 문제를 해결하기 위한 방안을 고민했습니다. 특히, `LATERAL`을 사용하는 방식이 성능에 미치는 영향을 고려하며 데이터를 효율적으로 조회할 방법을 찾았습니다.

## 3. 💡 알게된 점, 궁금한 점  
- `LATERAL`을 활용하여 서브쿼리 결과를 각 행에 대해 동적으로 처리할 수 있다는 점을 알게 되었습니다. 이를 통해 각 채팅방에 대해 가장 최근의 메시지를 효율적으로 조회할 수 있었습니다.
- `JOIN LATERAL`을 사용할 때, 성능상의 고려사항은 무엇인지, 특히 대용량 데이터에서 쿼리 성능을 최적화하려면 어떤 방법을 고려해야 할지 생각이 많아졌습니다..



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 채팅방 생성 시 응답 객체를 반환하도록 `createChatroom` 메서드가 업데이트되었습니다.
  - 단일 채팅방 요약 정보를 조회할 수 있는 새로운 메서드 `carerSingleChatroomSummary`가 추가되었습니다.
  - 새로운 데이터 클래스 `ChatMessageResponse`와 `CreateChatRoomResponse`가 추가되었습니다.
  - `ReadNoti` 데이터 클래스가 추가되어 읽은 메시지에 대한 정보를 포함합니다.

- **Refactor**
  - 채팅방 요약에 사용되는 대상자 명칭을 일관되게 “receiver”에서 “opponent”로 변경하여 정보의 표현을 명확하게 개선했습니다.
  - SQL 쿼리를 개선하여 가독성과 효율성을 높였습니다.

- **Documentation**
  - API 설명 문구를 업데이트하여, 채팅방 요약 기능이 단일 항목이 아닌 목록 형태로 제공됨을 보다 명확하게 전달합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->