### PR TITLE
[IDLE-563] Redis 세션 공유 기반 알림 필터링 및 읽음처리 정상화

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatRoomService.kt
@@ -37,22 +37,4 @@ class ChatRoomService (val chatroomRepository: ChatRoomRepository){
             count = projection.getUnreadCount(),
             opponentId = projection.getOpponentId()
         )
-
-    fun getByCenterWithCarer(centerId: UUID, carerId: UUID, isCarer: Boolean): ChatRoomSummaryInfo {
-        val projections: ChatRoomSummaryInfoProjection
-
-        if(isCarer) {
-            projections = chatroomRepository.carerFindSingleChatRoom(
-                centerId = centerId,
-                carerId = carerId
-            )
-        }else {
-            projections = chatroomRepository.centerFindSingleChatRoom(
-                centerId = centerId,
-                carerId = carerId
-            )
-        }
-
-        return mappingChatRoomSummaryInfo(projections)
-    }
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -90,32 +90,4 @@ class ChatFacadeService(
             }
         }
     }
-
-    fun getSingleChatRoomInfo(chatRoomId: UUID, opponentId: UUID,isCarer: Boolean): ChatRoomSummaryInfo {
-        val (carerId, centerId) = if (isCarer) {
-            getUserAuthentication().userId to opponentId
-        } else {
-            opponentId to getUserAuthentication().userId
-        }
-
-        val chatRoomSummaryInfo = chatroomService.getByCenterWithCarer(
-            centerId = centerId,
-            carerId =carerId,
-            isCarer)
-
-        return if (isCarer) {
-            val center = centerService.getById(centerId)
-            chatRoomSummaryInfo.also {
-                it.opponentName = center.centerName
-                it.opponentProfileImageUrl = center.profileImageUrl
-            }
-
-        }else {
-            val carer = carerService.getById(carerId)
-            chatRoomSummaryInfo.also {
-                it.opponentName = carer.name
-                it.opponentProfileImageUrl = carer.profileImageUrl
-            }
-        }
-    }
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -6,7 +6,7 @@ import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.notification.domain.DeviceTokenService
 import com.swm.idle.application.user.carer.domain.CarerService
 import com.swm.idle.application.user.center.service.domain.CenterService
-import com.swm.idle.domain.chat.event.ChatRedisPublisher
+import com.swm.idle.domain.chat.event.ChatRedisTemplate
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.domain.chat.vo.ReadMessage
 import com.swm.idle.infrastructure.fcm.chat.ChatNotificationService
@@ -19,7 +19,7 @@ import java.util.*
 @Service
 @Transactional(readOnly = true)
 class ChatFacadeService(
-    private val redisPublisher: ChatRedisPublisher,
+    private val chatRedisTemplate: ChatRedisTemplate,
     private val messageService: ChatMessageService,
     private val notificationService: ChatNotificationService,
     private val deviceTokenService: DeviceTokenService,
@@ -32,8 +32,9 @@ class ChatFacadeService(
     @Transactional
     fun sendMessage(request: SendChatMessageRequest, userId: UUID) {
         val message = messageService.save(request, userId)
-        redisPublisher.publish(message)
+        chatRedisTemplate.publish(message)
 
+        if (chatRedisTemplate.isChatting(message.receiverId)) return
         val token = deviceTokenService.findByUserId(message.receiverId)
         notificationService.send(message, request.senderName, token)
     }
@@ -47,7 +48,7 @@ class ChatFacadeService(
             receiverId = request.opponentId,
             readUserId = userId
         )
-        redisPublisher.publish(readMessage)
+        chatRedisTemplate.publish(readMessage)
     }
 
     @Transactional

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/event/ChatRedisSubscriber.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/event/ChatRedisSubscriber.kt
@@ -21,17 +21,17 @@ class ChatRedisSubscriber(
         val actualJson = objectMapper.readTree(rawJson).asText()
         val jsonNode = objectMapper.readTree(actualJson)
 
-        when (jsonNode.get(ChatRedisPublisher.TYPE).asText()) {
-            ChatRedisPublisher.SEND_MESSAGE -> {
+        when (jsonNode.get(ChatRedisTemplate.TYPE).asText()) {
+            ChatRedisTemplate.SEND_MESSAGE -> {
                 val chatMessage: ChatMessage = objectMapper.treeToValue(
-                    jsonNode.get(ChatRedisPublisher.DATA), ChatMessage::class.java
+                    jsonNode.get(ChatRedisTemplate.DATA), ChatMessage::class.java
                 )
 
                 eventPublisher.publishEvent(chatMessage)
             }
-            ChatRedisPublisher.READ_MESSAGE -> {
+            ChatRedisTemplate.READ_MESSAGE -> {
                 val readMessage: ReadMessage = objectMapper.treeToValue(
-                    jsonNode.get(ChatRedisPublisher.DATA), ReadMessage::class.java
+                    jsonNode.get(ChatRedisTemplate.DATA), ReadMessage::class.java
                 )
 
                 eventPublisher.publishEvent(readMessage)

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/event/ChatRedisTemplate.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/event/ChatRedisTemplate.kt
@@ -6,12 +6,25 @@ import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import com.swm.idle.domain.chat.vo.ReadMessage
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.*
 
 @Component
-class ChatRedisPublisher(
+class ChatRedisTemplate(
     private val redisTemplate: RedisTemplate<String, Any>,
     private val objectMapper: ObjectMapper
 ) {
+    fun isChatting(userId: UUID): Boolean {
+        return redisTemplate.hasKey(userId.toString())
+    }
+
+    fun delete(userId: String) {
+        redisTemplate.delete(userId)
+    }
+
+    fun setSession(userId: String, duration: Duration) {
+        redisTemplate.opsForValue().set(userId,duration)
+    }
 
     fun publish(chatMessage: ChatMessage) {
         val message = objectMapper.writeValueAsString(

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/event/ChatRedisTemplate.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/event/ChatRedisTemplate.kt
@@ -23,7 +23,7 @@ class ChatRedisTemplate(
     }
 
     fun setSession(userId: String, duration: Duration) {
-        redisTemplate.opsForValue().set(userId,duration)
+        redisTemplate.opsForValue().set(userId,"active",duration)
     }
 
     fun publish(chatMessage: ChatMessage) {

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatMessageRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatMessageRepository.kt
@@ -2,6 +2,7 @@ package com.swm.idle.domain.chat.repository
 
 import com.swm.idle.domain.chat.entity.jpa.ChatMessage
 import io.lettuce.core.dynamic.annotation.Param
+import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -10,7 +11,8 @@ import java.util.*
 
 @Repository
 interface ChatMessageRepository : JpaRepository<ChatMessage, UUID> {
-    @Modifying
+    @Transactional
+    @Modifying(clearAutomatically = true)
     @Query("""
     UPDATE ChatMessage cm 
     SET cm.isRead = true 

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
@@ -29,6 +29,7 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         FROM chat_message cm
         WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
           AND cm.is_read = false
+          AND cm.receiverId = :userId
         GROUP BY cm.chat_room_id
     )
     
@@ -66,6 +67,7 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         FROM chat_message cm
         WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
           AND cm.is_read = false
+          AND cm.receiverId = :userId
         GROUP BY cm.chat_room_id
     )
     

--- a/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
+++ b/idle-domain/src/main/kotlin/com/swm/idle/domain/chat/repository/ChatRoomRepository.kt
@@ -13,7 +13,8 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
 
     fun findByCarerIdAndCenterId(carerId: UUID, centerId: UUID): ChatRoom?
 
-    @Query("""
+    @Query(
+        """
     WITH FilteredChatRooms AS (
         SELECT
             cr.id AS chat_room_id,
@@ -48,10 +49,12 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         ORDER BY id DESC
         LIMIT 1
     ) cm;
-""", nativeQuery = true)
+""", nativeQuery = true
+    )
     fun carerFindChatRooms(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
 
-    @Query("""
+    @Query(
+        """
     WITH FilteredChatRooms AS (
         SELECT
             cr.id AS chat_room_id,
@@ -86,85 +89,7 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, UUID> {
         ORDER BY id DESC
         LIMIT 1
     ) cm;
-""", nativeQuery = true)
+""", nativeQuery = true
+    )
     fun centerFindChatRooms(@Param("userId") userId: UUID): List<ChatRoomSummaryInfoProjection>
-
-
-    @Query("""
-    WITH FilteredChatRooms AS (
-        SELECT
-            cr.id AS chat_room_id,
-            cr.center_id 
-        FROM chat_room cr
-        WHERE cr.carer_id = :carerId
-        AND cr.center_id =:centerId
-    ),
-    
-    UnreadMessageCounts AS (
-        SELECT 
-            cm.chat_room_id,
-            COUNT(*) AS unread_count
-        FROM chat_message cm
-        WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
-          AND cm.is_read = false
-        GROUP BY cm.chat_room_id
-    )
-    
-    SELECT
-        fcr.chat_room_id AS chatRoomId,
-        fcr.center_id AS opponentId,
-        umc.unread_count AS unreadCount,  
-        cm.content AS lastMessage,
-        cm.created_at AS lastMessageTime
-    FROM FilteredChatRooms fcr
-    JOIN UnreadMessageCounts umc ON fcr.chat_room_id = umc.chat_room_id
-    JOIN LATERAL (
-        SELECT content, created_at
-        FROM chat_message
-        WHERE chat_room_id = fcr.chat_room_id AND is_read = false
-        ORDER BY id DESC
-        LIMIT 1
-    ) cm;
-""", nativeQuery = true)
-    fun carerFindSingleChatRoom(@Param("centerId") centerId: UUID,
-                                @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
-
-    @Query("""
-    WITH FilteredChatRooms AS (
-        SELECT
-            cr.id AS chat_room_id,
-            cr.carer_id 
-        FROM chat_room cr
-        WHERE cr.carer_id = :carerId
-        AND cr.center_id =:centerId
-    ),
-    
-    UnreadMessageCounts AS (
-        SELECT 
-            cm.chat_room_id,
-            COUNT(*) AS unread_count
-        FROM chat_message cm
-        WHERE cm.chat_room_id IN (SELECT chat_room_id FROM FilteredChatRooms)
-          AND cm.is_read = false
-        GROUP BY cm.chat_room_id
-    )
-    
-    SELECT
-        fcr.chat_room_id AS chatRoomId,
-        fcr.carer_id AS opponentId,
-        umc.unread_count AS unreadCount,  
-        cm.content AS lastMessage,
-        cm.created_at AS lastMessageTime
-    FROM FilteredChatRooms fcr
-    JOIN UnreadMessageCounts umc ON fcr.chat_room_id = umc.chat_room_id
-    JOIN LATERAL (
-        SELECT content, created_at
-        FROM chat_message
-        WHERE chat_room_id = fcr.chat_room_id AND is_read = false
-        ORDER BY id DESC
-        LIMIT 1
-    ) cm;
-""", nativeQuery = true)
-    fun centerFindSingleChatRoom(@Param("centerId") centerId: UUID,
-                                 @Param("carerId") carerId: UUID): ChatRoomSummaryInfoProjection
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCarerApi.kt
@@ -33,11 +33,4 @@ interface ChatCarerApi {
     @GetMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
     fun carerChatroomSummary(): List<ChatRoomSummaryInfo>
-
-    @Secured
-    @Operation(summary = "보호사의 단일 채팅방 정보 조회 API")
-    @GetMapping("/chatrooms/{chatroom-id}/opponent/{opponent-id}")
-    @ResponseStatus(HttpStatus.OK)
-    fun carerSingleChatroomSummary(@PathVariable(value = "chatroom-id") chatroomId: UUID,
-                                   @PathVariable(value = "opponent-id") opponentId: UUID,): ChatRoomSummaryInfo
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/api/ChatCenterApi.kt
@@ -33,11 +33,4 @@ interface ChatCenterApi {
     @GetMapping("/chatrooms")
     @ResponseStatus(HttpStatus.OK)
     fun centerChatroomSummary(): List<ChatRoomSummaryInfo>
-
-    @Secured
-    @Operation(summary = "센터장의 단일 채팅방 정보 조회 API")
-    @GetMapping("/chatrooms/{chatroom-id}/opponent/{opponent-id}")
-    @ResponseStatus(HttpStatus.OK)
-    fun carerSingleChatroomSummary(@PathVariable(value = "chatroom-id") chatroomId: UUID,
-                                   @PathVariable(value = "opponent-id") opponentId: UUID): ChatRoomSummaryInfo
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/config/ChatHandshakeInterceptor.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/config/ChatHandshakeInterceptor.kt
@@ -1,6 +1,7 @@
 package com.swm.idle.presentation.chat.config
 
 import com.swm.idle.application.common.properties.JwtTokenProperties
+import com.swm.idle.domain.chat.event.ChatRedisTemplate
 import com.swm.idle.support.security.util.JwtTokenProvider
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
@@ -8,10 +9,12 @@ import org.springframework.http.server.ServletServerHttpRequest
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.WebSocketHandler
 import org.springframework.web.socket.server.HandshakeInterceptor
+import java.time.Duration
 
 @Component
 class ChatHandshakeInterceptor(
     private val jwtTokenProperties: JwtTokenProperties,
+    private val redisTemplate : ChatRedisTemplate,
     ): HandshakeInterceptor {
 
     override fun beforeHandshake(
@@ -29,7 +32,11 @@ class ChatHandshakeInterceptor(
                 return false
             }
 
-            attributes["userId"] = claims.customClaims["userId"] as String
+            val userId = claims.customClaims["userId"] as String
+            attributes["userId"] = userId
+
+            redisTemplate.setSession(userId, Duration.ofHours(24))
+
             return true
         }
         return false

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/config/WebSocketDisconnectListener.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/config/WebSocketDisconnectListener.kt
@@ -1,0 +1,23 @@
+package com.swm.idle.presentation.chat.config
+
+import com.swm.idle.domain.chat.event.ChatRedisTemplate
+import org.springframework.context.event.EventListener
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+@Component
+class WebSocketDisconnectListener(
+    private val redisTemplate: ChatRedisTemplate
+) {
+
+    @EventListener
+    fun handleDisconnect(event: SessionDisconnectEvent) {
+        val headers = StompHeaderAccessor.wrap(event.message)
+        val userId = headers.sessionAttributes?.get("userId") as? String
+
+        if (userId != null) {
+            redisTemplate.delete(userId)
+        }
+    }
+}

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCarerController.kt
@@ -25,8 +25,4 @@ class ChatCarerController(
     override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
         return chatMessageService.getRecentMessages(chatroomId, messageId)
     }
-
-    override fun carerSingleChatroomSummary(chatroomId: UUID, opponentId: UUID): ChatRoomSummaryInfo {
-        return chatMessageService.getSingleChatRoomInfo(chatroomId,opponentId, true)
-    }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatCenterController.kt
@@ -25,8 +25,4 @@ class ChatCenterController(
     override fun recentMessages(chatroomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
         return chatMessageService.getRecentMessages(chatroomId, messageId)
     }
-
-    override fun carerSingleChatroomSummary(chatroomId: UUID, opponentId: UUID): ChatRoomSummaryInfo {
-        return chatMessageService.getSingleChatRoomInfo(chatroomId, opponentId, false)
-    }
 }


### PR DESCRIPTION
## 1. 📄 Summary
- Redis를 통한 현재 채팅방 입장자 id를 공유하여,  알림 전달 필터링 
- 채팅방 목록 쿼리를 내가 안읽은 메시지기반으로 수정
- 읽음 처리 동작 정상화
- 사용하지 않는 API 삭제 (단일 채팅방 요약정보 조회)

## 2. 🤔 고민했던 점
1. 채팅방 내에서 접속한 사용자와 접속하지 않은 사용자를 구분해, 불필요한 알림 푸시를 줄이는 방식을 고민했습니다.

2. WebSocket 기반 시스템에서 세션 종료나 예상치 못한 끊김 등으로 Redis 정리가 누락되는 상황을 방지할 수 있을지에 대한 고민이 있었습니다.

3. Redis에 사용자 정보를 저장할 때 어떻게 만료(TTL)를 활용하여 자동 정리를 유도할지, 그리고 이는 실사용자 경험에 영향을 주지 않을지 고려했습니다.

## 3. 💡 알게된 점, 궁금한 점
- WebSocket 연결 시점과 종료 시점에 Redis를 통해 세션을 관리하면, 실시간 사용자 상태 추적이 가능한 것을 알게되었고, STOMP기반이기 때문에 handshake와 connection이 닫기는 이벤트에 따라 Redis에 id값을 관리하도록 하였습니다.  

- Redis에 TTL(Time-To-Live)을 설정해두면, 예기치 못한 예외 상황에도 리소스가 자동으로 정리되는 이점이 있음을 알게되었습니다.
이에따라, 사용자가 정상적으로 접속 종료하지 않더라도 세션 정보가 과도하게 쌓이지 않고 일정 시간 뒤 정리되도록 하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 채팅 연결 시 사용자 세션이 생성되고, 24시간 유지되며, 연결 해제 시 자동으로 정리되는 기능이 추가되었습니다.
  - 채팅 메시지 발송 및 세션 관리 기능이 향상되었습니다.
- **버그 수정**
  - 특정 채팅방 정보 조회 기능이 제거되어 인터페이스가 일관되게 정리되었습니다.
- **리팩토링**
  - 채팅 메시지 전송 및 조회 처리 과정이 간소화되어 성능과 안정성이 개선되었습니다.
- **변경사항**
  - 채팅방 검색 기능이 개선되어 사용자 ID에 따라 필터링할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->