### PR TITLE
[IDLE-571] ChatManager가 Center로서 공동 동작할 수 있도록 사용하는 id값 변경

### DIFF
--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -10,6 +10,7 @@ import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.chat.event.ChatRedisTemplate
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.domain.chat.vo.ReadMessage
+import com.swm.idle.domain.user.center.entity.jpa.CenterManager
 import com.swm.idle.domain.user.center.exception.CenterException
 import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.infrastructure.fcm.chat.ChatNotificationService
@@ -34,28 +35,28 @@ class ChatFacadeService(
 ) {
 
     @Transactional
-    fun carerSend(request: SendChatMessageRequest, userId: UUID) {
-        val message = messageService.save(request, userId)
+    fun carerSend(request: SendChatMessageRequest, carerId: UUID) {
+        val message = messageService.save(request, carerId)
         chatRedisTemplate.publish(message)
 
-        for(centerManager in centerManagers()) {
-            if (chatRedisTemplate.isChatting(centerManager.id)) continue
+        for(manager in getManagersByCenterId(UUID.fromString(request.receiverId))) {
+            if (chatRedisTemplate.isChatting(manager.id)) continue
 
-            val token = deviceTokenService.findByUserId(centerManager.id)
+            val token = deviceTokenService.findByUserId(manager.id)
             notificationService.send(message, request.senderName, token)
         }
     }
 
-    private fun centerManagers() = centerManagerService
-        .findAllByCenterBusinessRegistrationNumber(
-            BusinessRegistrationNumber(
-                getCenter().businessRegistrationNumber
-            )
-        )?: emptyList()
+    private fun getManagersByCenterId(centerId:UUID): List<CenterManager> {
+        val businessNumber = BusinessRegistrationNumber(centerService.getById(centerId).businessRegistrationNumber)
+        val centerManagers = centerManagerService.findAllByCenterBusinessRegistrationNumber(businessNumber)?: emptyList()
+        return centerManagers
+    }
 
     @Transactional
-    fun centerSend(request: SendChatMessageRequest, userId: UUID) {
-        val message = messageService.save(request, getCenter().id)
+    fun centerSend(request: SendChatMessageRequest, managerId: UUID) {
+        val centerId = getCenterId(managerId)
+        val message = messageService.save(request, centerId)
         chatRedisTemplate.publish(message)
 
         if (chatRedisTemplate.isChatting(message.receiverId)) return
@@ -65,25 +66,26 @@ class ChatFacadeService(
     }
 
     @Transactional
-    fun carerRead(request: ReadChatMessagesReqeust, userId: UUID) {
-        messageService.read(request, userId)
+    fun carerRead(request: ReadChatMessagesReqeust, carerId: UUID) {
+        messageService.read(request, carerId)
 
         val readMessage = ReadMessage(
             chatRoomId = request.chatroomId,
             receiverId = request.opponentId,
-            readUserId = userId
+            readUserId = carerId
         )
         chatRedisTemplate.publish(readMessage)
     }
 
     @Transactional
-    fun centerRead(request: ReadChatMessagesReqeust, userId: UUID) {
-        messageService.read(request, getCenter().id)
+    fun centerRead(request: ReadChatMessagesReqeust, managerId: UUID) {
+        val centerId = getCenterId(managerId)
+        messageService.read(request, centerId)
 
         val readMessage = ReadMessage(
             chatRoomId = request.chatroomId,
             receiverId = request.opponentId,
-            readUserId = userId
+            readUserId = centerId
         )
         chatRedisTemplate.publish(readMessage)
     }
@@ -92,7 +94,7 @@ class ChatFacadeService(
     fun createChatroom(request: CreateChatRoomRequest, isCarer: Boolean):CreateChatRoomResponse {
         val (carerId, centerId) =
             if (isCarer) getUserAuthentication().userId to request.opponentId
-            else request.opponentId to getCenter().id
+            else request.opponentId to getCenterIdByAuthentication()
 
         val chatRoomId = chatroomService.create(
                 carerId = carerId,
@@ -100,6 +102,14 @@ class ChatFacadeService(
         )
 
         return CreateChatRoomResponse(chatRoomId)
+    }
+
+    fun getCenterIdByAuthentication():UUID {
+        val managerId = getUserAuthentication().userId
+        val manager = centerManagerService.getById(managerId)
+        val businessNumber = BusinessRegistrationNumber(manager.centerBusinessRegistrationNumber)
+        val center = centerService.findByBusinessRegistrationNumber(businessNumber)?: throw CenterException.NotFoundException()
+        return center.id
     }
 
     fun getRecentMessages(chatRoomId: UUID, messageId: UUID?): List<ChatMessageResponse> {
@@ -110,10 +120,8 @@ class ChatFacadeService(
     }
 
     fun getChatroomSummary(isCarer: Boolean): List<ChatRoomSummaryInfo> {
-        val userId: UUID =
-            if (isCarer) getUserAuthentication().userId
-            else getCenter().id
-
+        val userId: UUID = if (isCarer) getUserAuthentication().userId
+        else getCenterIdByAuthentication()
 
         val summary = chatroomService.findChatroomSummaries(userId, isCarer)
 
@@ -130,11 +138,10 @@ class ChatFacadeService(
         }
     }
 
-    private fun getCenter() = getUserAuthentication().userId.let { centerManagerId ->
-        centerManagerService.getById(centerManagerId).let {
-            centerService.findByBusinessRegistrationNumber(
-                BusinessRegistrationNumber(it.centerBusinessRegistrationNumber)
-            ) ?: throw CenterException.NotFoundException()
-        }
+    private fun getCenterId(managerId:UUID): UUID {
+        val manager = centerManagerService.getById(managerId)
+        val businessNumber = BusinessRegistrationNumber(manager.centerBusinessRegistrationNumber)
+        val center = centerService.findByBusinessRegistrationNumber(businessNumber)?: throw CenterException.NotFoundException()
+        return center.id
     }
 }

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -5,10 +5,13 @@ import com.swm.idle.application.chat.domain.ChatRoomService
 import com.swm.idle.application.common.security.getUserAuthentication
 import com.swm.idle.application.notification.domain.DeviceTokenService
 import com.swm.idle.application.user.carer.domain.CarerService
+import com.swm.idle.application.user.center.service.domain.CenterManagerService
 import com.swm.idle.application.user.center.service.domain.CenterService
 import com.swm.idle.domain.chat.event.ChatRedisTemplate
 import com.swm.idle.domain.chat.vo.ChatRoomSummaryInfo
 import com.swm.idle.domain.chat.vo.ReadMessage
+import com.swm.idle.domain.user.center.exception.CenterException
+import com.swm.idle.domain.user.center.vo.BusinessRegistrationNumber
 import com.swm.idle.infrastructure.fcm.chat.ChatNotificationService
 import com.swm.idle.support.common.uuid.UuidCreator
 import com.swm.idle.support.transfer.chat.*
@@ -19,6 +22,7 @@ import java.util.*
 @Service
 @Transactional(readOnly = true)
 class ChatFacadeService(
+    private val centerManagerService: CenterManagerService,
     private val chatRedisTemplate: ChatRedisTemplate,
     private val messageService: ChatMessageService,
     private val notificationService: ChatNotificationService,
@@ -30,17 +34,38 @@ class ChatFacadeService(
 ) {
 
     @Transactional
-    fun sendMessage(request: SendChatMessageRequest, userId: UUID) {
+    fun carerSend(request: SendChatMessageRequest, userId: UUID) {
         val message = messageService.save(request, userId)
         chatRedisTemplate.publish(message)
 
+        for(centerManager in centerManagers()) {
+            if (chatRedisTemplate.isChatting(centerManager.id)) continue
+
+            val token = deviceTokenService.findByUserId(centerManager.id)
+            notificationService.send(message, request.senderName, token)
+        }
+    }
+
+    private fun centerManagers() = centerManagerService
+        .findAllByCenterBusinessRegistrationNumber(
+            BusinessRegistrationNumber(
+                getCenter().businessRegistrationNumber
+            )
+        )?: emptyList()
+
+    @Transactional
+    fun centerSend(request: SendChatMessageRequest, userId: UUID) {
+        val message = messageService.save(request, getCenter().id)
+        chatRedisTemplate.publish(message)
+
         if (chatRedisTemplate.isChatting(message.receiverId)) return
+
         val token = deviceTokenService.findByUserId(message.receiverId)
         notificationService.send(message, request.senderName, token)
     }
 
     @Transactional
-    fun readMessage(request: ReadChatMessagesReqeust, userId: UUID) {
+    fun carerRead(request: ReadChatMessagesReqeust, userId: UUID) {
         messageService.read(request, userId)
 
         val readMessage = ReadMessage(
@@ -52,12 +77,22 @@ class ChatFacadeService(
     }
 
     @Transactional
+    fun centerRead(request: ReadChatMessagesReqeust, userId: UUID) {
+        messageService.read(request, getCenter().id)
+
+        val readMessage = ReadMessage(
+            chatRoomId = request.chatroomId,
+            receiverId = request.opponentId,
+            readUserId = userId
+        )
+        chatRedisTemplate.publish(readMessage)
+    }
+
+    @Transactional
     fun createChatroom(request: CreateChatRoomRequest, isCarer: Boolean):CreateChatRoomResponse {
-        val (carerId, centerId) = if (isCarer) {
-            getUserAuthentication().userId to request.opponentId
-        } else {
-            request.opponentId to getUserAuthentication().userId
-        }
+        val (carerId, centerId) =
+            if (isCarer) getUserAuthentication().userId to request.opponentId
+            else request.opponentId to getCenter().id
 
         val chatRoomId = chatroomService.create(
                 carerId = carerId,
@@ -75,7 +110,11 @@ class ChatFacadeService(
     }
 
     fun getChatroomSummary(isCarer: Boolean): List<ChatRoomSummaryInfo> {
-        val userId = getUserAuthentication().userId
+        val userId: UUID =
+            if (isCarer) getUserAuthentication().userId
+            else getCenter().id
+
+
         val summary = chatroomService.findChatroomSummaries(userId, isCarer)
 
         return if (isCarer) {
@@ -88,6 +127,14 @@ class ChatFacadeService(
                 val carer = carerService.getById(it.opponentId)
                 it.copy(opponentName = carer.name, opponentProfileImageUrl = carer.profileImageUrl)
             }
+        }
+    }
+
+    private fun getCenter() = getUserAuthentication().userId.let { centerManagerId ->
+        centerManagerService.getById(centerManagerId).let {
+            centerService.findByBusinessRegistrationNumber(
+                BusinessRegistrationNumber(it.centerBusinessRegistrationNumber)
+            ) ?: throw CenterException.NotFoundException()
         }
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatSocketController.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/controller/ChatSocketController.kt
@@ -14,17 +14,31 @@ class ChatSocketController (
     private val chatMessageService: ChatFacadeService,
 ) {
 
-    @MessageMapping("/send")
-    fun sendMessage(@Payload request: SendChatMessageRequest,
+    @MessageMapping("/send/carer")
+    fun carerSendMessage(@Payload request: SendChatMessageRequest,
                              headerAccessor: SimpMessageHeaderAccessor) {
         val userId = UUID.fromString(headerAccessor.sessionAttributes?.get("userId") as String)
-        chatMessageService.sendMessage(request, userId)
+        chatMessageService.carerSend(request, userId)
     }
 
-    @MessageMapping("/read")
-    fun read(@Payload request: ReadChatMessagesReqeust,
+    @MessageMapping("/read/carer")
+    fun carerRead(@Payload request: ReadChatMessagesReqeust,
                       headerAccessor: SimpMessageHeaderAccessor) {
         val userId = UUID.fromString(headerAccessor.sessionAttributes?.get("userId") as String)
-        chatMessageService.readMessage(request, userId)
+        chatMessageService.carerRead(request, userId)
+    }
+
+    @MessageMapping("/send/center")
+    fun centerSendMessage(@Payload request: SendChatMessageRequest,
+                    headerAccessor: SimpMessageHeaderAccessor) {
+        val userId = UUID.fromString(headerAccessor.sessionAttributes?.get("userId") as String)
+        chatMessageService.centerSend(request, userId)
+    }
+
+    @MessageMapping("/read/center")
+    fun centerRead(@Payload request: ReadChatMessagesReqeust,
+             headerAccessor: SimpMessageHeaderAccessor) {
+        val userId = UUID.fromString(headerAccessor.sessionAttributes?.get("userId") as String)
+        chatMessageService.centerRead(request, userId)
     }
 }


### PR DESCRIPTION
## 1. 📄 Summary
요양보호사가 Center에게 채팅을 보내면,
 CenterManager들은 본인의 센터와 관련된 채팅을 공동으로 접근하고 사용할 수 있도록 하였습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 채팅 메시지 전송 및 읽기 기능이 보호자와 센터장 역할별로 분리되었습니다. 이제 각각의 역할에 맞는 별도의 엔드포인트(`/send/carer`, `/read/carer`, `/send/center`, `/read/center`)를 통해 채팅을 이용할 수 있습니다.
    - 센터장 인증 정보를 기반으로 센터 ID를 자동으로 조회하는 기능이 추가되어 센터 관련 채팅 관리가 개선되었습니다.
- **버그 수정**
    - 센터 정보가 없을 경우 명확한 오류 메시지가 제공되어 문제 상황 인지가 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->