### PR TITLE
[IDLE-572] 케어밋 서버를 홈 서버로 이전

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -28,21 +28,6 @@ jobs:
           response=$(curl -s canhazip.com)
           echo "ip=$response" >> "$GITHUB_OUTPUT"
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'ap-northeast-2'
-
-      - name: Add GitHub Actions IP
-        run: |
-          aws ec2 authorize-security-group-ingress \
-              --group-id ${{ secrets.SECURITY_GROUP_ID }} \
-              --protocol tcp \
-              --port 22 \
-              --cidr ${{ steps.publicip.outputs.ip }}/32
-
       - name: Copy Docker Compose file to server
         uses: appleboy/scp-action@master
         with:
@@ -100,11 +85,3 @@ jobs:
             echo "${{ secrets.DOCKER_PASSWORD }}" | sudo docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             sudo docker-compose -f ~/app/docker/idle-presentation/compose-dev.yaml pull
             sudo docker-compose -f ~/app/docker/idle-presentation/compose-dev.yaml up -d --force-recreate
-
-      - name: Remove GitHub Actions IP
-        run: |
-          aws ec2 revoke-security-group-ingress \
-              --group-id ${{ secrets.SECURITY_GROUP_ID }} \
-              --protocol tcp \
-              --port 22 \
-              --cidr ${{ steps.publicip.outputs.ip }}/32

--- a/.github/workflows/prod-server-deployer.yaml
+++ b/.github/workflows/prod-server-deployer.yaml
@@ -134,7 +134,7 @@ jobs:
               fi
               sudo docker run --name caremeet_server_prod --env-file ./app/docker/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -d -p 8080:8080 public.ecr.aws/e4z1s9l7/caremeet:latest
+              -d -p 8081:8081 public.ecr.aws/e4z1s9l7/caremeet:latest
             EOF
             ssh -S my-cicd-socket -O exit ec2-user@${{ vars.BASTION_HOST }}
             rm -f private_key.pem

--- a/.github/workflows/prod-server-deployer.yaml
+++ b/.github/workflows/prod-server-deployer.yaml
@@ -1,9 +1,6 @@
 name: Production Server Deployer (CD)
 
-on:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -31,118 +28,56 @@ jobs:
           response=$(curl -s canhazip.com)
           echo "ip=$response" >> "$GITHUB_OUTPUT"
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'ap-northeast-2'
-
-      - name: Add GitHub Actions IP
-        run: |
-          aws ec2 authorize-security-group-ingress \
-              --group-id ${{ secrets.SECURITY_GROUP_ID }} \
-              --protocol tcp \
-              --port 22 \
-              --cidr ${{ steps.publicip.outputs.ip }}/32
-
-      - name: SSH to Bastion and Install Docker if not present on Production server
+      - name: Install Docker if not present
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ vars.BASTION_HOST }}
-          username: ${{ vars.BASTION_USERNAME }}
+          host: ${{ vars.INSTANCE_HOST }}
+          username: ${{ vars.INSTANCE_USERNAME }}
           key: ${{ secrets.INSTANCE_PEM_KEY }}
           script: |
-            if [ ! -f private_key.pem ]; then
-              echo "${{ secrets.INSTANCE_PEM_KEY }}" > private_key.pem
-              chmod 600 private_key.pem
+            if ! command -v docker >/dev/null 2>&1; then
+              echo "Installing Docker..."
+              sudo apt-get update
+              sudo apt-get install -y docker.io
+            else
+              echo "Docker already installed."
             fi
-            ssh -f -N -M -S my-cicd-socket -o StrictHostKeyChecking=no -i private_key.pem -L 2222:${{ vars.INSTANCE_HOST }}:22 ec2-user@${{ vars.BASTION_HOST }}
-            ssh -o StrictHostKeyChecking=no -i private_key.pem -p 2222 ubuntu@localhost << 'EOF'
-              echo "Connected to Private Subnet productionServer via SSH Tunneling"
-              if ! command -v docker >/dev/null 2>&1; then
-                echo "Installing Docker..."
-                sudo apt-get update
-                sudo apt-get install -y docker.io
-              else
-                echo "Docker already installed."
-              fi
-              if ! command -v docker-compose >/dev/null 2>&1; then
-                echo "Installing Docker Compose..."
-                sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                sudo chmod +x /usr/local/bin/docker-compose
-              else
-                echo "Docker Compose already installed."
-              fi
-            EOF
-            ssh -S my-cicd-socket -O exit ec2-user@${{ vars.BASTION_HOST }}
-            rm -f private_key.pem
+            if ! command -v docker-compose >/dev/null 2>&1; then
+              echo "Installing Docker Compose..."
+              sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+              sudo chmod +x /usr/local/bin/docker-compose
+            else
+              echo "Docker Compose already installed."
+            fi
 
       - name: Configuration Env file
         uses: appleboy/ssh-action@master
+        env:
+          VARS_CONTEXT: ${{ toJson(vars) }}
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
         with:
-          host: ${{ vars.BASTION_HOST }}
-          username: ${{ vars.BASTION_USERNAME }}
+          host: ${{ vars.INSTANCE_HOST }}
+          username: ${{ vars.INSTANCE_USERNAME }}
           key: ${{ secrets.INSTANCE_PEM_KEY }}
+          envs: VARS_CONTEXT,SECRETS_CONTEXT
           script: |
-            if [ ! -f private_key.pem ]; then
-              echo "${{ secrets.INSTANCE_PEM_KEY }}" > private_key.pem
-              chmod 600 private_key.pem
-            fi
-            ssh -f -N -M -S my-cicd-socket -o StrictHostKeyChecking=no -i private_key.pem -L 2222:${{ vars.INSTANCE_HOST }}:22 ec2-user@${{ vars.BASTION_HOST }}
-            ssh -o StrictHostKeyChecking=no -i private_key.pem -p 2222 ubuntu@localhost << 'EOF'
-              echo "Connected to Private Subnet productionServer via SSH Tunneling"
-              cd ~/app/docker
+            cd ~/app/docker/idle-presentation
+            jq -s '.[0] * .[1]' <(echo "$VARS_CONTEXT") <(echo "$SECRETS_CONTEXT") \
+              | jq -r 'to_entries | map(select(.key != "INSTANCE_PEM_KEY")) | map("\(.key)=\(.value)") | .[]' > .env
 
-              echo "VARS_CONTEXT: ${{ toJson(vars) }}"
-              echo "SECRETS_CONTEXT: ${{ toJson(secrets) }}"
-
-              VARS_CONTEXT_JSON='${{ toJson(vars) }}'
-              SECRETS_CONTEXT_JSON='${{ toJson(secrets) }}'
-
-              echo "$VARS_CONTEXT_JSON" > vars_context.json
-              echo "$SECRETS_CONTEXT_JSON" > secrets_context.json
-
-              jq -s '.[0] * .[1]' vars_context.json secrets_context.json \
-                | jq -r 'to_entries | map(select(.key != "INSTANCE_PEM_KEY")) | map("\(.key)=\(.value)") | .[]' > .env
-
-              echo ".env file generated:"
-              cat .env
-            EOF
-            ssh -S my-cicd-socket -O exit ec2-user@${{ vars.BASTION_HOST }}
-            rm -f private_key.pem
-
-      - name: SSH to Bastion and deploy to Production server
+      - name: Deploy to Production server
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ vars.BASTION_HOST }}
-          username: ${{ vars.BASTION_USERNAME }}
+          host: ${{ vars.INSTANCE_HOST }}
+          username: ${{ vars.INSTANCE_USERNAME }}
           key: ${{ secrets.INSTANCE_PEM_KEY }}
           script: |
-            if [ ! -f private_key.pem ]; then
-              echo "${{ secrets.INSTANCE_PEM_KEY }}" > private_key.pem
-              chmod 600 private_key.pem
+            sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+            sudo docker pull public.ecr.aws/e4z1s9l7/caremeet:latest
+            if [ $(sudo docker ps -q -f name=caremeet_server_prod) ]; then
+              sudo docker stop caremeet_server_prod
+              sudo docker rm caremeet_server_prod
             fi
-            ssh -f -N -M -S my-cicd-socket -o StrictHostKeyChecking=no -i private_key.pem -L 2222:${{ vars.INSTANCE_HOST }}:22 ec2-user@${{ vars.BASTION_HOST }}
-            ssh -o StrictHostKeyChecking=no -i private_key.pem -p 2222 ubuntu@localhost << 'EOF'
-              echo "Connected to Private Subnet productionServer via SSH Tunneling"
-              sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-              sudo docker pull public.ecr.aws/e4z1s9l7/caremeet:latest
-              if [ $(sudo docker ps -q -f name=caremeet_server_prod) ]; then
-                sudo docker stop caremeet_server_prod
-                sudo docker rm caremeet_server_prod
-              fi
-              sudo docker run --name caremeet_server_prod --env-file ./app/docker/.env \
-              -e SPRING_PROFILES_ACTIVE=prod \
-              -d -p 8081:8081 public.ecr.aws/e4z1s9l7/caremeet:latest
-            EOF
-            ssh -S my-cicd-socket -O exit ec2-user@${{ vars.BASTION_HOST }}
-            rm -f private_key.pem
-
-      - name: Remove GitHub Actions IP
-        run: |
-          aws ec2 revoke-security-group-ingress \
-              --group-id ${{ secrets.SECURITY_GROUP_ID }} \
-              --protocol tcp \
-              --port 22 \
-              --cidr ${{ steps.publicip.outputs.ip }}/32
+            sudo docker run --name caremeet_server_prod --env-file ./app/docker/.env \
+            -e SPRING_PROFILES_ACTIVE=prod \
+            -d -p 8081:8081 public.ecr.aws/e4z1s9l7/caremeet:latest

--- a/idle-presentation/compose-dev.yaml
+++ b/idle-presentation/compose-dev.yaml
@@ -11,7 +11,7 @@ services:
     env_file:
       - .env
     ports:
-      - "8080:8080"
+      - "8082:8082"
     depends_on:
       - mysql
       - redis

--- a/idle-presentation/compose-dev.yaml
+++ b/idle-presentation/compose-dev.yaml
@@ -1,4 +1,5 @@
 version: '3.8'
+
 services:
   spring:
     image: public.ecr.aws/${ECR_REGISTRY_ALIAS}/caremeet:${VERSION:-latest}
@@ -16,20 +17,26 @@ services:
       - mysql
       - redis
     networks:
-      - redis-caremeet-net
-      - mysql-caremeet-net
+      - caremeet-net
 
   mysql:
     image: mysql:8.0.33
     container_name: mysql_dev
     environment:
-      MYSQL_DATABASE: caremeet
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       TZ: Asia/Seoul
+    command: >
+      bash -c "docker-entrypoint.sh mysqld &
+               sleep 10 && 
+               mysql -u root -p${DB_PASSWORD} -e 'CREATE DATABASE IF NOT EXISTS \`caremeet\`;' &&
+               mysql -u root -p${DB_PASSWORD} -e 'CREATE DATABASE IF NOT EXISTS \`caremeet-dev\`;' &&
+               wait"
     ports:
       - "3306:3306"
+    volumes:
+      - mysql-volume:/var/lib/mysql
     networks:
-      - mysql-caremeet-net
+      - caremeet-net
 
   redis:
     image: redis:7.2.5
@@ -43,12 +50,10 @@ services:
       - redis-volume:/data
     restart: unless-stopped
     networks:
-      - redis-caremeet-net
+      - caremeet-net
 
 networks:
-  mysql-caremeet-net:
-    driver: bridge
-  redis-caremeet-net:
+  caremeet-net:
     driver: bridge
 
 volumes:

--- a/idle-presentation/src/main/resources/application.yml
+++ b/idle-presentation/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: ${SERVER_PORT:8080}
   shutdown: graceful
 
 spring:


### PR DESCRIPTION
## 1. 📄 Summary
기존 AWS 기반으로 운영되던 서버를 홈 서버 환경으로 이전하였습니다.
이전된 홈 서버는 Nginx를 활용한 SSL 터미네이션 및 로드 밸런싱 구성을 통해,
production 및 development 서버를 분리하여 운용하고 있습니다.

또한, MySQL과 Redis 서비스를 포함한 전체 인프라를 구축 완료하였으며,
기존 데이터에 대한 백업 및 마이그레이션 작업도 완료하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 배포 워크플로우에서 AWS 자격 증명 및 보안 그룹 수정 단계를 제거하여 배포 과정을 간소화했습니다.
  - 프로덕션 배포 워크플로우가 수동 실행으로 변경되고, Bastion 호스트를 통한 SSH 터널링 없이 직접 서버에 연결하도록 개선되었습니다.
  - Docker 설치 및 환경 변수 설정 과정이 간단해졌으며, 서비스 포트가 8081로 변경되었습니다.

- **Refactor**
  - 개발용 Docker Compose 설정에서 네트워크 구성을 하나로 통합하고, 서비스 포트 및 데이터베이스 초기화 방식을 개선했습니다.
  - 서버 포트가 환경 변수로 설정 가능하도록 변경되어 유연성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->