### PR TITLE
[IDLE-557] 채팅 API Response 값 변경 

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatMessageService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatMessageService.kt
@@ -3,22 +3,29 @@ package com.swm.idle.application.chat.domain
 import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.repository.ChatMessageRepository
 import com.swm.idle.support.transfer.chat.ReadChatMessagesReqeust
+import com.swm.idle.support.transfer.chat.SendChatMessageRequest
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
-import java.util.UUID
+import java.util.*
 
 @Service
 class ChatMessageService (
     private val chatMessageRepository: ChatMessageRepository
 ){
     @Transactional
-    fun save(chatMessage: ChatMessage) {
-        chatMessageRepository.save(chatMessage)
+    fun save(request: SendChatMessageRequest, userId: UUID): ChatMessage {
+        val message = ChatMessage(
+            chatRoomId = UUID.fromString(request.chatroomId),
+            content = request.content,
+            senderId = userId,
+            receiverId = UUID.fromString(request.receiverId),
+        )
+        return chatMessageRepository.save(message)
     }
 
     @Transactional
     fun read(request: ReadChatMessagesReqeust, readUserId: UUID) {
-        chatMessageRepository.readByChatroomId(request.chatRoomId, readUserId)
+        chatMessageRepository.readByChatroomId(request.chatroomId, readUserId)
     }
 
     @Transactional

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -43,7 +43,7 @@ class ChatFacadeService(
         messageService.read(request, userId)
 
         val readMessage = ReadMessage(
-            chatRoomId = request.chatRoomId,
+            chatRoomId = request.chatroomId,
             receiverId = request.opponentId,
             readUserId = userId
         )

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -6,14 +6,12 @@ import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.notification.domain.DeviceTokenService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterService
-import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.event.ChatRedisPublisher
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.domain.chat.vo.ReadMessage
 import com.swm.idle.infrastructure.fcm.chat.ChatNotificationService
 import com.swm.idle.support.common.uuid.UuidCreator
 import com.swm.idle.support.transfer.chat.*
-import kotlinx.coroutines.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -33,35 +31,23 @@ class ChatFacadeService(
 
     @Transactional
     fun sendMessage(request: SendChatMessageRequest, userId: UUID) {
-        val message = ChatMessage(
-            chatRoomId = UUID.fromString(request.chatroomId),
-            content = request.content,
-            senderId = userId,
-            receiverId = UUID.fromString(request.receiverId),
-        )
-        runBlocking{
-            launch { messageService.save(message) }
-            launch { redisPublisher.publish(message) }
-            launch {
-                val token = deviceTokenService.findByUserId(message.receiverId)
-                notificationService.send(message, request.senderName, token)
-            }
-        }
+        val message = messageService.save(request, userId)
+        redisPublisher.publish(message)
 
+        val token = deviceTokenService.findByUserId(message.receiverId)
+        notificationService.send(message, request.senderName, token)
     }
 
     @Transactional
-    fun readMessage(request: ReadChatMessagesReqeust, userId: UUID){
-        runBlocking {
-            launch { messageService.read(request, userId) }
-            launch {
-                val redisMessage = ReadMessage(
-                    chatRoomId = request.chatRoomId,
-                    receiverId = request.opponentId,
-                    readUserId = userId)
-                redisPublisher.publish(redisMessage)
-            }
-        }
+    fun readMessage(request: ReadChatMessagesReqeust, userId: UUID) {
+        messageService.read(request, userId)
+
+        val readMessage = ReadMessage(
+            chatRoomId = request.chatRoomId,
+            receiverId = request.opponentId,
+            readUserId = userId
+        )
+        redisPublisher.publish(readMessage)
     }
 
     @Transactional

--- a/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/user/center/service/facade/CenterFacadeService.kt
@@ -78,6 +78,7 @@ class CenterFacadeService(
                 ?: throw CenterException.NotFoundException()
 
         return GetCenterProfileResponse(
+            id = center.id,
             centerName = center.centerName,
             officeNumber = center.officeNumber,
             roadNameAddress = center.roadNameAddress,
@@ -94,6 +95,7 @@ class CenterFacadeService(
         val center = centerService.getById(centerId)
 
         return GetCenterProfileResponse(
+            id = center.id,
             centerName = center.centerName,
             officeNumber = center.officeNumber,
             roadNameAddress = center.roadNameAddress,

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
@@ -15,6 +15,7 @@ class ChatHandler(
     @EventListener
     fun handleSendMessage(sendMessage: ChatMessage) {
         messageTemplate.convertAndSend("/sub/${sendMessage.receiverId}", ChatMessageResponse(sendMessage))
+        messageTemplate.convertAndSend("/sub/${sendMessage.senderId}", ChatMessageResponse(sendMessage))
     }
 
     @EventListener

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ChatMessageResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ChatMessageResponse.kt
@@ -5,19 +5,23 @@ import java.util.UUID
 import java.time.LocalDateTime
 
 data class ChatMessageResponse(
+    val type: ChatMessageType,
     val id: UUID,
-    val chatRoomId: UUID,
+    val chatroomId: UUID,
     val senderId: UUID,
     val receiverId: UUID,
     val content: String,
-    val createdAt: LocalDateTime?
+    val createdAt: LocalDateTime,
+    val isRead: Boolean
 ) {
     constructor(message: ChatMessage) : this(
+        type = ChatMessageType.MESSAGE,
         id = message.id,
-        chatRoomId = message.chatRoomId,
+        chatroomId = message.chatRoomId,
         senderId = message.senderId,
         receiverId = message.receiverId,
         content = message.content,
-        createdAt = message.createdAt
+        isRead = message.isRead,
+        createdAt = message.createdAt ?: LocalDateTime.now(),
     )
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ChatMessageType.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ChatMessageType.kt
@@ -1,0 +1,5 @@
+package com.swm.idle.support.transfer.chat
+
+enum class ChatMessageType {
+    MESSAGE, READ
+}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
@@ -2,4 +2,4 @@ package com.swm.idle.support.transfer.chat
 
 import java.util.UUID
 
-data class ReadChatMessagesReqeust(val chatRoomId: UUID, val opponentId: UUID)
+data class ReadChatMessagesReqeust(val chatroomId: UUID, val opponentId: UUID)

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadNoti.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadNoti.kt
@@ -3,9 +3,10 @@ package com.swm.idle.support.transfer.chat
 import com.swm.idle.domain.chat.vo.ReadMessage
 import java.util.*
 
-data class ReadNoti(val chatRoomId: UUID, val readByUserId: UUID) {
+data class ReadNoti(val chatroomId: UUID, val readByUserId: UUID, val type: ChatMessageType) {
     constructor(message: ReadMessage) : this(
         readByUserId = message.readUserId,
-        chatRoomId = message.chatRoomId
+        chatroomId = message.chatRoomId,
+        type = ChatMessageType.READ
     )
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/GetCenterProfileResponse.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/user/center/GetCenterProfileResponse.kt
@@ -1,12 +1,15 @@
 package com.swm.idle.support.transfer.user.center
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
 
 @Schema(
     name = "GetCenterProfileResponse",
     description = "센터 프로필 상세 조회"
 )
 data class GetCenterProfileResponse(
+    @Schema(description = "센터 id")
+    val id: UUID,
     @Schema(description = "센터 이름")
     val centerName: String,
     @Schema(description = "대표자(담당자) 연락처")


### PR DESCRIPTION
## 1. 📄 Summary
- 프론트엔드의 요청으로 인해 기존의 채팅 API의 전달 내용을 수정합니다. 
- 채팅에 필요한 센터장 id 값을 프로필 조회에서도 얻을 수 있도록 합니다.
- 메시지 값에서 chatroomId로 네이밍을 통일합니다. 
- 채팅에서 코루틴을 삭제합니다. 

## 2. 🤔 고민했던 점
- Spring MVC 환경에서 코루틴을 적용한 경우, 특정 작업이 워커 스레드에 바인딩되지 않고 다른 스레드에서 실행되면서 RuntimeException에 의한 롤백이 의도와 다르게 동작할 수 있음을 확인하였습니다. 예외를 상위로 전달하는 방식도 고려했지만, 현재 이슈에서는 해당 문제를 해결하지 않고, 추후 과제로 미루기로 하여 코루틴 적용을 제거하였습니다.

## 3. 💡 알게된 점, 궁금한 점
-  MVC 환경에서 트랜잭션 내부의 예외를 구조적으로 제어하고, 멀티스레드 환경에서 발생할 수 있는 예외 전달의 불확실성을 방지하기 위한 설계 방안에 대해 더 고민할 필요가 있음을 느꼈습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 센터 프로필 응답에 고유 식별자(id)가 추가되어 프로필 식별이 명확해졌습니다.
  - 채팅 메시지 응답에 메시지 타입, 생성 시간, 읽음 여부 등 추가 정보가 포함되어 알림 기능이 강화되었습니다.
  - 읽은 메시지 알림에 메시지 타입이 포함되어 메시지 상태를 명확히 전달합니다.

- **Refactor**
  - 채팅 메시지 저장 및 조회 처리 흐름이 단순화되어 성능과 안정성이 개선되었습니다.
  - 발신자와 수신자 모두에게 실시간 알림이 원활하게 전달되도록 처리 로직이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->