### PR TITLE
[IDLE-572] 읽음 처리 및 홈서버 이동 에러 수정

### DIFF
--- a/.github/workflows/dev-server-deployer.yaml
+++ b/.github/workflows/dev-server-deployer.yaml
@@ -35,7 +35,7 @@ jobs:
           username: ${{ vars.INSTANCE_USERNAME }}
           key: ${{ secrets.INSTANCE_PEM_KEY }}
           source: "./idle-presentation/compose-dev.yaml"
-          target: "~/app/docker"
+          target: "~/app/docker/"
           overwrite: true
 
       - name: Install Docker if not present
@@ -75,7 +75,7 @@ jobs:
             jq -s '.[0] * .[1]' <(echo "$VARS_CONTEXT") <(echo "$SECRETS_CONTEXT") \
               | jq -r 'to_entries | map(select(.key != "INSTANCE_PEM_KEY")) | map("\(.key)=\(.value)") | .[]' > .env
 
-      - name: Run Docker Compose up
+      - name: Run Docker Compose up (Selective)
         uses: appleboy/ssh-action@master
         with:
           host: ${{ vars.INSTANCE_HOST }}
@@ -83,5 +83,11 @@ jobs:
           key: ${{ secrets.INSTANCE_PEM_KEY }}
           script: |
             echo "${{ secrets.DOCKER_PASSWORD }}" | sudo docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+            for service in caremeet_server_dev mysql_dev redis_dev; do
+              if [ $(sudo docker ps -q -f name=$service) ]; then
+                sudo docker stop $service
+                sudo docker rm $service
+              fi
+            done
             sudo docker-compose -f ~/app/docker/idle-presentation/compose-dev.yaml pull
             sudo docker-compose -f ~/app/docker/idle-presentation/compose-dev.yaml up -d --force-recreate

--- a/.github/workflows/prod-server-deployer.yaml
+++ b/.github/workflows/prod-server-deployer.yaml
@@ -78,6 +78,8 @@ jobs:
               sudo docker stop caremeet_server_prod
               sudo docker rm caremeet_server_prod
             fi
-            sudo docker run --name caremeet_server_prod --env-file ./app/docker/.env \
+            sudo docker run --name caremeet_server_prod \
+            --network idle-presentation_caremeet-net \
+            --env-file ./app/docker/idle-presentation/.env \
             -e SPRING_PROFILES_ACTIVE=prod \
             -d -p 8081:8081 public.ecr.aws/e4z1s9l7/caremeet:latest

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatMessageService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/domain/ChatMessageService.kt
@@ -25,7 +25,7 @@ class ChatMessageService (
 
     @Transactional
     fun read(request: ReadChatMessagesReqeust, readUserId: UUID) {
-        chatMessageRepository.readByChatroomId(request.chatroomId, readUserId)
+        chatMessageRepository.readByChatroomId(UUID.fromString(request.chatroomId), readUserId)
     }
 
     @Transactional

--- a/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
+++ b/idle-application/src/main/kotlin/com/swm/idle/application/chat/facade/ChatFacadeService.kt
@@ -70,8 +70,8 @@ class ChatFacadeService(
         messageService.read(request, carerId)
 
         val readMessage = ReadMessage(
-            chatRoomId = request.chatroomId,
-            receiverId = request.opponentId,
+            chatRoomId = UUID.fromString(request.chatroomId),
+            receiverId = UUID.fromString(request.opponentId),
             readUserId = carerId
         )
         chatRedisTemplate.publish(readMessage)
@@ -83,8 +83,8 @@ class ChatFacadeService(
         messageService.read(request, centerId)
 
         val readMessage = ReadMessage(
-            chatRoomId = request.chatroomId,
-            receiverId = request.opponentId,
+            chatRoomId = UUID.fromString(request.chatroomId),
+            receiverId = UUID.fromString(request.opponentId),
             readUserId = centerId
         )
         chatRedisTemplate.publish(readMessage)

--- a/idle-domain/build.gradle.kts
+++ b/idle-domain/build.gradle.kts
@@ -10,13 +10,20 @@ dependencies {
     implementation(project(":idle-support:common"))
     implementation(project(":idle-support:security"))
 
+    implementation("org.springframework.boot:spring-boot-starter-json")
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.data.redis)
     implementation(libs.querydsl.spatial)
     implementation(libs.hibernate.spatial)
     implementation(libs.flyway.core)
     implementation(libs.flyway.mysql)
-
     runtimeOnly(libs.mysql.connector.java)
 
+    testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
+    testImplementation("io.kotest:kotest-assertions-core:5.8.0")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+
+    testImplementation("org.testcontainers:junit-jupiter:1.18.3")
+    testImplementation("com.h2database:h2")
+    testImplementation("it.ozimov:embedded-redis:0.7.2")
 }

--- a/idle-domain/src/test/kotlin/com/swm/idle/ChatTest.kt
+++ b/idle-domain/src/test/kotlin/com/swm/idle/ChatTest.kt
@@ -1,0 +1,42 @@
+package com.swm.idle
+
+import com.swm.idle.config.DomainTestApplication
+import com.swm.idle.domain.chat.entity.jpa.ChatMessage
+import com.swm.idle.domain.chat.repository.ChatMessageRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(classes = [DomainTestApplication::class])
+@ActiveProfiles("test")
+class ChatTest : BehaviorSpec() {
+    @Autowired
+    lateinit var chatMessageRepository: ChatMessageRepository
+
+    val chatRoomId = UUID.randomUUID()
+    val senderId = UUID.randomUUID()
+    val receiverId = UUID.randomUUID()
+
+
+    init {
+        given("채팅 메시지가 여러개 주어졌을 때") {
+            val msg1 = ChatMessage(chatRoomId = chatRoomId, senderId = senderId, receiverId = receiverId, content = "1")
+            val msg2 = ChatMessage(chatRoomId = chatRoomId, senderId = senderId, receiverId = receiverId, content = "2")
+            val msg3 = ChatMessage(chatRoomId = chatRoomId, senderId = senderId, receiverId = UUID.randomUUID(), content = "3")
+            chatMessageRepository.saveAll(listOf(msg1, msg2, msg3))
+
+            `when`("readByChatroomId 메서드로 읽음 처리 하면") {
+                chatMessageRepository.readByChatroomId(chatRoomId, receiverId)
+
+                then("해당 메시지들의 isRead 상태가 true로 업데이트 되어야 한다") {
+                    val updatedMessages = chatMessageRepository.findAll()
+                    val readMessages = updatedMessages.filter { it.receiverId == receiverId && it.chatRoomId == chatRoomId }
+                    assertThat(readMessages).allMatch { it.isRead }
+                }
+            }
+        }
+    }
+}

--- a/idle-domain/src/test/kotlin/com/swm/idle/config/DomainTestApplication.kt
+++ b/idle-domain/src/test/kotlin/com/swm/idle/config/DomainTestApplication.kt
@@ -1,0 +1,6 @@
+package com.swm.idle.config
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication(scanBasePackages = ["com.swm.idle.domain"])
+class DomainTestApplication

--- a/idle-domain/src/test/kotlin/com/swm/idle/config/EmbeddedRedisConfig.kt
+++ b/idle-domain/src/test/kotlin/com/swm/idle/config/EmbeddedRedisConfig.kt
@@ -1,0 +1,27 @@
+package com.swm.idle.config
+
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import redis.embedded.RedisServer
+
+@Configuration
+@Profile("test")
+class EmbeddedRedisConfig {
+
+    private val redisPort = 6379
+    private val redisServer = RedisServer(redisPort)
+
+    @PostConstruct
+    fun startRedis() {
+        if (!redisServer.isActive) {
+            redisServer.start()
+        }
+    }
+
+    @PreDestroy
+    fun stopRedis() {
+        redisServer.stop()
+    }
+}

--- a/idle-domain/src/test/kotlin/com/swm/idle/config/ProjectConfig.kt
+++ b/idle-domain/src/test/kotlin/com/swm/idle/config/ProjectConfig.kt
@@ -1,0 +1,9 @@
+package com.swm.idle.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.extensions.spring.SpringExtension
+
+object ProjectConfig : AbstractProjectConfig() {
+    override fun extensions(): List<Extension> = listOf(SpringExtension)
+}

--- a/idle-domain/src/test/resources/application-test.yml
+++ b/idle-domain/src/test/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    database-platform: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ""

--- a/idle-presentation/compose-dev.yaml
+++ b/idle-presentation/compose-dev.yaml
@@ -2,13 +2,11 @@ version: '3.8'
 
 services:
   spring:
+    container_name: caremeet_server_dev
     image: public.ecr.aws/${ECR_REGISTRY_ALIAS}/caremeet:${VERSION:-latest}
-    volumes:
-      - mysql-volume:/var/lib/mysql
     environment:
       - VERSION=${VERSION:-latest}
       - SPRING_PROFILES_ACTIVE=dev
-    pull_policy: always
     env_file:
       - .env
     ports:
@@ -25,12 +23,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       TZ: Asia/Seoul
-    command: >
-      bash -c "docker-entrypoint.sh mysqld &
-               sleep 10 && 
-               mysql -u root -p${DB_PASSWORD} -e 'CREATE DATABASE IF NOT EXISTS \`caremeet\`;' &&
-               mysql -u root -p${DB_PASSWORD} -e 'CREATE DATABASE IF NOT EXISTS \`caremeet-dev\`;' &&
-               wait"
     ports:
       - "3306:3306"
     volumes:

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/chat/handler/ChatHandler.kt
@@ -21,5 +21,6 @@ class ChatHandler(
     @EventListener
     fun handleReadMessage(readMessage: ReadMessage) {
         messageTemplate.convertAndSend("/sub/${readMessage.receiverId}", ReadNoti(readMessage))
+        messageTemplate.convertAndSend("/sub/${readMessage.readUserId}", ReadNoti(readMessage))
     }
 }

--- a/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/config/SwaggerConfig.kt
+++ b/idle-presentation/src/main/kotlin/com/swm/idle/presentation/common/config/SwaggerConfig.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.models.servers.Server
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.ForwardedHeaderFilter
 
 @Configuration
 class SwaggerConfig(
@@ -34,4 +35,8 @@ class SwaggerConfig(
             )
     }
 
+    @Bean
+    fun forwardedHeaderFilter(): ForwardedHeaderFilter {
+        return ForwardedHeaderFilter()
+    }
 }

--- a/idle-presentation/src/main/resources/application.yml
+++ b/idle-presentation/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 server:
   port: ${SERVER_PORT:8080}
   shutdown: graceful
+  forward-headers-strategy: framework
 
 spring:
   profiles:
@@ -32,6 +33,7 @@ spring:
 springdoc:
   swagger-ui:
     enabled: true
+    url: ${SERVER_URL:http://localhost:8080}/v3/api-docs
     path: /swagger-ui.html
 
 ---
@@ -47,6 +49,7 @@ spring:
 springdoc:
   swagger-ui:
     enabled: true
+    url: ${SERVER_URL:http://localhost:8080}/v3/api-docs
 
 sentry:
   dsn: ${SENTRY_DSN}
@@ -65,6 +68,7 @@ spring:
 springdoc:
   swagger-ui:
     enabled: true
+    url: ${SERVER_URL:http://localhost:8080}/v3/api-docs
 
 sentry:
   dsn: ${SENTRY_DSN}

--- a/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
+++ b/idle-support/transfer/src/main/kotlin/com/swm/idle/support/transfer/chat/ReadChatMessagesReqeust.kt
@@ -2,9 +2,8 @@ package com.swm.idle.support.transfer.chat
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.UUID
 
 data class ReadChatMessagesReqeust @JsonCreator constructor(
-    @JsonProperty("chatroomId") val chatroomId: UUID,
-    @JsonProperty("opponentId")val opponentId: UUID
+    @JsonProperty("chatroomId") val chatroomId: String,
+    @JsonProperty("opponentId")val opponentId: String
 )


### PR DESCRIPTION
## 1. 📄 Summary
- 홈서버 환경에서 도커 컨테이너 관리 및 NginX 설정 개선
- Swagger 파일 인식 문제 해결
- 채팅 메시지 읽음 처리 관련 테스트 코드 및 도메인 모듈 테스트 설정 추가
- 불필요한 명령어 삭제 및 스크립트 최적화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - Swagger API 문서의 URL 및 프록시 환경 지원을 위한 설정이 추가되었습니다.
    - 테스트 환경에서 임베디드 Redis 서버와 H2 데이터베이스가 자동으로 구성됩니다.

- **버그 수정**
    - 채팅 메시지 읽음 알림이 수신자뿐만 아니라 읽은 사용자에게도 전송됩니다.

- **개선사항**
    - Docker Compose 및 배포 스크립트가 일부 환경에서 더 안정적으로 동작하도록 개선되었습니다.
    - 채팅 메시지 읽기 처리 시 ID 타입 일관성이 보장됩니다.

- **테스트**
    - 채팅 메시지 읽음 상태 변경에 대한 테스트가 추가되었습니다.
    - 테스트 환경 구성을 위한 설정 파일 및 클래스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->