### PR TITLE
[IDLE-561] 웹소켓 직렬화/역직렬화 이슈 해결 및 채팅방 생성 케이스 보완

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
@@ -10,13 +10,11 @@ import java.util.*
 @Service
 class ChatRoomService (val chatroomRepository: ChatRoomRepository){
 
-    fun create(carerId: UUID, centerId:UUID):UUID {
-        val chatRoom = ChatRoom(
-            carerId = carerId,
-            centerId = centerId,
-        )
-        return chatroomRepository.save(chatRoom).id
+    fun create(carerId: UUID, centerId: UUID): UUID {
+        val existing = chatroomRepository.findByCarerIdAndCenterId(carerId, centerId)
+        return existing?.id ?: chatroomRepository.save(ChatRoom(carerId = carerId, centerId = centerId)).id
     }
+
 
     fun findChatroomSummaries(userId: UUID, isCarer: Boolean): List<ChatRoomSummaryInfo> {
         val projections: List<ChatRoomSummaryInfoProjection>

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
@@ -11,6 +11,8 @@ import java.util.*
 @Repository
 interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
 
+    fun findByCarerIdAndCenterId(carerId: UUID, centerId: UUID): ChatRoom?
+
     @Query("""
     WITH FilteredChatRooms AS (
         SELECT

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/config/WebSocketConfig.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/config/WebSocketConfig.kt
@@ -1,6 +1,8 @@
 package com.swm.idle.presentation.chat.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.springframework.context.annotation.Configuration
 import org.springframework.messaging.converter.DefaultContentTypeResolver
 import org.springframework.messaging.converter.MappingJackson2MessageConverter
@@ -30,19 +32,19 @@ class WebSocketConfig(
             .setAllowedOriginPatterns("*")
     }
 
-    override fun configureMessageConverters(messageConverters: MutableList<MessageConverter>): Boolean {
+    override fun configureMessageConverters(messageConverters: MutableList<MessageConverter?>): Boolean {
         val resolver = DefaultContentTypeResolver()
-            .also {
-                it.defaultMimeType = MimeTypeUtils.APPLICATION_JSON
-            }
+        resolver.defaultMimeType = MimeTypeUtils.APPLICATION_JSON
 
-        messageConverters.add(
-            MappingJackson2MessageConverter()
-                .also {
-                    it.objectMapper = ObjectMapper()
-                    it.contentTypeResolver = resolver
-                }
-        )
+        val objectMapper = ObjectMapper()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+        val converter = MappingJackson2MessageConverter()
+        converter.objectMapper = objectMapper
+        converter.contentTypeResolver = resolver
+
+        messageConverters.add(converter)
         return false
     }
 }

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
@@ -1,5 +1,10 @@
 package com.swm.idle.support.transfer.chat
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
-data class ReadChatMessagesReqeust(val chatroomId: UUID, val opponentId: UUID)
+data class ReadChatMessagesReqeust @JsonCreator constructor(
+    @JsonProperty("chatroomId") val chatroomId: UUID,
+    @JsonProperty("opponentId")val opponentId: UUID
+)


### PR DESCRIPTION
## 1. 📄 Summary
- LocalDateTime 직렬화 이슈 해결 
- WebSocket Payload 역직렬화 문제 해결 
- 채팅방 생성 시 기존에 존재하는 방이면 ID 반환하도록 로직 수정

## 2. 💡 알게된 점, 궁금한 점
Java에서 record를 DTO로 사용할 땐 WebSocket에서 직렬화/역직렬화 문제가 발생하지 않았지만,
Kotlin의 data class를 사용하니 역직렬화 오류가 발생했습니다.

이는 기본적으로 자바의 Record는 기본 생성자를 컴파일 시점에서 생성해주지만,
Kotlin의 data class는 기본 생성자(default constructor) 가 명시적으로 존재하지 않으며!
null-safety, val/var, companion 등 다양한 기능을 포함해서 동작합니다.

이에따라 Jackson이 역직렬화 시 적절한 생성자나 프로퍼티 주입 정보를 찾지 못해 예외를 발생시키게 됐습니다.

따라서 @JsonCreator와 @JsonProperty를 사용해 생성자 기반 역직렬화 방식으로 명확히 지정해주거나,
jackson-module-kotlin을 반드시 등록해줘야 안정적으로 처리할 수 있다는 걸 알게 되었습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 채팅방 생성 로직이 개선되어, 동일 조건의 채팅방이 이미 존재할 경우 해당 채팅방을 재사용합니다.

- **Refactor**
  - 메시지 전송 설정이 개선되어 날짜 포맷 및 메시지 변환 처리가 향상되었습니다.
  - 채팅 메시지 요청 데이터의 JSON 직렬화 방식이 개선되어 안정적인 데이터 처리가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->